### PR TITLE
feat(act): generic actor type + descriptive generic rename

### DIFF
--- a/libs/act/src/act-builder.ts
+++ b/libs/act/src/act-builder.ts
@@ -9,6 +9,7 @@ import { _this_, _void_, mergeProjection, registerState } from "./merge.js";
 import type { Projection } from "./projection-builder.js";
 import type { Slice } from "./slice-builder.js";
 import type {
+  Actor,
   Committed,
   Dispatcher,
   EventRegister,
@@ -31,22 +32,26 @@ import type {
  * - Registering states via `.withState()`
  * - Registering slices via `.withSlice()`
  * - Registering projections via `.withProjection()`
+ * - Locking a custom actor type via `.withActor<TActor>()`
  * - Defining event reactions via `.on()` → `.do()` → `.to()` or `.void()`
  * - Building the orchestrator via `.build()`
  *
- * @template S - Schema register for states (maps action names to state schemas)
- * @template E - Event schemas (maps event names to event data schemas)
- * @template A - Action schemas (maps action names to action payload schemas)
+ * @template TSchemaReg - Schema register for states (maps action names to state schemas)
+ * @template TEvents - Event schemas (maps event names to event data schemas)
+ * @template TActions - Action schemas (maps action names to action payload schemas)
+ * @template TStateMap - Map of state names to state schemas
+ * @template TActor - Actor type extending base Actor
  *
  * @see {@link act} for usage examples
  * @see {@link Act} for the built orchestrator API
  */
 export type ActBuilder<
-  S extends SchemaRegister<A>,
-  E extends Schemas,
-  A extends Schemas,
+  TSchemaReg extends SchemaRegister<TActions>,
+  TEvents extends Schemas,
+  TActions extends Schemas,
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  M extends Record<string, Schema> = {},
+  TStateMap extends Record<string, Schema> = {},
+  TActor extends Actor = Actor,
 > = {
   /**
    * Registers a state definition with the builder.
@@ -57,17 +62,18 @@ export type ActBuilder<
    * @throws {Error} If duplicate action or event names are detected
    */
   withState: <
-    SX extends Schema,
-    EX extends Schemas,
-    AX extends Schemas,
-    NX extends string = string,
+    TNewState extends Schema,
+    TNewEvents extends Schemas,
+    TNewActions extends Schemas,
+    TNewName extends string = string,
   >(
-    state: State<SX, EX, AX, NX>
+    state: State<TNewState, TNewEvents, TNewActions, TNewName>
   ) => ActBuilder<
-    S & { [K in keyof AX]: SX },
-    E & EX,
-    A & AX,
-    M & { [K in NX]: SX }
+    TSchemaReg & { [K in keyof TNewActions]: TNewState },
+    TEvents & TNewEvents,
+    TActions & TNewActions,
+    TStateMap & { [K in TNewName]: TNewState },
+    TActor
   >;
   /**
    * Registers a slice with the builder.
@@ -79,24 +85,63 @@ export type ActBuilder<
    * @throws {Error} If duplicate action or event names are detected
    */
   withSlice: <
-    SX extends SchemaRegister<AX>,
-    EX extends Schemas,
-    AX extends Schemas,
-    MX extends Record<string, Schema>,
+    TNewSchemaReg extends SchemaRegister<TNewActions>,
+    TNewEvents extends Schemas,
+    TNewActions extends Schemas,
+    TNewMap extends Record<string, Schema>,
   >(
-    slice: Slice<SX, EX, AX, MX>
-  ) => ActBuilder<S & SX, E & EX, A & AX, M & MX>;
+    slice: Slice<TNewSchemaReg, TNewEvents, TNewActions, TNewMap>
+  ) => ActBuilder<
+    TSchemaReg & TNewSchemaReg,
+    TEvents & TNewEvents,
+    TActions & TNewActions,
+    TStateMap & TNewMap,
+    TActor
+  >;
   /**
    * Registers a standalone projection with the builder.
    *
    * The projection's events must be a subset of events already registered
    * via `.withState()` or `.withSlice()`.
    */
-  withProjection: <EX extends Schemas>(
-    projection: [Exclude<keyof EX, keyof E>] extends [never]
-      ? Projection<EX>
+  withProjection: <TNewEvents extends Schemas>(
+    projection: [Exclude<keyof TNewEvents, keyof TEvents>] extends [never]
+      ? Projection<TNewEvents>
       : never
-  ) => ActBuilder<S, E, A, M>;
+  ) => ActBuilder<TSchemaReg, TEvents, TActions, TStateMap, TActor>;
+  /**
+   * Locks a custom actor type for this application.
+   *
+   * This is a pure type-level method — it returns the same builder at
+   * runtime but narrows the `TActor` generic so that `app.do()` and
+   * reaction dispatchers require the richer actor shape.
+   *
+   * @template TNewActor - Custom actor type extending base Actor
+   * @returns The same builder with `TActor` locked to `TNewActor`
+   *
+   * @example
+   * ```typescript
+   * type MyActor = { id: string; name: string; role: string; tenantId: string };
+   *
+   * const app = act()
+   *   .withActor<MyActor>()
+   *   .withState(Counter)
+   *   .build();
+   *
+   * // Now app.do() requires MyActor in the target
+   * await app.do("increment", {
+   *   stream: "counter-1",
+   *   actor: { id: "1", name: "Alice", role: "admin", tenantId: "t1" }
+   * }, { by: 5 });
+   * ```
+   */
+  withActor: <TNewActor extends Actor>() => ActBuilder<
+    TSchemaReg,
+    TEvents,
+    TActions,
+    TStateMap,
+    TNewActor
+  >;
   /**
    * Begins defining a reaction to a specific event.
    *
@@ -104,23 +149,25 @@ export type ActBuilder<
    * additional actions, update external systems, or perform side effects. Reactions
    * are processed asynchronously during drain cycles.
    *
-   * @template K - Event name (must be a registered event)
+   * @template TKey - Event name (must be a registered event)
    * @param event - The event name to react to
    * @returns An object with `.do()` method to define the reaction handler
    */
-  on: <K extends keyof E>(
-    event: K
+  on: <TKey extends keyof TEvents>(
+    event: TKey
   ) => {
     do: (
       handler: (
-        event: Committed<E, K>,
+        event: Committed<TEvents, TKey>,
         stream: string,
-        app: Dispatcher<A>
-      ) => Promise<Snapshot<Schema, E> | void>,
+        app: Dispatcher<TActions, TActor>
+      ) => Promise<Snapshot<Schema, TEvents> | void>,
       options?: Partial<ReactionOptions>
-    ) => ActBuilder<S, E, A, M> & {
-      to: (resolver: ReactionResolver<E, K> | string) => ActBuilder<S, E, A, M>;
-      void: () => ActBuilder<S, E, A, M>;
+    ) => ActBuilder<TSchemaReg, TEvents, TActions, TStateMap, TActor> & {
+      to: (
+        resolver: ReactionResolver<TEvents, TKey> | string
+      ) => ActBuilder<TSchemaReg, TEvents, TActions, TStateMap, TActor>;
+      void: () => ActBuilder<TSchemaReg, TEvents, TActions, TStateMap, TActor>;
     };
   };
   /**
@@ -131,11 +178,13 @@ export type ActBuilder<
    *
    * @see {@link Act} for available orchestrator methods
    */
-  build: (drainLimit?: number) => Act<S, E, A, M>;
+  build: (
+    drainLimit?: number
+  ) => Act<TSchemaReg, TEvents, TActions, TStateMap, TActor>;
   /**
    * The registered event schemas and their reaction maps.
    */
-  readonly events: EventRegister<E>;
+  readonly events: EventRegister<TEvents>;
 };
 
 /* eslint-disable @typescript-eslint/no-empty-object-type -- {} used as generic defaults */
@@ -146,6 +195,16 @@ export type ActBuilder<
  * @example Basic application with single state
  * ```typescript
  * const app = act()
+ *   .withState(Counter)
+ *   .build();
+ * ```
+ *
+ * @example Application with custom actor type
+ * ```typescript
+ * type MyActor = { id: string; name: string; role: string };
+ *
+ * const app = act()
+ *   .withActor<MyActor>()
  *   .withState(Counter)
  *   .build();
  * ```
@@ -171,124 +230,160 @@ export type ActBuilder<
  */
 export function act<
   // @ts-expect-error empty schema
-  S extends SchemaRegister<A> = {},
-  E extends Schemas = {},
-  A extends Schemas = {},
-  M extends Record<string, Schema> = {},
+  TSchemaReg extends SchemaRegister<TActions> = {},
+  TEvents extends Schemas = {},
+  TActions extends Schemas = {},
+  TStateMap extends Record<string, Schema> = {},
+  TActor extends Actor = Actor,
 >(
   states: Map<string, State<any, any, any>> = new Map(),
-  registry: Registry<S, E, A> = {
-    actions: {} as Registry<S, E, A>["actions"],
-    events: {} as Registry<S, E, A>["events"],
+  registry: Registry<TSchemaReg, TEvents, TActions> = {
+    actions: {} as Registry<TSchemaReg, TEvents, TActions>["actions"],
+    events: {} as Registry<TSchemaReg, TEvents, TActions>["events"],
   },
   pendingProjections: Projection<any>[] = []
-): ActBuilder<S, E, A, M> {
-  const builder: ActBuilder<S, E, A, M> = {
-    withState: <
-      SX extends Schema,
-      EX extends Schemas,
-      AX extends Schemas,
-      NX extends string = string,
-    >(
-      state: State<SX, EX, AX, NX>
-    ) => {
-      registerState(state, states, registry.actions, registry.events);
-      return act<
-        S & { [K in keyof AX]: SX },
-        E & EX,
-        A & AX,
-        M & { [K in NX]: SX }
+): ActBuilder<TSchemaReg, TEvents, TActions, TStateMap, TActor> {
+  const builder: ActBuilder<TSchemaReg, TEvents, TActions, TStateMap, TActor> =
+    {
+      withState: <
+        TNewState extends Schema,
+        TNewEvents extends Schemas,
+        TNewActions extends Schemas,
+        TNewName extends string = string,
       >(
-        states,
-        registry as unknown as Registry<
-          S & { [K in keyof AX]: SX },
-          E & EX,
-          A & AX
-        >,
-        pendingProjections
-      );
-    },
-    withSlice: <
-      SX extends SchemaRegister<AX>,
-      EX extends Schemas,
-      AX extends Schemas,
-      MX extends Record<string, Schema>,
-    >(
-      input: Slice<SX, EX, AX, MX>
-    ) => {
-      for (const s of input.states.values()) {
-        registerState(s, states, registry.actions, registry.events);
-      }
-      for (const eventName of Object.keys(input.events)) {
-        const sliceRegister = input.events[eventName];
-        for (const [name, reaction] of sliceRegister.reactions) {
-          (
-            registry.events as Record<
-              string,
-              { reactions: Map<string, unknown> }
-            >
-          )[eventName].reactions.set(name, reaction);
-        }
-      }
-      pendingProjections.push(...input.projections);
-      return act<S & SX, E & EX, A & AX, M & MX>(
-        states,
-        registry as unknown as Registry<S & SX, E & EX, A & AX>,
-        pendingProjections
-      );
-    },
-    withProjection: <EX extends Schemas>(proj: Projection<EX>) => {
-      mergeProjection(proj, registry.events);
-      return act<S, E, A, M>(states, registry, pendingProjections);
-    },
-    on: <K extends keyof E>(event: K) => ({
-      do: (
-        handler: (
-          event: Committed<E, K>,
-          stream: string,
-          app: Dispatcher<A>
-        ) => Promise<Snapshot<Schema, E> | void>,
-        options?: Partial<ReactionOptions>
+        state: State<TNewState, TNewEvents, TNewActions, TNewName>
       ) => {
-        const reaction: Reaction<E, K, A> = {
-          handler: handler as ReactionHandler<E, K, A>,
-          resolver: _this_,
-          options: {
-            blockOnError: options?.blockOnError ?? true,
-            maxRetries: options?.maxRetries ?? 3,
-          },
-        };
-        const name =
-          handler.name ||
-          `${String(event)}_${registry.events[event].reactions.size}`;
-        registry.events[event].reactions.set(name, reaction);
-        return {
-          ...builder,
-          to(resolver: ReactionResolver<E, K> | string) {
-            registry.events[event].reactions.set(name, {
-              ...reaction,
-              resolver:
-                typeof resolver === "string" ? { target: resolver } : resolver,
-            });
-            return builder;
-          },
-          void() {
-            registry.events[event].reactions.set(name, {
-              ...reaction,
-              resolver: _void_,
-            });
-            return builder;
-          },
-        };
+        registerState(state, states, registry.actions, registry.events);
+        return act<
+          TSchemaReg & { [K in keyof TNewActions]: TNewState },
+          TEvents & TNewEvents,
+          TActions & TNewActions,
+          TStateMap & { [K in TNewName]: TNewState },
+          TActor
+        >(
+          states,
+          registry as unknown as Registry<
+            TSchemaReg & { [K in keyof TNewActions]: TNewState },
+            TEvents & TNewEvents,
+            TActions & TNewActions
+          >,
+          pendingProjections
+        );
       },
-    }),
-    build: () => {
-      for (const proj of pendingProjections) {
-        mergeProjection(proj, registry.events as Record<string, any>);
-      }
-      return new Act<S, E, A, M>(registry, states);
-    },
-    events: registry.events,
-  };
+      withSlice: <
+        TNewSchemaReg extends SchemaRegister<TNewActions>,
+        TNewEvents extends Schemas,
+        TNewActions extends Schemas,
+        TNewMap extends Record<string, Schema>,
+      >(
+        input: Slice<TNewSchemaReg, TNewEvents, TNewActions, TNewMap>
+      ) => {
+        for (const s of input.states.values()) {
+          registerState(s, states, registry.actions, registry.events);
+        }
+        for (const eventName of Object.keys(input.events)) {
+          const sliceRegister = input.events[eventName];
+          for (const [name, reaction] of sliceRegister.reactions) {
+            (
+              registry.events as Record<
+                string,
+                { reactions: Map<string, unknown> }
+              >
+            )[eventName].reactions.set(name, reaction);
+          }
+        }
+        pendingProjections.push(...input.projections);
+        return act<
+          TSchemaReg & TNewSchemaReg,
+          TEvents & TNewEvents,
+          TActions & TNewActions,
+          TStateMap & TNewMap,
+          TActor
+        >(
+          states,
+          registry as unknown as Registry<
+            TSchemaReg & TNewSchemaReg,
+            TEvents & TNewEvents,
+            TActions & TNewActions
+          >,
+          pendingProjections
+        );
+      },
+      withProjection: <TNewEvents extends Schemas>(
+        proj: Projection<TNewEvents>
+      ) => {
+        mergeProjection(proj, registry.events);
+        return act<TSchemaReg, TEvents, TActions, TStateMap, TActor>(
+          states,
+          registry,
+          pendingProjections
+        );
+      },
+      withActor: <TNewActor extends Actor>() => {
+        return act<TSchemaReg, TEvents, TActions, TStateMap, TNewActor>(
+          states,
+          registry,
+          pendingProjections
+        );
+      },
+      on: <TKey extends keyof TEvents>(event: TKey) => ({
+        do: (
+          handler: (
+            event: Committed<TEvents, TKey>,
+            stream: string,
+            app: Dispatcher<TActions, TActor>
+          ) => Promise<Snapshot<Schema, TEvents> | void>,
+          options?: Partial<ReactionOptions>
+        ) => {
+          const reaction: Reaction<TEvents, TKey, TActions, TActor> = {
+            handler: handler as ReactionHandler<
+              TEvents,
+              TKey,
+              TActions,
+              TActor
+            >,
+            resolver: _this_,
+            options: {
+              blockOnError: options?.blockOnError ?? true,
+              maxRetries: options?.maxRetries ?? 3,
+            },
+          };
+          const name =
+            handler.name ||
+            `${String(event)}_${registry.events[event].reactions.size}`;
+          registry.events[event].reactions.set(name, reaction);
+          return {
+            ...builder,
+            to(resolver: ReactionResolver<TEvents, TKey> | string) {
+              registry.events[event].reactions.set(name, {
+                ...reaction,
+                resolver:
+                  typeof resolver === "string"
+                    ? { target: resolver }
+                    : resolver,
+              });
+              return builder;
+            },
+            void() {
+              registry.events[event].reactions.set(name, {
+                ...reaction,
+                resolver: _void_,
+              });
+              return builder;
+            },
+          };
+        },
+      }),
+      build: () => {
+        for (const proj of pendingProjections) {
+          mergeProjection(proj, registry.events as Record<string, any>);
+        }
+        return new Act<TSchemaReg, TEvents, TActions, TStateMap, TActor>(
+          registry,
+          states
+        );
+      },
+      events: registry.events,
+    };
   return builder;
 }

--- a/libs/act/src/merge.ts
+++ b/libs/act/src/merge.ts
@@ -54,10 +54,10 @@ export function mergeSchemas(
  * Merges two init functions by spreading both results together.
  * Each partial only provides its own defaults.
  */
-export function mergeInits<S extends Schema>(
-  existing: () => Readonly<S>,
-  incoming: () => Readonly<S>
-): () => Readonly<S> {
+export function mergeInits<TState extends Schema>(
+  existing: () => Readonly<TState>,
+  incoming: () => Readonly<TState>
+): () => Readonly<TState> {
   return () => ({ ...existing(), ...incoming() });
 }
 

--- a/libs/act/src/types/errors.ts
+++ b/libs/act/src/types/errors.ts
@@ -1,4 +1,11 @@
-import type { Message, Schema, Schemas, Snapshot, Target } from "./action.js";
+import type {
+  Actor,
+  Message,
+  Schema,
+  Schemas,
+  Snapshot,
+  Target,
+} from "./action.js";
 
 /**
  * @packageDocumentation
@@ -79,10 +86,11 @@ export class ValidationError extends Error {
  * This error provides complete context about what action was attempted and
  * why it was rejected.
  *
- * @template S - State schema type
- * @template E - Event schemas type
- * @template A - Action schemas type
- * @template K - Action name
+ * @template TState - State schema type
+ * @template TEvents - Event schemas type
+ * @template TActions - Action schemas type
+ * @template TKey - Action name
+ * @template TActor - Actor type extending base Actor
  *
  * @example Catching invariant violations
  * ```typescript
@@ -140,20 +148,21 @@ export class ValidationError extends Error {
  * @see {@link Invariant} for defining business rules
  */
 export class InvariantError<
-  S extends Schema,
-  E extends Schemas,
-  A extends Schemas,
-  K extends keyof A,
+  TState extends Schema,
+  TEvents extends Schemas,
+  TActions extends Schemas,
+  TKey extends keyof TActions,
+  TActor extends Actor = Actor,
 > extends Error {
   constructor(
     /** The action that was attempted */
-    readonly action: K,
+    readonly action: TKey,
     /** The action payload that was provided */
-    readonly payload: Readonly<A[K]>,
+    readonly payload: Readonly<TActions[TKey]>,
     /** The target stream and actor context */
-    readonly target: Target,
+    readonly target: Target<TActor>,
     /** The current state snapshot when invariant was checked */
-    readonly snapshot: Snapshot<S, E>,
+    readonly snapshot: Snapshot<TState, TEvents>,
     /** Human-readable description of why the invariant failed */
     readonly description: string
   ) {

--- a/libs/act/src/types/registry.ts
+++ b/libs/act/src/types/registry.ts
@@ -12,40 +12,47 @@ import type { Reaction } from "./reaction.js";
 /**
  * Reactions register
  */
-export type ReactionsRegister<E extends Schemas, K extends keyof E> = {
-  schema: ZodType<E[K]>;
-  reactions: Map<string, Reaction<E, K>>;
+export type ReactionsRegister<
+  TEvents extends Schemas,
+  TKey extends keyof TEvents,
+> = {
+  schema: ZodType<TEvents[TKey]>;
+  reactions: Map<string, Reaction<TEvents, TKey>>;
 };
 
 /**
  * Maps event names to their schema and registered reactions.
- * @template E - Event schemas.
+ * @template TEvents - Event schemas.
  */
-export type EventRegister<E extends Schemas> = {
-  [K in keyof E]: ReactionsRegister<E, K>;
+export type EventRegister<TEvents extends Schemas> = {
+  [TKey in keyof TEvents]: ReactionsRegister<TEvents, TKey>;
 };
 
 /**
  * Maps action names to their schema definitions.
- * @template A - Action schemas.
+ * @template TSchemaReg - Schema register for actions.
  */
-export type SchemaRegister<A> = { [K in keyof A]: Schema };
+export type SchemaRegister<TSchemaReg> = {
+  [TKey in keyof TSchemaReg]: Schema;
+};
 
 /**
  * Registry of all actions and events for a domain.
- * @template S - State schemas.
- * @template E - Event schemas.
- * @template A - Action schemas.
+ * @template TSchemaReg - State schemas.
+ * @template TEvents - Event schemas.
+ * @template TActions - Action schemas.
  * @property actions - Map of action names to state definitions.
  * @property events - Map of event names to event registration info.
  */
 export type Registry<
-  S extends SchemaRegister<A>,
-  E extends Schemas,
-  A extends Schemas,
+  TSchemaReg extends SchemaRegister<TActions>,
+  TEvents extends Schemas,
+  TActions extends Schemas,
 > = {
-  readonly actions: { [K in keyof A]: State<S[K], E, A> };
-  readonly events: EventRegister<E>;
+  readonly actions: {
+    [TKey in keyof TActions]: State<TSchemaReg[TKey], TEvents, TActions>;
+  };
+  readonly events: EventRegister<TEvents>;
 };
 
 /**

--- a/libs/act/src/types/schemas.ts
+++ b/libs/act/src/types/schemas.ts
@@ -20,6 +20,7 @@ export const ActorSchema = z
     id: z.string(),
     name: z.string(),
   })
+  .loose()
   .readonly();
 
 /**
@@ -31,6 +32,7 @@ export const TargetSchema = z
     actor: ActorSchema,
     expectedVersion: z.number().optional(),
   })
+  .loose()
   .readonly();
 
 /**

--- a/libs/act/test/actor-generic.spec.ts
+++ b/libs/act/test/actor-generic.spec.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { act, state, store } from "../src/index.js";
+
+type MyActor = { id: string; name: string; role: string; tenantId: string };
+
+describe("actor generic", () => {
+  const Counter = state({ Counter: z.object({ count: z.number() }) })
+    .init(() => ({ count: 0 }))
+    .emits({ Incremented: z.object({ by: z.number() }) })
+    .patch({
+      Incremented: ({ data }, s) => ({ count: s.count + data.by }),
+    })
+    .on({ increment: z.object({ by: z.number() }) })
+    .emit("Incremented")
+    .build();
+
+  beforeEach(async () => {
+    await store().seed();
+  });
+
+  it("should accept richer actor in app.do() via .withActor()", async () => {
+    const app = act().withActor<MyActor>().withState(Counter).build();
+
+    const target = {
+      stream: "counter-1",
+      actor: { id: "1", name: "Alice", role: "admin", tenantId: "t1" },
+    };
+    const snaps = await app.do("increment", target, { by: 5 });
+    expect(snaps[0].state.count).toBe(5);
+  });
+
+  it("should preserve extra actor fields in event metadata via .loose()", async () => {
+    const app = act().withActor<MyActor>().withState(Counter).build();
+
+    const target = {
+      stream: "counter-2",
+      actor: { id: "2", name: "Bob", role: "user", tenantId: "t2" },
+    };
+    await app.do("increment", target, { by: 3 });
+
+    const events = await app.query_array({ stream: "counter-2" });
+    expect(events.length).toBe(1);
+    const actor = events[0].meta.causation.action?.actor;
+    expect(actor).toBeDefined();
+    expect(actor!.id).toBe("2");
+    expect(actor!.name).toBe("Bob");
+    // Extra fields preserved thanks to .loose() on ActorSchema
+    expect((actor as any).role).toBe("user");
+    expect((actor as any).tenantId).toBe("t2");
+  });
+
+  it("should work with default actor (no .withActor())", async () => {
+    const app = act().withState(Counter).build();
+
+    const target = {
+      stream: "counter-3",
+      actor: { id: "1", name: "Default" },
+    };
+    const snaps = await app.do("increment", target, { by: 1 });
+    expect(snaps[0].state.count).toBe(1);
+  });
+
+  it("should type-check .withActor() reactions with typed Dispatcher", async () => {
+    const reactionTarget = {
+      stream: "counter-4",
+      actor: { id: "sys", name: "System", role: "system", tenantId: "t0" },
+    };
+
+    const app = act()
+      .withActor<MyActor>()
+      .withState(Counter)
+      .on("Incremented")
+      .do(async (_event, _stream, dispatcher) => {
+        await dispatcher.do("increment", reactionTarget, { by: 1 });
+      })
+      .void()
+      .build();
+
+    const target = {
+      stream: "counter-5",
+      actor: { id: "1", name: "Alice", role: "admin", tenantId: "t1" },
+    };
+    await app.do("increment", target, { by: 10 });
+    expect(true).toBe(true); // Compiles and runs
+  });
+});


### PR DESCRIPTION
## Summary

- **Generic Actor** — Add `TActor extends Actor = Actor` generic at the orchestrator level with `.withActor<TActor>()`, enabling type-safe richer actors (role, tenantId, etc.) throughout the write path (`Target`, `Invariant`, `Dispatcher`, `Act.do()`)
- **Descriptive generics** — Rename all single-letter generic parameters (`S`, `E`, `A`, `K`, `N`, `M`) to `TPrefix` convention (`TState`, `TEvents`, `TActions`, `TKey`, `TName`, `TStateMap`) across all type files, builders, and runtime modules
- **Loose schemas** — Add `.loose()` to `ActorSchema` and `TargetSchema` so extra actor fields survive Zod 4 validation at runtime

## Test plan

- [x] New `actor-generic.spec.ts` — verifies `.withActor<MyActor>()` requires richer actor, extra fields preserved in metadata, default behavior unchanged, typed Dispatcher in reactions
- [x] All 245 existing tests pass unchanged
- [x] `pnpm build` — all packages compile
- [x] `pnpm typecheck` — strict mode clean
- [x] Existing `type-check.ts` compile-time diagnostics still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)