### PR TITLE
fix(act): scope CD build to target lib and its deps

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install
-      - run: pnpm build
+      - run: pnpm -F @rotorsoft/${{ matrix.lib }}... build
 
       - name: configure git
         run: |


### PR DESCRIPTION
## Summary

- Replace `pnpm build` (entire monorepo) with `pnpm -F @rotorsoft/<lib>... build`
- The `...` suffix builds the target lib and its workspace dependencies only
- CI already ran full tests — CD only needs to build and publish

## Test plan

- [ ] CI passes
- [ ] CD builds only the relevant libs per matrix entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)