### PR TITLE
feat(act): add settle() for debounced correlate→drain

### DIFF
--- a/.claude/skills/scaffold-act-app/production.md
+++ b/.claude/skills/scaffold-act-app/production.md
@@ -1,6 +1,6 @@
 # Production Deployment
 
-Covers production-specific concerns beyond what's in [monorepo-template.md](monorepo-template.md). The template already provides `scheduleDrain()`, `eventBus`, auth crypto, `createContext()`, and dev seed scripts.
+Covers production-specific concerns beyond what's in [monorepo-template.md](monorepo-template.md). The template already provides `app.settle()`, auth crypto, `createContext()`, and dev seed scripts.
 
 ## Switch to PostgreSQL
 
@@ -23,7 +23,7 @@ Install: `pnpm -F @my-app/app add @rotorsoft/act-pg`
 
 ## Background Correlation (Large-Scale)
 
-For high-throughput deployments, use periodic background correlation instead of (or in addition to) the debounced `scheduleDrain()` from helpers.ts:
+For high-throughput deployments, use periodic background correlation instead of (or in addition to) `app.settle()`:
 
 ```typescript
 // Periodic correlation resolution — discovers new reaction streams every 3s
@@ -89,6 +89,9 @@ await app.drain({
 ```typescript
 // Observe all state changes
 app.on("committed", (snapshots) => { /* log, metrics */ });
+
+// React when system settles after settle() completes
+app.on("settled", (drain) => { /* notify SSE clients, update caches */ });
 
 // Catch reaction failures
 app.on("blocked", (leases) => { /* alert on blocked streams */ });

--- a/AGENT.md
+++ b/AGENT.md
@@ -200,6 +200,9 @@ const snapshot = await app.load(Counter, "counter1");
 
 // Process reactions (event-driven workflows)
 await app.drain({ streamLimit: 100, eventLimit: 1000 });
+
+// Debounced correlate→drain for production (non-blocking, emits "settled" when done)
+app.settle();
 ```
 
 ### Event Sourcing Model
@@ -254,6 +257,7 @@ Dynamic stream discovery through correlation metadata:
 - Each action/event includes `correlation` (request ID) and `causation` (what triggered it)
 - Reactions can discover new streams to process by querying uncommitted events
 - `app.correlate()` - Manual correlation
+- `app.settle()` - Debounced, non-blocking correlate→drain loop; emits `"settled"` when done
 - `app.start_correlations()` - Periodic background correlation
 
 ### Invariants

--- a/libs/act/src/types/reaction.ts
+++ b/libs/act/src/types/reaction.ts
@@ -8,6 +8,7 @@ import type {
   Actor,
   Committed,
   Dispatcher,
+  Query,
   Schema,
   Schemas,
   Snapshot,
@@ -257,4 +258,21 @@ export type Drain<TEvents extends Schemas> = {
   readonly leased: Lease[];
   readonly acked: Lease[];
   readonly blocked: Array<Lease & { readonly error: string }>;
+};
+
+/**
+ * Options for the debounced settle cycle.
+ *
+ * Extends {@link DrainOptions} with parameters that control the debounce
+ * window, the correlation query, and the maximum number of correlate→drain
+ * passes.
+ *
+ * @property debounceMs - Debounce window in milliseconds (default: 10)
+ * @property correlate - Query filter for correlation scans (default: `{ after: -1, limit: 100 }`)
+ * @property maxPasses - Maximum correlate→drain loops (default: 5)
+ */
+export type SettleOptions = DrainOptions & {
+  readonly debounceMs?: number;
+  readonly correlate?: Query;
+  readonly maxPasses?: number;
 };

--- a/performance/act-performance/src/index.ts
+++ b/performance/act-performance/src/index.ts
@@ -1,7 +1,6 @@
 import {
   act,
   type Committed,
-  type DrainOptions,
   type Schemas,
   sleep,
   store,
@@ -164,7 +163,7 @@ async function main(
 
 // 👉 Change drain options to evaluate performance at different load levels
 const drainFrequency = 500;
-const drainOptions: DrainOptions = {
+const drainOptions = {
   streamLimit: 15,
   eventLimit: 20,
 };


### PR DESCRIPTION
## Summary

- Adds `app.settle()` — a debounced, non-blocking correlate→drain loop that emits a `"settled"` lifecycle event when the system reaches consistency
- Consolidates the `scheduleDrain()`/`eventBus` pattern (previously reimplemented in every scaffolded app's `helpers.ts`) into the framework
- `drain()` remains unchanged as the synchronous single-cycle method for tests/scripts
- Adds `SettleOptions` type, `stop_settling()` cleanup method, and normalizes timer field naming

## Test plan

- [x] All 249 existing tests pass
- [x] New tests cover: debounce coalescing, `"settled"` event emission, concurrent settle guard, custom options
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Verify scaffold skill generates correct `app.settle()` + `app.on("settled")` pattern in new apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)