### PR TITLE
fix(act): use workspace:^ and order CD matrix by dep chain

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       max-parallel: 1 # prevents concurrent pull/push conflicts on main branch
       matrix:
-        lib: [act, act-patch, act-pg, act-sse]
+        lib: [act-patch, act, act-sse, act-pg]
 
     steps:
       - uses: actions/checkout@v4

--- a/libs/act-pg/package.json
+++ b/libs/act-pg/package.json
@@ -36,7 +36,7 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@rotorsoft/act": "workspace:*",
+    "@rotorsoft/act": "workspace:^",
     "pg": "^8.20.0",
     "zod": "^4.3.6"
   },

--- a/libs/act-sse/package.json
+++ b/libs/act-sse/package.json
@@ -36,6 +36,6 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@rotorsoft/act-patch": "workspace:*"
+    "@rotorsoft/act-patch": "workspace:^"
   }
 }

--- a/libs/act/package.json
+++ b/libs/act/package.json
@@ -35,7 +35,7 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@rotorsoft/act-patch": "workspace:*",
+    "@rotorsoft/act-patch": "workspace:^",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "scrub": "chmod +x ./scripts/scrub.sh && ./scripts/scrub.sh"
   },
   "dependencies": {
-    "@rotorsoft/act": "workspace:*",
-    "@rotorsoft/act-pg": "workspace:*"
+    "@rotorsoft/act": "workspace:^",
+    "@rotorsoft/act-pg": "workspace:^"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,9 +7,9 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@act/calculator": "workspace:*",
-    "@rotorsoft/act": "workspace:*",
-    "@rotorsoft/act-pg": "workspace:*",
+    "@act/calculator": "workspace:^",
+    "@rotorsoft/act": "workspace:^",
+    "@rotorsoft/act-pg": "workspace:^",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
     "@trpc/client": "11.12.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,9 +13,9 @@
   "keywords": [],
   "license": "ISC",
   "dependencies": {
-    "@act/calculator": "workspace:*",
-    "@rotorsoft/act": "workspace:*",
-    "@rotorsoft/act-pg": "workspace:*",
+    "@act/calculator": "workspace:^",
+    "@rotorsoft/act": "workspace:^",
+    "@rotorsoft/act-pg": "workspace:^",
     "@trpc/server": "11.12.0",
     "cors": "^2.8.6",
     "zod": "^4.3.6"

--- a/packages/wolfdesk/package.json
+++ b/packages/wolfdesk/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@libsql/client": "^0.17.0",
-    "@rotorsoft/act": "workspace:*",
-    "@rotorsoft/act-pg": "workspace:*",
+    "@rotorsoft/act": "workspace:^",
+    "@rotorsoft/act-pg": "workspace:^",
     "@trpc/server": "11.12.0",
     "drizzle-orm": "^0.45.1",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
   .:
     dependencies:
       '@rotorsoft/act':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:libs/act
       '@rotorsoft/act-pg':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:libs/act-pg
     devDependencies:
       '@commitlint/cli':
@@ -170,7 +170,7 @@ importers:
   libs/act:
     dependencies:
       '@rotorsoft/act-patch':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../act-patch
       pino:
         specifier: ^10.3.1
@@ -187,7 +187,7 @@ importers:
   libs/act-pg:
     dependencies:
       '@rotorsoft/act':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../act
       pg:
         specifier: ^8.20.0
@@ -203,7 +203,7 @@ importers:
   libs/act-sse:
     dependencies:
       '@rotorsoft/act-patch':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../act-patch
 
   packages/calculator:
@@ -228,13 +228,13 @@ importers:
   packages/client:
     dependencies:
       '@act/calculator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../calculator
       '@rotorsoft/act':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../libs/act
       '@rotorsoft/act-pg':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../libs/act-pg
       '@tanstack/react-query':
         specifier: ^5.90.21
@@ -292,13 +292,13 @@ importers:
   packages/server:
     dependencies:
       '@act/calculator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../calculator
       '@rotorsoft/act':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../libs/act
       '@rotorsoft/act-pg':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../libs/act-pg
       '@trpc/server':
         specifier: 11.12.0
@@ -320,10 +320,10 @@ importers:
         specifier: ^0.17.0
         version: 0.17.0
       '@rotorsoft/act':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../libs/act
       '@rotorsoft/act-pg':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../libs/act-pg
       '@trpc/server':
         specifier: 11.12.0


### PR DESCRIPTION
## Summary

- Switch all `workspace:*` → `workspace:^` so published packages use semver ranges (`^x.y.z`) instead of exact pins
- Reorder CD matrix to `[act-patch, act, act-sse, act-pg]` so dependencies publish before dependents

Fixes stale `@rotorsoft/act-patch@0.1.0` references on npm — the `package.json` changes in each lib directory will trigger semantic-release to re-publish with `^1.0.2`.

## Test plan

- [ ] CI passes
- [ ] After merge, `act`, `act-sse`, `act-pg` re-publish with correct `act-patch` range

🤖 Generated with [Claude Code](https://claude.com/claude-code)