### PR TITLE
docs: projection optimization strategies for act-sse apps

### DIFF
--- a/.claude/skills/scaffold-act-app/SKILL.md
+++ b/.claude/skills/scaffold-act-app/SKILL.md
@@ -295,6 +295,8 @@ export const ItemSlice = slice()
 
 > **Warning:** `.void()` reactions are **NEVER processed by `drain()`** — the void resolver returns `undefined`, so drain skips them entirely. Use `.to(resolver)` for any reaction that must be discovered and executed during drain. Reserve `.void()` only for inline side effects (logging, metrics) that don't need drain processing. See [act-api.md](act-api.md) §6 (Void Reactions).
 
+**Lifecycle-only projections**: When using `act-sse` for real-time broadcast, projections only need to persist data for **lifecycle events** (entity created, member added, completed, deleted, etc.) — not every high-frequency operational event. The broadcast cache is the source of truth for full state; the DB stores lightweight summaries for cold-start recovery and list views. See [production.md](production.md) § Projection Optimization Strategies.
+
 ### Step 5 — Cross-Aggregate Projections
 
 Projections can consume events from multiple aggregates. Include the additional state in the slice to make the events available:
@@ -446,6 +448,7 @@ For production deployment (PostgresStore, background processing, automated jobs)
 - [ ] Invariants enforce all business rules
 - [ ] Reactions pass triggering event for causation tracking
 - [ ] Projections co-located with slices, with query and clear functions
+- [ ] Projections register only lifecycle event handlers when using act-sse broadcast
 - [ ] Tests use InMemoryStore with `store().seed()` and `clear*()` in `beforeEach`, `dispose()()` in `afterAll`
 - [ ] Domain package has no infrastructure dependencies
 - [ ] All packages use `"type": "module"` and TypeScript strict mode

--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -406,6 +406,8 @@ const ItemProjection = projection("items")
 - `.to(resolver)` / `.void()` — Override the default resolver per handler
 - `.build()` — Returns a `Projection` with `_tag: "Projection"`
 
+**Optimization:** When using `act-sse` broadcast, only register handlers for lifecycle events (entity creation, deletion, membership changes). High-frequency operational events don't need projection handlers — the broadcast cache is the source of truth. This reduces drain work and DB writes by ~95%. See [production.md](production.md) § Projection Optimization Strategies.
+
 ## 13. Slice Builder — Vertical Slice Architecture
 
 Slices group partial states with scoped reactions into self-contained feature modules. Handlers receive a typed `Dispatcher` for cross-state action dispatch.

--- a/.claude/skills/scaffold-act-app/production.md
+++ b/.claude/skills/scaffold-act-app/production.md
@@ -314,6 +314,87 @@ onStateChange: publicProcedure
   }),
 ```
 
+### Projection Optimization Strategies
+
+Not all events need to hit the database. When a broadcast cache already serves real-time state to clients, projections can be optimized to only persist **summary data** for **lifecycle events** — the subset that changes entity existence or membership.
+
+#### Lifecycle-Only Projections
+
+Classify events into two tiers:
+
+| Tier | Examples | Projection behavior |
+|------|---------|---------------------|
+| **Lifecycle** — changes existence/membership | `Created`, `MemberAdded`, `Completed`, `Archived`, `Deleted` | Persist summary to DB |
+| **Operational** — high-frequency state changes | `Updated`, `ItemMoved`, `FieldChanged`, `EntryLogged` | Skip — broadcast cache is source of truth |
+
+The projection registers handlers **only for lifecycle events**. Operational events are not projected at all — the broadcast cache (seeded after every `app.do()`) is the single source of truth for full state.
+
+```typescript
+// Only lifecycle events — no operational handlers needed
+const OrderProjection = projection("orders")
+  .on({ OrderCreated })
+  .do(async (event) => { await persistSummary(event.stream); })
+  .on({ MemberAdded })
+  .do(async (event) => { await persistSummary(event.stream); })
+  .on({ OrderCompleted })
+  .do(async (event) => { await persistSummary(event.stream); })
+  .build();
+
+// Handler reads from broadcast cache (always hot after app.do())
+async function persistSummary(streamId: string): Promise<void> {
+  const state = broadcast.getState(streamId);
+  if (!state) return; // cold start — bootstrap will rebuild
+  const summary = toSummary(state); // lightweight ~500B vs ~2KB full state
+  await db.upsert(streamId, summary);
+}
+```
+
+**Impact:** A typical entity with 250 events might have only ~13 lifecycle events — **95% fewer DB writes**, with each write **75% smaller** (summary vs full state).
+
+#### List View Cache Freshness
+
+The DB projection only updates on lifecycle events, but list views need fresh aggregate counts (totals, progress indicators, etc.) after every event. Solve this with a `settled` listener that syncs broadcast cache → in-memory list cache:
+
+```typescript
+app.on("settled", () => {
+  for (const [id, state] of broadcast.cache.entries()) {
+    listCache.set(id, toSummary(state));
+  }
+});
+```
+
+The list cache stays fresh after every event batch. The DB only writes on lifecycle events. Clients get current data from the list cache; the DB is for cold-start recovery only.
+
+#### Cold-Start Recovery
+
+During server restart, the broadcast cache is empty. Projection handlers skip (no state to read). After `app.settle()` completes:
+
+1. Load summaries from DB (correct for completed/inactive entities from previous run)
+2. Rebuild **active** entities from event log → seed broadcast cache + overwrite summaries
+3. Enable background processes (timers, scheduled jobs, etc.)
+
+```typescript
+async function bootstrap() {
+  await initDb();
+  await store().seed();
+  await settleOnce(); // projection advances watermark, handlers skip
+
+  const entities = await getEntities(); // from DB (previous run)
+  const activeIds = Object.entries(entities)
+    .filter(([, e]) => e.status !== "completed")
+    .map(([id]) => id);
+
+  for (const id of activeIds) {
+    const state = await rebuildFromEvents(id);
+    broadcast.cache.set(id, { ...state, _v: 0 });
+  }
+
+  enableBackgroundProcesses();
+}
+```
+
+Only active entities replay events (typically few). Completed entities keep their DB summaries from the previous run.
+
 ### Aggregate Snapshots vs Projection State
 
 The snapshot from `app.do()` has all event patches applied — it is the authoritative current state. Projections run asynchronously via `settle()` and can lag behind by any amount.


### PR DESCRIPTION
## Summary

- Document the **lifecycle-only projection** pattern in scaffold skill docs — only register handlers for events that change entity existence/roster, skip high-frequency gameplay events entirely
- **Broadcast cache as source of truth** — projections read from `broadcast.getState()` to compute summaries, no patch replay needed
- **Lobby/list cache freshness** — `settled` listener syncs broadcast cache → list cache on every event batch
- **Cold-start recovery** — rebuild active entities from event log after settle, ended entities keep DB summaries from previous run

### Files changed

- `production.md` — new "Projection Optimization Strategies" section with code examples
- `SKILL.md` — lifecycle-only note in Step 4, added to completion checklist
- `act-api.md` — optimization note in Projection Builder API reference

### Context

Learned from the Risk multiplayer game: a 6-player game produces ~250 events, only ~13 are lifecycle. The old approach wrote full game state (~2KB) to DB on every event. The optimized approach writes summaries (~500B) only on lifecycle events — **95% fewer DB writes, 99% less bandwidth**.

Related: #482 (framework-level drain skip optimization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)