### PR TITLE
perf(act): replace fetched.find() with Map lookup in drain

### DIFF
--- a/libs/act-pg/test/drain-map-lookup.bench.ts
+++ b/libs/act-pg/test/drain-map-lookup.bench.ts
@@ -1,0 +1,66 @@
+/**
+ * Drain Map lookup benchmark.
+ *
+ * Measures drain cycle time at increasing stream counts to show
+ * the O(N²) → O(N) improvement from Map-based stream lookup.
+ *
+ * Run: npx tsx libs/act-pg/test/drain-map-lookup.bench.ts
+ */
+import { act, state, store, ZodEmpty } from "@rotorsoft/act";
+import { z } from "zod";
+import { PostgresStore } from "../src/PostgresStore.js";
+
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: ZodEmpty })
+  .patch({ Incremented: (_, s) => ({ count: s.count + 1 }) })
+  .on({ increment: ZodEmpty })
+  .emit(() => ["Incremented", {}])
+  .build();
+
+const noop = async () => {};
+const actor = { id: "a", name: "a" };
+
+store(
+  new PostgresStore({
+    port: 5431,
+    schema: "map_lookup_bench",
+    table: "events",
+  })
+);
+
+async function benchmark(streams: number, cycles: number) {
+  await store().drop();
+  await store().seed();
+
+  const app_ = act().withState(Counter).on("Incremented").do(noop).build();
+
+  // Seed streams with events
+  for (let i = 0; i < streams; i++) {
+    for (let j = 0; j < 3; j++) {
+      await app_.do("increment", { stream: `s-${i}`, actor }, {});
+    }
+  }
+  await app_.correlate({ limit: streams * 2 });
+
+  // Measure drain cycles
+  const start = performance.now();
+  for (let i = 0; i < cycles; i++) {
+    await app_.drain({ streamLimit: streams, eventLimit: 50, leaseMillis: 1 });
+  }
+  const elapsed = performance.now() - start;
+
+  console.log(
+    `| ${String(streams).padStart(7)} | ${String(cycles).padStart(6)} | ${elapsed.toFixed(0).padStart(9)}ms | ${(elapsed / cycles).toFixed(1).padStart(12)}ms |`
+  );
+}
+
+console.log("| Streams | Cycles |     Total | Per cycle    |");
+console.log("|---------|--------|-----------|--------------|");
+
+for (const streams of [10, 50, 100, 200, 500]) {
+  await benchmark(streams, 20);
+}
+
+await store().dispose();
+process.exit(0);

--- a/libs/act/PERFORMANCE.md
+++ b/libs/act/PERFORMANCE.md
@@ -206,3 +206,17 @@ Key: uses `=` (not `~` regex) for the stream match, which leverages the `(stream
 | **500 total, 50 active** | 5,416 | 58 | 24.0 | 15.6 | **35% faster** |
 
 The filter eliminates wasted claims — only streams with pending events are returned. At 200 streams with 10 active, claim returns 12 instead of 2,161 (216x fewer), and the drain cycle is 3.4x faster.
+
+---
+
+## Drain Map Lookup (v0.24.0)
+
+**PR:** #475 — Replace O(N²) `fetched.find()` with O(1) Map lookup.
+
+### Problem
+
+In the drain handle phase, `fetched.find((f) => f.stream === lease.stream)` performed a linear scan for each leased stream — O(N) per lease, called N times = O(N²). At `streamLimit=100`, up to 10,000 iterations per drain cycle.
+
+### Fix
+
+Convert `fetched` array to `Map<string, ...>` before the handle loop. O(N) to build, O(1) per lookup. Provable complexity improvement — no benchmark needed.

--- a/libs/act/PERFORMANCE.md
+++ b/libs/act/PERFORMANCE.md
@@ -219,4 +219,14 @@ In the drain handle phase, `fetched.find((f) => f.stream === lease.stream)` perf
 
 ### Fix
 
-Convert `fetched` array to `Map<string, ...>` before the handle loop. O(N) to build, O(1) per lookup. Provable complexity improvement — no benchmark needed.
+Convert `fetched` array to `Map<string, ...>` before the handle loop. O(N) to build, O(1) per lookup.
+
+### Benchmark (PostgreSQL, 20 drain cycles)
+
+| Streams | find() (ms/cycle) | Map (ms/cycle) | Improvement |
+|---:|---:|---:|---|
+| **50** | 5.7 | 4.3 | **25% faster** |
+| **100** | 6.4 | 5.4 | **16% faster** |
+| **200** | 9.9 | 8.9 | **10% faster** |
+
+The improvement is modest because drain cycles are dominated by DB I/O (claim, fetch, ack), not in-memory array scanning. The fix is free (one line, no downside) but not a bottleneck at realistic scales.

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -595,10 +595,11 @@ export class Act<
 
         tracer.leased(leased);
 
+        const fetchedMap = new Map(fetched.map((f) => [f.stream, f]));
         const handled = await Promise.all(
           leased.map((lease) => {
             // fast-forward watermark using fetched events or window max
-            const streamFetch = fetched.find((f) => f.stream === lease.stream);
+            const streamFetch = fetchedMap.get(lease.stream);
             const at = streamFetch?.events.at(-1)?.id || fetch_window_at;
             return this.handle(
               { ...lease, at },


### PR DESCRIPTION
## Summary

Closes #475

Replace O(N²) linear search with O(1) Map lookup in drain's handle phase.

### Problem

`fetched.find((f) => f.stream === lease.stream)` scanned the fetched array for each leased stream — O(N) per lease, called N times = O(N²). At `streamLimit=100`, up to 10,000 iterations per drain cycle.

### Fix

Convert `fetched` array to `Map<string, ...>` before the handle loop:

```typescript
const fetchedMap = new Map(fetched.map((f) => [f.stream, f]));
// O(1) lookup:
const streamFetch = fetchedMap.get(lease.stream);
```

O(N) to build the Map, O(1) per lookup. Provable algorithmic improvement.

## Test plan

- [x] All 342 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)