### PR TITLE
feat(act-inspector): event sourcing observatory (Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dev:calculator": "pnpm -F calculator dev",
     "dev:wolfdesk": "pnpm -F wolfdesk dev",
     "dev:trpc": "npx concurrently -n 'server,client' -c 'cyan,yellow' 'pnpm -F server dev' 'pnpm -F client dev'",
+    "dev:inspector": "pnpm -F @rotorsoft/act-inspector dev",
     "scrub": "chmod +x ./scripts/scrub.sh && ./scripts/scrub.sh"
   },
   "dependencies": {

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -1,0 +1,80 @@
+# Act Inspector
+
+Event sourcing observatory for the Act framework. Connect to any Act PostgreSQL store and inspect, query, and visualize events.
+
+## Quickstart
+
+```bash
+# From the monorepo root
+pnpm install
+pnpm dev:inspector
+```
+
+This starts both the tRPC server (port 4001) and the Vite client (port 3001).
+
+Open [http://localhost:3001](http://localhost:3001) — the connection dialog appears on launch.
+
+### Auto-discover
+
+Click **Scan...** to automatically find Act stores on your host:
+
+1. Scans ports 5430–5480 (configurable) for PostgreSQL servers
+2. Tries common credentials (`postgres/postgres`, etc.)
+3. Detects Act event tables by schema shape (`stream`, `meta`, `version` columns)
+4. Picks the best table per schema — prefers `public.events`, then largest by row count
+5. Click a result to fill the connection form, then **Connect**
+
+Connection names are derived from the discovered `schema.table` (e.g., `act.wolfdesk`).
+
+### Manual connection
+
+Fill in the connection fields directly:
+
+| Field    | Default     |
+|----------|-------------|
+| Host     | `localhost` |
+| Port     | `5432`      |
+| Database | `postgres`  |
+| User     | `postgres`  |
+| Password | `postgres`  |
+| Schema   | `public`    |
+| Table    | `events`    |
+
+## Features
+
+- **Auto-Discovery** — scan a host for PG servers and Act stores across ports and schemas
+- **Connection Manager** — save/switch between multiple named connections
+- **Event Log Explorer** — reverse-chronological event list with filters:
+  - Stream name (regex)
+  - Event type (multi-select pills)
+  - Time range (presets: 5m, 15m, 1h, 24h, 7d)
+  - Correlation ID
+- **Snapshot visibility** — `__snapshot__` events included in all queries
+- **Event Detail** — expandable rows with syntax-highlighted, collapsible JSON for `data` and `meta`
+- **Stats Bar** — total events, unique streams, event types, time span
+- **Infinite Scroll** — cursor-based pagination, accumulates pages as you scroll
+- **URL-Synced Filters** — shareable filtered views via URL parameters
+- **Dark Theme** — JetBrains Mono font, zinc/emerald color palette
+
+## Architecture
+
+```
+packages/inspector/
+├── src/
+│   ├── server/
+│   │   ├── server.ts    # Express + tRPC standalone server
+│   │   └── router.ts    # tRPC procedures (discover, connect, query, stats, eventNames, streams)
+│   └── client/
+│       ├── App.tsx
+│       ├── trpc.ts
+│       ├── stores/      # URL-synced filter state
+│       ├── components/  # Header, ConnectDialog, ScanDialog, FilterBar, StatsBar, EventRow, JsonViewer, Logo
+│       └── views/       # EventLog
+├── index.html
+├── vite.config.ts
+└── tsconfig.json
+```
+
+- **Server**: manages its own `PostgresStore` instance directly (not the Act singleton) — enables reconnecting to different stores
+- **Client**: React 19 + Vite + Tailwind CSS v4 + tRPC React Query
+- **Read-only**: no mutations, no replays — pure inspection

--- a/packages/inspector/index.html
+++ b/packages/inspector/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Act Inspector</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap" rel="stylesheet" />
+  </head>
+  <body class="bg-zinc-950 font-mono text-zinc-100" style="font-family: 'JetBrains Mono', monospace">
+    <div id="root"></div>
+    <script type="module" src="/src/client/main.tsx"></script>
+  </body>
+</html>

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@rotorsoft/act-inspector",
+  "version": "0.0.1",
+  "description": "Act event sourcing observatory — inspect, query, and visualize events in Act stores",
+  "type": "module",
+  "author": {
+    "name": "rotorsoft",
+    "email": "rotorsoft@outlook.com"
+  },
+  "scripts": {
+    "dev:server": "tsx watch src/server/server.ts",
+    "dev:client": "vite",
+    "dev": "concurrently -n 'server,client' -c 'cyan,yellow' 'pnpm run dev:server' 'pnpm run dev:client'"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "dependencies": {
+    "@rotorsoft/act": "workspace:^",
+    "@rotorsoft/act-pg": "workspace:^",
+    "@tanstack/react-query": "^5.90.21",
+    "@trpc/client": "11.12.1",
+    "@trpc/react-query": "11.12.1",
+    "@trpc/server": "11.12.1",
+    "cors": "^2.8.6",
+    "pg": "^8.20.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.8",
+    "@types/cors": "^2.8.19",
+    "@types/pg": "^8.18.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "autoprefixer": "^10.4.21",
+    "concurrently": "^9.1.2",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.8",
+    "typescript": "~5.9.3",
+    "vite": "^7.3.1"
+  }
+}

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -1,0 +1,43 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+import { ConnectDialog } from "./components/ConnectDialog.js";
+import { Header } from "./components/Header.js";
+import { queryClient, trpc, trpcClient } from "./trpc.js";
+import { EventLog } from "./views/EventLog.js";
+
+export default function App() {
+  const [connected, setConnected] = useState(false);
+  const [showConnect, setShowConnect] = useState(true);
+  const [connectionName, setConnectionName] = useState("");
+  const [connectionKey, setConnectionKey] = useState(0);
+
+  const handleConnected = (name: string) => {
+    // Clear all cached queries from previous connection
+    queryClient.clear();
+    setConnected(true);
+    setConnectionName(name);
+    setConnectionKey((k) => k + 1);
+    setShowConnect(false);
+  };
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <div className="flex h-screen flex-col bg-zinc-950 text-zinc-100">
+          <Header
+            connected={connected}
+            connectionName={connectionName}
+            onConnect={() => setShowConnect(true)}
+          />
+          {showConnect && (
+            <ConnectDialog
+              onConnected={handleConnected}
+              onClose={connected ? () => setShowConnect(false) : undefined}
+            />
+          )}
+          {connected && <EventLog key={connectionKey} />}
+        </div>
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/packages/inspector/src/client/components/ConnectDialog.tsx
+++ b/packages/inspector/src/client/components/ConnectDialog.tsx
@@ -1,0 +1,241 @@
+import { useState } from "react";
+import { trpc } from "../trpc.js";
+import { Logo } from "./Logo.js";
+import { ScanDialog, type ScanResult } from "./ScanDialog.js";
+
+type Connection = {
+  name: string;
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string;
+  schema: string;
+  table: string;
+};
+
+const defaultConn: Connection = {
+  name: "Local",
+  host: "localhost",
+  port: 5432,
+  database: "postgres",
+  user: "postgres",
+  password: "postgres",
+  schema: "public",
+  table: "events",
+};
+
+function loadSaved(): Connection[] {
+  try {
+    const raw = localStorage.getItem("inspector:connections");
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveConnections(conns: Connection[]) {
+  localStorage.setItem("inspector:connections", JSON.stringify(conns));
+}
+
+type Props = {
+  onConnected: (name: string) => void;
+  onClose?: () => void;
+};
+
+export function ConnectDialog({ onConnected, onClose }: Props) {
+  const [saved, setSaved] = useState<Connection[]>(loadSaved);
+  const [conn, setConn] = useState<Connection>(saved[0] ?? defaultConn);
+  const [error, setError] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [showScan, setShowScan] = useState(false);
+
+  const connectMutation = trpc.connect.useMutation({
+    onSuccess: () => {
+      const existing = saved.filter((s) => s.name !== conn.name);
+      const updated = [conn, ...existing];
+      setSaved(updated);
+      saveConnections(updated);
+      onConnected(conn.name);
+    },
+    onError: (err) => {
+      setError(err.message);
+      setTesting(false);
+    },
+  });
+
+  const handleScanSelect = (result: ScanResult) => {
+    // Connection name: schema.table if descriptive, otherwise database name
+    const isDefault = result.schema === "public" && result.table === "events";
+    const label = isDefault
+      ? result.database
+      : `${result.schema}.${result.table}`;
+    setConn({
+      ...conn,
+      name: label,
+      host: result.host,
+      port: result.port,
+      user: result.user,
+      database: result.database,
+      schema: result.schema,
+      table: result.table,
+    });
+    setShowScan(false);
+  };
+
+  const handleConnect = () => {
+    setError("");
+    setTesting(true);
+    connectMutation.mutate({
+      host: conn.host,
+      port: conn.port,
+      database: conn.database,
+      user: conn.user,
+      password: conn.password,
+      schema: conn.schema,
+      table: conn.table,
+    });
+  };
+
+  const handleSavedSelect = (name: string) => {
+    const found = saved.find((s) => s.name === name);
+    if (found) setConn(found);
+  };
+
+  const handleDelete = (name: string) => {
+    const updated = saved.filter((s) => s.name !== name);
+    setSaved(updated);
+    saveConnections(updated);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-lg rounded-xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <Logo size={24} />
+            <h2 className="text-lg font-semibold text-zinc-100">
+              Connect to Act Store
+            </h2>
+          </div>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="text-zinc-500 transition hover:text-zinc-300"
+            >
+              &times;
+            </button>
+          )}
+        </div>
+
+        {/* Saved connections */}
+        {saved.length > 0 && (
+          <div className="mb-4">
+            <span className="mb-1.5 block text-[10px] uppercase tracking-wider text-zinc-500">
+              Saved connections
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {saved.map((s) => (
+                <div key={s.name} className="flex items-center gap-1">
+                  <button
+                    onClick={() => handleSavedSelect(s.name)}
+                    className={`rounded-md border px-3 py-1 text-xs transition ${
+                      conn.name === s.name
+                        ? "border-emerald-600 bg-emerald-950 text-emerald-400"
+                        : "border-zinc-700 bg-zinc-800 text-zinc-300 hover:border-zinc-600"
+                    }`}
+                  >
+                    {s.name}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(s.name)}
+                    className="text-xs text-zinc-600 transition hover:text-red-400"
+                  >
+                    &times;
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Connection form */}
+        <div className="grid grid-cols-2 gap-3">
+          {(
+            [
+              ["Connection Name", "name", "text"],
+              ["Host", "host", "text"],
+              ["Port", "port", "number"],
+              ["Database", "database", "text"],
+              ["User", "user", "text"],
+              ["Password", "password", "password"],
+              ["Schema", "schema", "text"],
+              ["Table", "table", "text"],
+            ] as const
+          ).map(([label, key, type]) => (
+            <label key={key} className="flex flex-col gap-1">
+              <span className="text-xs text-zinc-400">{label}</span>
+              <input
+                type={type}
+                value={conn[key]}
+                onChange={(e) =>
+                  setConn({
+                    ...conn,
+                    [key]:
+                      type === "number"
+                        ? Number(e.target.value)
+                        : e.target.value,
+                  })
+                }
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+              />
+            </label>
+          ))}
+        </div>
+
+        {error && (
+          <div className="mt-3 rounded-md border border-red-900 bg-red-950 px-3 py-2 text-xs text-red-400">
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-4 flex justify-between">
+          <button
+            onClick={() => setShowScan(true)}
+            className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-300 transition hover:border-emerald-700 hover:text-emerald-400"
+          >
+            Scan...
+          </button>
+          <div className="flex gap-2">
+            {onClose && (
+              <button
+                onClick={onClose}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-400 transition hover:border-zinc-600"
+              >
+                Cancel
+              </button>
+            )}
+            <button
+              onClick={handleConnect}
+              disabled={testing}
+              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+            >
+              {testing ? "Connecting..." : "Connect"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Scan popup */}
+      {showScan && (
+        <ScanDialog
+          initialHost={conn.host}
+          onSelect={handleScanSelect}
+          onClose={() => setShowScan(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/inspector/src/client/components/EventRow.tsx
+++ b/packages/inspector/src/client/components/EventRow.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { JsonViewer } from "./JsonViewer.js";
+
+type EventMeta = {
+  correlation?: string;
+  causation?: {
+    action?: {
+      stream?: string;
+      actor?: { id?: string; name?: string };
+      name?: string;
+    };
+    event?: { id?: number; name?: string; stream?: string };
+  };
+};
+
+type Event = {
+  id: number;
+  name: string;
+  stream: string;
+  version: number;
+  created: string;
+  data: unknown;
+  meta: EventMeta;
+};
+
+type EventRowProps = {
+  event: Event;
+};
+
+/** Deterministic color from event name */
+function nameColor(name: string): string {
+  const colors = [
+    "bg-sky-900/50 text-sky-300 border-sky-800",
+    "bg-amber-900/50 text-amber-300 border-amber-800",
+    "bg-emerald-900/50 text-emerald-300 border-emerald-800",
+    "bg-purple-900/50 text-purple-300 border-purple-800",
+    "bg-rose-900/50 text-rose-300 border-rose-800",
+    "bg-cyan-900/50 text-cyan-300 border-cyan-800",
+    "bg-orange-900/50 text-orange-300 border-orange-800",
+    "bg-indigo-900/50 text-indigo-300 border-indigo-800",
+    "bg-teal-900/50 text-teal-300 border-teal-800",
+    "bg-pink-900/50 text-pink-300 border-pink-800",
+  ];
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 1000) return "just now";
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+function copyToClipboard(text: string) {
+  void navigator.clipboard.writeText(text);
+}
+
+export function EventRow({ event }: EventRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const actor = event.meta?.causation?.action?.actor;
+
+  return (
+    <div className="border-b border-zinc-800/50 transition hover:bg-zinc-900/50">
+      {/* Main row */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-3 px-4 py-2 text-left text-xs"
+      >
+        {/* ID */}
+        <span className="w-16 shrink-0 font-mono text-zinc-500">
+          #{event.id}
+        </span>
+
+        {/* Actor */}
+        <span className="w-24 shrink-0 truncate text-zinc-500">
+          {actor?.name ?? ""}
+        </span>
+
+        {/* Version */}
+        <span className="w-12 shrink-0 text-right font-mono text-zinc-500">
+          v{event.version}
+        </span>
+
+        {/* Event name pill */}
+        <span className="w-36 shrink-0 truncate">
+          <span
+            className={`inline-block rounded-md border px-2 py-0.5 text-[11px] font-medium ${nameColor(event.name)}`}
+          >
+            {event.name}
+          </span>
+        </span>
+
+        {/* Stream */}
+        <span className="min-w-0 flex-1 truncate font-mono text-zinc-300">
+          {event.stream}
+        </span>
+
+        {/* Time */}
+        <span
+          className="w-20 shrink-0 text-right text-zinc-500"
+          title={new Date(event.created).toLocaleString()}
+        >
+          {relativeTime(event.created)}
+        </span>
+
+        {/* Expand indicator */}
+        <span className="w-4 shrink-0 text-zinc-600">
+          {expanded ? "▾" : "▸"}
+        </span>
+      </button>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="border-t border-zinc-800/30 bg-zinc-900/80 px-4 py-3">
+          <div className="grid grid-cols-2 gap-4">
+            {/* Data */}
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-[10px] uppercase tracking-wider text-zinc-500">
+                  Data
+                </span>
+                <button
+                  onClick={() =>
+                    copyToClipboard(JSON.stringify(event.data, null, 2))
+                  }
+                  className="text-[10px] text-zinc-600 transition hover:text-zinc-400"
+                >
+                  Copy
+                </button>
+              </div>
+              <div className="rounded-md border border-zinc-800 bg-zinc-950 p-3">
+                <JsonViewer data={event.data} />
+              </div>
+            </div>
+
+            {/* Meta */}
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-[10px] uppercase tracking-wider text-zinc-500">
+                  Meta
+                </span>
+                <button
+                  onClick={() =>
+                    copyToClipboard(JSON.stringify(event.meta, null, 2))
+                  }
+                  className="text-[10px] text-zinc-600 transition hover:text-zinc-400"
+                >
+                  Copy
+                </button>
+              </div>
+              <div className="rounded-md border border-zinc-800 bg-zinc-950 p-3">
+                <JsonViewer data={event.meta} />
+              </div>
+            </div>
+          </div>
+
+          {/* Quick info bar */}
+          <div className="mt-3 flex flex-wrap gap-4 text-[10px] text-zinc-500">
+            <span>
+              Stream:{" "}
+              <button
+                onClick={() => copyToClipboard(event.stream)}
+                className="text-zinc-300 hover:text-emerald-400"
+              >
+                {event.stream}
+              </button>
+            </span>
+            {event.meta?.correlation && (
+              <span>
+                Correlation:{" "}
+                <button
+                  onClick={() => copyToClipboard(event.meta.correlation!)}
+                  className="font-mono text-zinc-300 hover:text-emerald-400"
+                >
+                  {event.meta.correlation}
+                </button>
+              </span>
+            )}
+            <span>
+              Created:{" "}
+              <span className="text-zinc-300">
+                {new Date(event.created).toISOString()}
+              </span>
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/inspector/src/client/components/FilterBar.tsx
+++ b/packages/inspector/src/client/components/FilterBar.tsx
@@ -1,0 +1,163 @@
+import { useRef, useState } from "react";
+import { useFilterStore } from "../stores/filters.js";
+import { trpc } from "../trpc.js";
+
+const TIME_PRESETS = [
+  { label: "5m", ms: 5 * 60_000 },
+  { label: "15m", ms: 15 * 60_000 },
+  { label: "1h", ms: 60 * 60_000 },
+  { label: "24h", ms: 24 * 60 * 60_000 },
+  { label: "7d", ms: 7 * 24 * 60 * 60_000 },
+] as const;
+
+export function FilterBar() {
+  const [filters, setFilters, clearFilters] = useFilterStore();
+  const [streamInput, setStreamInput] = useState(filters.stream ?? "");
+  const [corrInput, setCorrInput] = useState(filters.correlation ?? "");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const eventNamesQuery = trpc.eventNames.useQuery(undefined, {
+    staleTime: 30_000,
+  });
+  const allNames = eventNamesQuery.data ?? [];
+
+  const handleStreamChange = (value: string) => {
+    setStreamInput(value);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setFilters({ stream: value || undefined });
+    }, 400);
+  };
+
+  const handleCorrChange = (value: string) => {
+    setCorrInput(value);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setFilters({ correlation: value || undefined });
+    }, 400);
+  };
+
+  const toggleName = (name: string) => {
+    const current = filters.names ?? [];
+    const next = current.includes(name)
+      ? current.filter((n) => n !== name)
+      : [...current, name];
+    setFilters({ names: next.length ? next : undefined });
+  };
+
+  const setTimePreset = (ms: number) => {
+    setFilters({
+      created_after: new Date(Date.now() - ms).toISOString(),
+      created_before: undefined,
+    });
+  };
+
+  const clearTime = () => {
+    setFilters({ created_after: undefined, created_before: undefined });
+  };
+
+  const hasFilters =
+    filters.stream ||
+    filters.names?.length ||
+    filters.created_after ||
+    filters.correlation;
+
+  return (
+    <div className="flex flex-col gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-3">
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Stream filter */}
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] uppercase tracking-wider text-zinc-500">
+            Stream
+          </label>
+          <input
+            type="text"
+            value={streamInput}
+            onChange={(e) => handleStreamChange(e.target.value)}
+            placeholder="regex pattern..."
+            className="w-48 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-200 outline-none transition placeholder:text-zinc-600 focus:border-emerald-600"
+          />
+        </div>
+
+        {/* Correlation filter */}
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] uppercase tracking-wider text-zinc-500">
+            Correlation
+          </label>
+          <input
+            type="text"
+            value={corrInput}
+            onChange={(e) => handleCorrChange(e.target.value)}
+            placeholder="correlation id..."
+            className="w-56 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-200 outline-none transition placeholder:text-zinc-600 focus:border-emerald-600"
+          />
+        </div>
+
+        {/* Time range presets */}
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] uppercase tracking-wider text-zinc-500">
+            Time Range
+          </label>
+          <div className="flex gap-1">
+            {TIME_PRESETS.map((p) => {
+              const active =
+                filters.created_after &&
+                Math.abs(
+                  Date.now() - new Date(filters.created_after).getTime() - p.ms
+                ) < 60_000;
+              return (
+                <button
+                  key={p.label}
+                  onClick={() => (active ? clearTime() : setTimePreset(p.ms))}
+                  className={`rounded-md border px-2 py-1.5 text-xs transition ${
+                    active
+                      ? "border-emerald-600 bg-emerald-950 text-emerald-400"
+                      : "border-zinc-700 bg-zinc-800 text-zinc-400 hover:border-zinc-600 hover:text-zinc-300"
+                  }`}
+                >
+                  {p.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Clear all */}
+        {hasFilters && (
+          <button
+            onClick={() => {
+              clearFilters();
+              setStreamInput("");
+              setCorrInput("");
+            }}
+            className="mt-4 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs text-zinc-400 transition hover:border-red-800 hover:text-red-400"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Event name multi-select */}
+      {allNames.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {allNames.map((name) => {
+            const active = filters.names?.includes(name);
+            return (
+              <button
+                key={name}
+                onClick={() => toggleName(name)}
+                className={`rounded-full border px-2.5 py-0.5 text-[11px] transition ${
+                  active
+                    ? "border-emerald-700 bg-emerald-950 text-emerald-400"
+                    : "border-zinc-700 bg-zinc-850 text-zinc-400 hover:border-zinc-600 hover:text-zinc-300"
+                }`}
+              >
+                {name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/inspector/src/client/components/Header.tsx
+++ b/packages/inspector/src/client/components/Header.tsx
@@ -1,0 +1,39 @@
+import { Logo } from "./Logo.js";
+
+type HeaderProps = {
+  connected: boolean;
+  connectionName: string;
+  onConnect: () => void;
+};
+
+export function Header({ connected, connectionName, onConnect }: HeaderProps) {
+  return (
+    <header className="flex h-12 shrink-0 items-center justify-between border-b border-zinc-800 bg-zinc-925 px-4">
+      <div className="flex items-center gap-2.5">
+        <Logo size={22} />
+        <h1 className="text-sm font-semibold tracking-wide text-zinc-300">
+          <span className="text-emerald-400">act</span> inspector
+        </h1>
+      </div>
+      <div className="flex items-center gap-3">
+        {connected ? (
+          <button
+            onClick={onConnect}
+            className="flex items-center gap-2 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1 text-xs text-zinc-300 transition hover:border-zinc-600 hover:bg-zinc-750"
+          >
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            {connectionName}
+          </button>
+        ) : (
+          <button
+            onClick={onConnect}
+            className="flex items-center gap-2 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1 text-xs text-zinc-400 transition hover:border-zinc-600"
+          >
+            <span className="h-2 w-2 rounded-full bg-zinc-600" />
+            Not connected
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/packages/inspector/src/client/components/JsonViewer.tsx
+++ b/packages/inspector/src/client/components/JsonViewer.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+
+type JsonViewerProps = {
+  data: unknown;
+  collapsed?: boolean;
+  label?: string;
+};
+
+export function JsonViewer({
+  data,
+  collapsed = false,
+  label,
+}: JsonViewerProps) {
+  return (
+    <div className="font-mono text-xs leading-relaxed">
+      {label && <span className="mr-2 text-zinc-500">{label}:</span>}
+      <JsonNode data={data} depth={0} defaultCollapsed={collapsed} />
+    </div>
+  );
+}
+
+function JsonNode({
+  data,
+  depth,
+  defaultCollapsed,
+}: {
+  data: unknown;
+  depth: number;
+  defaultCollapsed: boolean;
+}) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed && depth > 0);
+
+  if (data === null) return <span className="json-null">null</span>;
+  if (data === undefined) return <span className="json-null">undefined</span>;
+
+  if (typeof data === "string")
+    return <span className="json-string">&quot;{data}&quot;</span>;
+  if (typeof data === "number")
+    return <span className="json-number">{data}</span>;
+  if (typeof data === "boolean")
+    return <span className="json-boolean">{String(data)}</span>;
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) return <span className="text-zinc-500">[]</span>;
+    if (collapsed)
+      return (
+        <span
+          onClick={() => setCollapsed(false)}
+          className="cursor-pointer text-zinc-500 hover:text-zinc-300"
+        >
+          [{data.length} items]
+        </span>
+      );
+    return (
+      <span>
+        <span
+          onClick={() => setCollapsed(true)}
+          className="cursor-pointer text-zinc-500 hover:text-zinc-300"
+        >
+          [
+        </span>
+        <div style={{ paddingLeft: 16 }}>
+          {data.map((item, i) => (
+            <div key={i}>
+              <JsonNode
+                data={item}
+                depth={depth + 1}
+                defaultCollapsed={defaultCollapsed}
+              />
+              {i < data.length - 1 && <span className="text-zinc-600">,</span>}
+            </div>
+          ))}
+        </div>
+        <span className="text-zinc-500">]</span>
+      </span>
+    );
+  }
+
+  if (typeof data === "object") {
+    const entries = Object.entries(data as Record<string, unknown>);
+    if (entries.length === 0)
+      return <span className="text-zinc-500">{"{}"}</span>;
+    if (collapsed)
+      return (
+        <span
+          onClick={() => setCollapsed(false)}
+          className="cursor-pointer text-zinc-500 hover:text-zinc-300"
+        >
+          {"{"}
+          {entries.length} fields{"}"}
+        </span>
+      );
+    return (
+      <span>
+        <span
+          onClick={() => setCollapsed(true)}
+          className="cursor-pointer text-zinc-500 hover:text-zinc-300"
+        >
+          {"{"}
+        </span>
+        <div style={{ paddingLeft: 16 }}>
+          {entries.map(([key, value], i) => (
+            <div key={key}>
+              <span className="json-key">{key}</span>
+              <span className="text-zinc-600">: </span>
+              <JsonNode
+                data={value}
+                depth={depth + 1}
+                defaultCollapsed={defaultCollapsed}
+              />
+              {i < entries.length - 1 && (
+                <span className="text-zinc-600">,</span>
+              )}
+            </div>
+          ))}
+        </div>
+        <span className="text-zinc-500">{"}"}</span>
+      </span>
+    );
+  }
+
+  return <span className="text-zinc-400">{JSON.stringify(data)}</span>;
+}

--- a/packages/inspector/src/client/components/Logo.tsx
+++ b/packages/inspector/src/client/components/Logo.tsx
@@ -1,0 +1,66 @@
+type LogoProps = {
+  size?: number;
+};
+
+export function Logo({ size = 24 }: LogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Magnifying glass body */}
+      <circle
+        cx="14"
+        cy="14"
+        r="9"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        className="text-emerald-400"
+      />
+      {/* Handle */}
+      <line
+        x1="21"
+        y1="21"
+        x2="28"
+        y2="28"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        className="text-emerald-400"
+      />
+      {/* Event stream lines inside lens */}
+      <path
+        d="M9 11h4M9 14h6M9 17h3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        className="text-emerald-300"
+      />
+      {/* Dot accents */}
+      <circle
+        cx="17"
+        cy="11"
+        r="1.2"
+        fill="currentColor"
+        className="text-amber-400"
+      />
+      <circle
+        cx="19"
+        cy="14"
+        r="1.2"
+        fill="currentColor"
+        className="text-sky-400"
+      />
+      <circle
+        cx="16"
+        cy="17"
+        r="1.2"
+        fill="currentColor"
+        className="text-purple-400"
+      />
+    </svg>
+  );
+}

--- a/packages/inspector/src/client/components/ScanDialog.tsx
+++ b/packages/inspector/src/client/components/ScanDialog.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { trpc } from "../trpc.js";
+
+type DiscoveredStore = {
+  host: string;
+  port: number;
+  user: string;
+  database: string;
+  schema: string;
+  table: string;
+  eventCount: number;
+};
+
+export type ScanResult = {
+  host: string;
+  port: number;
+  user: string;
+  database: string;
+  schema: string;
+  table: string;
+};
+
+type Props = {
+  initialHost: string;
+  onSelect: (result: ScanResult) => void;
+  onClose: () => void;
+};
+
+export function ScanDialog({ initialHost, onSelect, onClose }: Props) {
+  const [host, setHost] = useState(initialHost);
+  const [portFrom, setPortFrom] = useState(5430);
+  const [portTo, setPortTo] = useState(5480);
+  const [stores, setStores] = useState<DiscoveredStore[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState("");
+  const [scanned, setScanned] = useState(false);
+
+  const discoverMutation = trpc.discover.useMutation({
+    onSuccess: (result) => {
+      setStores(result.stores);
+      setScanning(false);
+      setScanned(true);
+      if (result.stores.length === 0) {
+        setError("No Act event stores found");
+      } else if (result.stores.length === 1) {
+        // Single result — auto-select it
+        handleSelect(result.stores[0]);
+      }
+    },
+    onError: (err) => {
+      setError(err.message);
+      setScanning(false);
+      setScanned(true);
+    },
+  });
+
+  const handleScan = () => {
+    setError("");
+    setStores([]);
+    setScanning(true);
+    setScanned(false);
+    discoverMutation.mutate({ host, portFrom, portTo });
+  };
+
+  const handleSelect = (store: DiscoveredStore) => {
+    onSelect({
+      host: store.host,
+      port: store.port,
+      user: store.user,
+      database: store.database,
+      schema: store.schema,
+      table: store.table,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-xl border border-zinc-700 bg-zinc-900 p-5 shadow-2xl">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-zinc-200">
+            Scan for Act Stores
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-zinc-500 transition hover:text-zinc-300"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Scan options */}
+        <div className="mb-4 flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-zinc-400">Host</span>
+            <input
+              type="text"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+            />
+          </label>
+          <div className="flex items-end gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-zinc-400">Port from</span>
+              <input
+                type="number"
+                value={portFrom}
+                onChange={(e) => setPortFrom(Number(e.target.value))}
+                className="w-24 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-zinc-400">Port to</span>
+              <input
+                type="number"
+                value={portTo}
+                onChange={(e) => setPortTo(Number(e.target.value))}
+                className="w-24 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600"
+              />
+            </label>
+            <button
+              onClick={handleScan}
+              disabled={scanning}
+              className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+            >
+              {scanning ? "Scanning..." : "Scan"}
+            </button>
+          </div>
+        </div>
+
+        {/* Scanning indicator */}
+        {scanning && (
+          <div className="mb-3 rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-[10px] text-zinc-500">
+            Scanning {host} — ports {portFrom}–{portTo}...
+          </div>
+        )}
+
+        {/* Results — one per port */}
+        {stores.length > 0 && (
+          <div className="max-h-56 overflow-y-auto">
+            <span className="mb-2 block text-xs font-medium text-emerald-400">
+              Found {stores.length} store{stores.length !== 1 ? "s" : ""}
+            </span>
+            <div className="flex flex-col gap-1.5">
+              {stores.map((s) => (
+                <button
+                  key={`${s.port}:${s.schema}`}
+                  onClick={() => handleSelect(s)}
+                  className="flex items-center gap-2 rounded-md border border-zinc-700/50 bg-zinc-800 px-3 py-2.5 text-left text-xs transition hover:border-emerald-700 hover:bg-emerald-950/30"
+                >
+                  <span className="shrink-0 rounded bg-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-300">
+                    :{s.port}
+                  </span>
+                  <span className="text-zinc-300">{s.database}</span>
+                  <span className="text-zinc-600">/</span>
+                  <span className="font-medium text-emerald-400">
+                    {s.schema}.{s.table}
+                  </span>
+                  {s.eventCount > 0 && (
+                    <span className="ml-auto rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] text-zinc-400">
+                      ~{s.eventCount.toLocaleString()} events
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* No results */}
+        {scanned && !scanning && stores.length === 0 && !error && (
+          <div className="rounded-md border border-zinc-800 bg-zinc-950 px-3 py-4 text-center text-xs text-zinc-500">
+            No Act event stores found on {host}
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-2 rounded-md border border-red-900 bg-red-950 px-3 py-2 text-xs text-red-400">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/inspector/src/client/components/StatsBar.tsx
+++ b/packages/inspector/src/client/components/StatsBar.tsx
@@ -1,0 +1,59 @@
+import { useFilterStore } from "../stores/filters.js";
+import { trpc } from "../trpc.js";
+
+export function StatsBar() {
+  const [filters] = useFilterStore();
+
+  const statsQuery = trpc.stats.useQuery(
+    {
+      stream: filters.stream,
+      names: filters.names,
+      created_after: filters.created_after,
+      created_before: filters.created_before,
+      correlation: filters.correlation,
+    },
+    { staleTime: 5_000 }
+  );
+
+  const stats = statsQuery.data;
+
+  return (
+    <div className="flex items-center gap-6 border-b border-zinc-800 bg-zinc-925 px-4 py-2 text-xs text-zinc-400">
+      {statsQuery.isLoading ? (
+        <span className="text-zinc-600">Loading stats...</span>
+      ) : stats ? (
+        <>
+          <Stat label="Events" value={stats.totalEvents.toLocaleString()} />
+          <Stat label="Streams" value={stats.uniqueStreams.toLocaleString()} />
+          <Stat
+            label="Event Types"
+            value={stats.uniqueEventNames.toLocaleString()}
+          />
+          {stats.timeSpan && (
+            <Stat
+              label="Time Span"
+              value={formatTimeSpan(stats.timeSpan.from, stats.timeSpan.to)}
+            />
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-zinc-500">{label}</span>
+      <span className="font-medium text-zinc-200">{value}</span>
+    </div>
+  );
+}
+
+function formatTimeSpan(from: string, to: string): string {
+  const ms = new Date(to).getTime() - new Date(from).getTime();
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  if (ms < 86_400_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+  return `${(ms / 86_400_000).toFixed(1)}d`;
+}

--- a/packages/inspector/src/client/main.tsx
+++ b/packages/inspector/src/client/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.js";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/packages/inspector/src/client/stores/filters.ts
+++ b/packages/inspector/src/client/stores/filters.ts
@@ -1,0 +1,91 @@
+import { useSyncExternalStore } from "react";
+
+export type Filters = {
+  stream?: string;
+  names?: string[];
+  created_after?: string;
+  created_before?: string;
+  correlation?: string;
+  backward: boolean;
+  limit: number;
+  before?: number;
+};
+
+const defaultFilters: Filters = {
+  backward: true,
+  limit: 50,
+};
+
+let filters: Filters = loadFromUrl();
+let listeners: Array<() => void> = [];
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+function loadFromUrl(): Filters {
+  if (typeof window === "undefined") return { ...defaultFilters };
+  const params = new URLSearchParams(window.location.search);
+  return {
+    stream: params.get("stream") || undefined,
+    names: params.get("names")?.split(",").filter(Boolean) || undefined,
+    created_after: params.get("created_after") || undefined,
+    created_before: params.get("created_before") || undefined,
+    correlation: params.get("correlation") || undefined,
+    backward: params.get("backward") !== "false",
+    limit: Number(params.get("limit")) || 50,
+    before: params.has("before") ? Number(params.get("before")) : undefined,
+  };
+}
+
+function syncToUrl(f: Filters) {
+  const params = new URLSearchParams();
+  if (f.stream) params.set("stream", f.stream);
+  if (f.names?.length) params.set("names", f.names.join(","));
+  if (f.created_after) params.set("created_after", f.created_after);
+  if (f.created_before) params.set("created_before", f.created_before);
+  if (f.correlation) params.set("correlation", f.correlation);
+  if (!f.backward) params.set("backward", "false");
+  if (f.limit !== 50) params.set("limit", String(f.limit));
+  const search = params.toString();
+  const url = search ? `?${search}` : window.location.pathname;
+  window.history.replaceState(null, "", url);
+}
+
+export function setFilters(update: Partial<Filters>) {
+  // Reset cursor when filters change (except when paging)
+  const resetCursor = !("before" in update);
+  filters = {
+    ...filters,
+    ...update,
+    ...(resetCursor ? { before: undefined } : {}),
+  };
+  syncToUrl(filters);
+  notify();
+}
+
+export function clearFilters() {
+  filters = { ...defaultFilters };
+  syncToUrl(filters);
+  notify();
+}
+
+export function getFilters(): Filters {
+  return filters;
+}
+
+function subscribe(listener: () => void) {
+  listeners.push(listener);
+  return () => {
+    listeners = listeners.filter((l) => l !== listener);
+  };
+}
+
+export function useFilterStore(): [
+  Filters,
+  typeof setFilters,
+  typeof clearFilters,
+] {
+  const snapshot = useSyncExternalStore(subscribe, getFilters);
+  return [snapshot, setFilters, clearFilters];
+}

--- a/packages/inspector/src/client/styles.css
+++ b/packages/inspector/src/client/styles.css
@@ -1,0 +1,38 @@
+@import "tailwindcss";
+
+@theme {
+  --color-zinc-925: #111113;
+}
+
+/* Custom scrollbar for dark theme */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: theme("colors.zinc.900");
+}
+::-webkit-scrollbar-thumb {
+  background: theme("colors.zinc.700");
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: theme("colors.zinc.600");
+}
+
+/* JSON tree viewer */
+.json-key {
+  color: theme("colors.sky.400");
+}
+.json-string {
+  color: theme("colors.emerald.400");
+}
+.json-number {
+  color: theme("colors.amber.400");
+}
+.json-boolean {
+  color: theme("colors.purple.400");
+}
+.json-null {
+  color: theme("colors.zinc.500");
+}

--- a/packages/inspector/src/client/trpc.ts
+++ b/packages/inspector/src/client/trpc.ts
@@ -1,0 +1,23 @@
+import { QueryClient } from "@tanstack/react-query";
+import {
+  type CreateTRPCReact,
+  createTRPCReact,
+  httpLink,
+} from "@trpc/react-query";
+import { type InspectorRouter } from "../server/router.js";
+
+export const trpc: CreateTRPCReact<InspectorRouter, unknown> =
+  createTRPCReact<InspectorRouter>();
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export const trpcClient = trpc.createClient({
+  links: [httpLink({ url: "http://localhost:4001" })],
+});

--- a/packages/inspector/src/client/views/EventLog.tsx
+++ b/packages/inspector/src/client/views/EventLog.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { EventRow } from "../components/EventRow.js";
+import { FilterBar } from "../components/FilterBar.js";
+import { StatsBar } from "../components/StatsBar.js";
+import { useFilterStore } from "../stores/filters.js";
+import { trpc } from "../trpc.js";
+
+type AnyEvent = {
+  id: number;
+  name: string;
+  stream: string;
+  version: number;
+  created: string;
+  data: unknown;
+  meta: Record<string, unknown>;
+};
+
+export function EventLog() {
+  const [filters] = useFilterStore();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [pages, setPages] = useState<AnyEvent[][]>([]);
+  const [cursor, setCursor] = useState<number | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(true);
+
+  // Reset pages when filters change (except cursor-driven pagination)
+  const filterKey = JSON.stringify({
+    stream: filters.stream,
+    names: filters.names,
+    created_after: filters.created_after,
+    created_before: filters.created_before,
+    correlation: filters.correlation,
+    backward: filters.backward,
+    limit: filters.limit,
+  });
+
+  useEffect(() => {
+    setPages([]);
+    setCursor(undefined);
+    setHasMore(true);
+  }, [filterKey]);
+
+  const eventsQuery = trpc.query.useQuery(
+    {
+      stream: filters.stream,
+      names: filters.names,
+      before: cursor,
+      limit: filters.limit,
+      created_after: filters.created_after,
+      created_before: filters.created_before,
+      backward: filters.backward,
+      correlation: filters.correlation,
+    },
+    {
+      staleTime: 10_000,
+      placeholderData: (prev) => prev,
+    }
+  );
+
+  // Append new page when data arrives
+  useEffect(() => {
+    if (!eventsQuery.data) return;
+    const newEvents = eventsQuery.data.events as unknown as AnyEvent[];
+    if (newEvents.length < filters.limit) {
+      setHasMore(false);
+    }
+    if (newEvents.length === 0) return;
+
+    setPages((prev) => {
+      // Avoid duplicates — check if this page is already appended
+      const lastPage = prev[prev.length - 1];
+      if (
+        lastPage &&
+        lastPage.length > 0 &&
+        newEvents.length > 0 &&
+        lastPage[0].id === newEvents[0].id
+      ) {
+        return prev;
+      }
+      return [...prev, newEvents];
+    });
+  }, [eventsQuery.data, filters.limit]);
+
+  const allEvents = pages.flat();
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || eventsQuery.isFetching) return;
+    const lastEvent = allEvents[allEvents.length - 1];
+    if (lastEvent) {
+      setCursor(lastEvent.id);
+    }
+  }, [hasMore, eventsQuery.isFetching, allEvents]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 200;
+    if (nearBottom) loadMore();
+  }, [loadMore]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <FilterBar />
+      <StatsBar />
+
+      {/* Column headers */}
+      <div className="flex items-center gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-1.5 text-[10px] uppercase tracking-wider text-zinc-500">
+        <span className="w-16 shrink-0">ID</span>
+        <span className="w-24 shrink-0">Actor</span>
+        <span className="w-12 shrink-0 text-right">Version</span>
+        <span className="w-36 shrink-0">Event</span>
+        <span className="min-w-0 flex-1">Stream</span>
+        <span className="w-20 shrink-0 text-right">Time</span>
+        <span className="w-4 shrink-0" />
+      </div>
+
+      {/* Event list */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto"
+      >
+        {eventsQuery.isLoading && allEvents.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+            Loading events...
+          </div>
+        ) : allEvents.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+            No events found
+          </div>
+        ) : (
+          <>
+            {allEvents.map((event) => (
+              <EventRow key={event.id} event={event as any} />
+            ))}
+            {eventsQuery.isFetching && (
+              <div className="py-4 text-center text-xs text-zinc-600">
+                Loading more...
+              </div>
+            )}
+            {!hasMore && allEvents.length > 0 && (
+              <div className="py-4 text-center text-xs text-zinc-700">
+                End of results
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -1,0 +1,437 @@
+import type { Committed, Schemas, Store } from "@rotorsoft/act";
+import { PostgresStore } from "@rotorsoft/act-pg";
+import { initTRPC } from "@trpc/server";
+import { createConnection, type Socket } from "net";
+import pg from "pg";
+import { z } from "zod";
+
+const t = initTRPC.create();
+
+/** Loosely-typed committed event for inspector queries */
+type AnyEvent = Committed<Schemas, string>;
+
+/** Collect events into an array */
+const collect =
+  (target: AnyEvent[]) =>
+  (event: AnyEvent): void => {
+    target.push(event);
+  };
+
+/** Parse optional ISO string to Date */
+const toDate = (iso: string | undefined): Date | undefined =>
+  iso ? new Date(iso) : undefined;
+
+/** Managed store instance — not the singleton, so we can reconnect */
+let currentStore: Store | null = null;
+
+function getStore(): Store {
+  if (!currentStore) throw new Error("Not connected to a store");
+  return currentStore;
+}
+
+// --- Discovery ---
+
+/** PG port range to scan: 5430–5480 */
+const PORT_RANGE_START = 5430;
+const PORT_RANGE_END = 5480;
+
+/** Common credential combos to try */
+const COMMON_CREDS = [
+  { user: "postgres", password: "postgres" },
+  { user: "postgres", password: "" },
+  { user: "postgres", password: "password" },
+  { user: "root", password: "root" },
+  { user: "admin", password: "admin" },
+];
+
+/** One discovered store per port — the best candidate */
+type DiscoveredStore = {
+  host: string;
+  port: number;
+  user: string;
+  database: string;
+  schema: string;
+  table: string;
+  eventCount: number;
+};
+
+/** Check if a TCP port is open */
+function probePort(
+  host: string,
+  port: number,
+  timeoutMs = 500
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket: Socket = createConnection({ host, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/** Try to authenticate with a PG server using given credentials */
+async function tryConnect(
+  host: string,
+  port: number,
+  user: string,
+  password: string
+): Promise<pg.Client | null> {
+  const client = new pg.Client({
+    host,
+    port,
+    user,
+    password,
+    database: "postgres",
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await client.connect();
+    return client;
+  } catch {
+    return null;
+  }
+}
+
+/** Find the best Act event table per schema in a database (non-empty) */
+async function findEventTables(
+  config: { host: string; port: number; user: string; password: string },
+  dbName: string
+): Promise<{ schema: string; table: string; count: number }[]> {
+  const client = new pg.Client({
+    ...config,
+    database: dbName,
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await client.connect();
+    // Find all Act-shaped tables, one best per schema
+    const result = await client.query<{
+      table_schema: string;
+      table_name: string;
+      row_estimate: string;
+    }>(
+      `SELECT DISTINCT ON (t.table_schema)
+              t.table_schema, t.table_name,
+              (SELECT reltuples::bigint FROM pg_class c
+               JOIN pg_namespace n ON n.oid = c.relnamespace
+               WHERE n.nspname = t.table_schema AND c.relname = t.table_name) AS row_estimate
+       FROM information_schema.tables t
+       WHERE t.table_type = 'BASE TABLE'
+         AND t.table_schema NOT IN ('pg_catalog', 'information_schema')
+         AND EXISTS (SELECT 1 FROM information_schema.columns c
+           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'stream')
+         AND EXISTS (SELECT 1 FROM information_schema.columns c
+           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'meta')
+         AND EXISTS (SELECT 1 FROM information_schema.columns c
+           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'version')
+       ORDER BY t.table_schema,
+         (t.table_name = 'events') DESC,
+         row_estimate DESC NULLS LAST`
+    );
+
+    // Filter out truly empty tables — reltuples can be -1 (no stats) or 0
+    const tables: { schema: string; table: string; count: number }[] = [];
+    for (const r of result.rows) {
+      const estimate = Number(r.row_estimate);
+      if (estimate > 0) {
+        tables.push({
+          schema: r.table_schema,
+          table: r.table_name,
+          count: estimate,
+        });
+      } else {
+        // Stats not gathered or zero — check for actual rows
+        const check = await client.query(
+          `SELECT EXISTS (SELECT 1 FROM "${r.table_schema}"."${r.table_name}" LIMIT 1) AS has_rows`
+        );
+        if (check.rows[0]?.has_rows) {
+          tables.push({
+            schema: r.table_schema,
+            table: r.table_name,
+            count: 0,
+          });
+        }
+      }
+    }
+    return tables;
+  } catch {
+    return [];
+  } finally {
+    await client.end();
+  }
+}
+
+/** Full discovery: scan ports, try credentials, pick best Act store per port */
+async function discover(
+  host: string,
+  portFrom: number,
+  portTo: number
+): Promise<DiscoveredStore[]> {
+  // 1. Scan port range in parallel
+  const ports = Array.from(
+    { length: portTo - portFrom + 1 },
+    (_, i) => portFrom + i
+  );
+  const portResults = await Promise.all(
+    ports.map(async (port) => ({ port, open: await probePort(host, port) }))
+  );
+  const openPorts = portResults.filter((r) => r.open).map((r) => r.port);
+
+  if (openPorts.length === 0) return [];
+
+  // 2. For each open port, try credential combos and find best table
+  const stores: DiscoveredStore[] = [];
+
+  for (const port of openPorts) {
+    for (const creds of COMMON_CREDS) {
+      const client = await tryConnect(host, port, creds.user, creds.password);
+      if (!client) continue;
+
+      try {
+        const dbResult = await client.query<{ datname: string }>(
+          `SELECT datname FROM pg_database
+           WHERE datistemplate = false AND datallowconn = true
+           ORDER BY datname`
+        );
+
+        // Find best table per schema across all databases on this port
+        for (const row of dbResult.rows) {
+          const tables = await findEventTables(
+            { host, port, user: creds.user, password: creds.password },
+            row.datname
+          );
+          for (const t of tables) {
+            stores.push({
+              host,
+              port,
+              user: creds.user,
+              database: row.datname,
+              schema: t.schema,
+              table: t.table,
+              eventCount: t.count,
+            });
+          }
+        }
+      } finally {
+        await client.end();
+      }
+
+      // Found working creds for this port, move to next port
+      break;
+    }
+  }
+
+  return stores;
+}
+
+export const inspectorRouter = t.router({
+  /** Scan host for PG servers and discover Act event stores */
+  discover: t.procedure
+    .input(
+      z.object({
+        host: z.string().default("localhost"),
+        portFrom: z.number().min(1).max(65535).default(PORT_RANGE_START),
+        portTo: z.number().min(1).max(65535).default(PORT_RANGE_END),
+      })
+    )
+    .mutation(async ({ input }) => {
+      try {
+        const stores = await discover(input.host, input.portFrom, input.portTo);
+        return { ok: true as const, stores };
+      } catch (err) {
+        throw new Error(
+          `Discovery failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }),
+
+  /** Initialize a PostgresStore connection */
+  connect: t.procedure
+    .input(
+      z.object({
+        host: z.string().default("localhost"),
+        port: z.number().default(5432),
+        database: z.string().default("postgres"),
+        user: z.string().default("postgres"),
+        password: z.string().default("postgres"),
+        schema: z.string().default("public"),
+        table: z.string().default("events"),
+      })
+    )
+    .mutation(async ({ input }) => {
+      try {
+        if (currentStore) {
+          await currentStore.dispose();
+          currentStore = null;
+        }
+        const newStore = new PostgresStore(input);
+        // Test the connection
+        await newStore.query<Schemas>(() => {}, { limit: 1 });
+        currentStore = newStore;
+        return { ok: true as const, config: { ...input, password: "***" } };
+      } catch (err) {
+        currentStore = null;
+        throw new Error(
+          `Connection failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }),
+
+  /** Disconnect from current store */
+  disconnect: t.procedure.mutation(async () => {
+    if (currentStore) {
+      await currentStore.dispose();
+      currentStore = null;
+    }
+    return { ok: true as const };
+  }),
+
+  /** Check connection status */
+  status: t.procedure.query(() => ({ connected: currentStore !== null })),
+
+  /** Query events using the Store interface */
+  query: t.procedure
+    .input(
+      z.object({
+        stream: z.string().optional(),
+        names: z.string().array().optional(),
+        before: z.number().optional(),
+        after: z.number().optional(),
+        limit: z.number().min(1).max(500).default(50),
+        created_before: z.string().optional(),
+        created_after: z.string().optional(),
+        backward: z.boolean().optional(),
+        correlation: z.string().optional(),
+      })
+    )
+    .query(async ({ input }) => {
+      const s = getStore();
+
+      const events: AnyEvent[] = [];
+      await s.query<Schemas>(collect(events), {
+        ...input,
+        created_before: toDate(input.created_before),
+        created_after: toDate(input.created_after),
+        with_snaps: true,
+      });
+
+      return { events };
+    }),
+
+  /** Get aggregate stats for current filters */
+  stats: t.procedure
+    .input(
+      z.object({
+        stream: z.string().optional(),
+        names: z.string().array().optional(),
+        created_before: z.string().optional(),
+        created_after: z.string().optional(),
+        correlation: z.string().optional(),
+      })
+    )
+    .query(async ({ input }) => {
+      const s = getStore();
+
+      const events: AnyEvent[] = [];
+      await s.query<Schemas>(collect(events), {
+        ...input,
+        created_before: toDate(input.created_before),
+        created_after: toDate(input.created_after),
+        with_snaps: true,
+      });
+
+      const streams = new Set<string>();
+      const names = new Set<string>();
+      let minTime: Date | undefined;
+      let maxTime: Date | undefined;
+
+      for (const e of events) {
+        streams.add(e.stream);
+        names.add(String(e.name));
+        const created =
+          e.created instanceof Date ? e.created : new Date(String(e.created));
+        if (!minTime || created < minTime) minTime = created;
+        if (!maxTime || created > maxTime) maxTime = created;
+      }
+
+      return {
+        totalEvents: events.length,
+        uniqueStreams: streams.size,
+        uniqueEventNames: names.size,
+        timeSpan:
+          minTime && maxTime
+            ? { from: minTime.toISOString(), to: maxTime.toISOString() }
+            : null,
+      };
+    }),
+
+  /** Get distinct event names for filter dropdown */
+  eventNames: t.procedure.query(async () => {
+    const s = getStore();
+
+    const events: AnyEvent[] = [];
+    await s.query<Schemas>(collect(events), { with_snaps: true });
+
+    const names = new Set<string>();
+    for (const e of events) names.add(String(e.name));
+    return [...names].sort();
+  }),
+
+  /** Get distinct stream names for filter suggestions */
+  streams: t.procedure
+    .input(
+      z
+        .object({
+          limit: z.number().min(1).max(1000).default(100),
+        })
+        .optional()
+    )
+    .query(async ({ input }) => {
+      const s = getStore();
+
+      const events: AnyEvent[] = [];
+      await s.query<Schemas>(collect(events), { with_snaps: true });
+
+      const streamMap = new Map<
+        string,
+        { count: number; lastEvent: string; lastVersion: number }
+      >();
+
+      for (const e of events) {
+        const existing = streamMap.get(e.stream);
+        if (!existing || e.version > existing.lastVersion) {
+          streamMap.set(e.stream, {
+            count: (existing?.count ?? 0) + 1,
+            lastEvent: String(e.created),
+            lastVersion: e.version,
+          });
+        } else {
+          existing.count++;
+        }
+      }
+
+      return [...streamMap.entries()]
+        .map(([stream, info]) => ({
+          stream,
+          eventCount: info.count,
+          lastEvent: info.lastEvent,
+          currentVersion: info.lastVersion,
+        }))
+        .sort((a, b) => b.eventCount - a.eventCount)
+        .slice(0, input?.limit ?? 100);
+    }),
+});
+
+export type InspectorRouter = typeof inspectorRouter;

--- a/packages/inspector/src/server/server.ts
+++ b/packages/inspector/src/server/server.ts
@@ -1,0 +1,14 @@
+import { createHTTPServer } from "@trpc/server/adapters/standalone";
+import cors from "cors";
+import { inspectorRouter } from "./router.js";
+
+const PORT = 4001;
+
+const server = createHTTPServer({
+  middleware: cors(),
+  router: inspectorRouter,
+});
+
+server.listen(PORT, () => {
+  console.log(`Inspector server listening on http://localhost:${PORT}`);
+});

--- a/packages/inspector/tsconfig.json
+++ b/packages/inspector/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../libs/act" },
+    { "path": "../../libs/act-pg" }
+  ]
+}

--- a/packages/inspector/vite.config.ts
+++ b/packages/inspector/vite.config.ts
@@ -1,0 +1,10 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 3001,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
       chance:
         specifier: ^1.1.13
         version: 1.1.13
@@ -113,10 +113,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   docs:
     dependencies:
@@ -138,7 +138,7 @@ importers:
     devDependencies:
       '@docusaurus/core':
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/faster':
         specifier: ^3.9.2
         version: 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2)
@@ -147,7 +147,7 @@ importers:
         version: 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/preset-classic':
         specifier: ^3.9.2
-        version: 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)
       '@docusaurus/tsconfig':
         specifier: 3.9.2
         version: 3.9.2
@@ -266,7 +266,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.6.1)
@@ -287,7 +287,80 @@ importers:
         version: 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/inspector:
+    dependencies:
+      '@rotorsoft/act':
+        specifier: workspace:^
+        version: link:../../libs/act
+      '@rotorsoft/act-pg':
+        specifier: workspace:^
+        version: link:../../libs/act-pg
+      '@tanstack/react-query':
+        specifier: ^5.90.21
+        version: 5.90.21(react@19.2.4)
+      '@trpc/client':
+        specifier: 11.12.1
+        version: 11.12.1(@trpc/server@11.12.1(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/react-query':
+        specifier: 11.12.1
+        version: 11.12.1(@tanstack/react-query@5.90.21(react@19.2.4))(@trpc/client@11.12.1(@trpc/server@11.12.1(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.12.1(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
+      '@trpc/server':
+        specifier: 11.12.1
+        version: 11.12.1(typescript@5.9.3)
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.8
+        version: 4.2.1(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
+      '@types/pg':
+        specifier: ^8.18.0
+        version: 8.18.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.23(postcss@8.5.6)
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.2.1
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^4.1.8
+        version: 4.2.1
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/server:
     dependencies:
@@ -3048,6 +3121,100 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
+  '@tailwindcss/node@4.2.1':
+    resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    resolution: {integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    resolution: {integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    resolution: {integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    resolution: {integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.1':
+    resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.1':
+    resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
+
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -3976,6 +4143,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -4554,6 +4726,10 @@ packages:
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
   entities@2.2.0:
@@ -5722,8 +5898,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.31.1:
+    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.31.1:
+    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -5734,8 +5922,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.31.1:
+    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.31.1:
+    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -5746,8 +5946,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -5760,8 +5973,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.31.1:
+    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -5774,8 +6001,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.31.1:
+    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -5786,8 +6026,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.31.1:
+    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.31.1:
+    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -7621,6 +7871,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -8048,6 +8301,9 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwindcss@4.2.1:
+    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
@@ -10271,7 +10527,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/bundler@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@docusaurus/babel': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10283,7 +10539,7 @@ snapshots:
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2))
       css-loader: 6.11.0(@rspack/core@1.7.0(@swc/helpers@0.5.15))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.27.2)(lightningcss@1.31.1)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2))
       cssnano: 6.1.2(postcss@8.5.6)
       file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2))
       html-minifier-terser: 7.2.0
@@ -10314,10 +10570,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
       '@docusaurus/babel': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/bundler': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/bundler': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10460,13 +10716,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-blog@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-common': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10501,13 +10757,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-common': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10541,9 +10797,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-pages@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10571,9 +10827,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10598,9 +10854,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-debug@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fs-extra: 11.3.3
@@ -10626,9 +10882,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-analytics@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -10652,9 +10908,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-gtag@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/gtag.js': 0.0.12
@@ -10679,9 +10935,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-tag-manager@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -10705,9 +10961,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-sitemap@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10736,9 +10992,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-svgr@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10766,22 +11022,22 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-debug': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-google-analytics': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-google-gtag': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-google-tag-manager': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-sitemap': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-svgr': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/theme-classic': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/theme-search-algolia': 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-debug': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-google-analytics': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-google-gtag': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-google-tag-manager': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-sitemap': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-svgr': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/theme-classic': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/theme-search-algolia': 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10811,16 +11067,16 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
-  '@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/theme-translations': 3.9.2
       '@docusaurus/types': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10858,11 +11114,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-common': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/history': 4.7.11
@@ -10882,13 +11138,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(@types/react@19.2.14)(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
       '@docsearch/react': 4.4.0(@algolia/client-search@5.46.2)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(esbuild@0.27.2))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.0(@swc/helpers@0.5.15))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/theme-translations': 3.9.2
       '@docusaurus/utils': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -12154,6 +12410,74 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tailwindcss/node@4.2.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.1
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-x64': 4.2.1
+      '@tailwindcss/oxide-freebsd-x64': 4.2.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+
+  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tailwindcss/node': 4.2.1
+      '@tailwindcss/oxide': 4.2.1
+      tailwindcss: 4.2.1
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/query-devtools@5.93.0': {}
@@ -12534,7 +12858,7 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -12542,11 +12866,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -12558,7 +12882,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -12569,13 +12893,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -13249,6 +13573,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   confbox@0.1.8: {}
 
   config-chain@1.1.13:
@@ -13425,7 +13758,7 @@ snapshots:
       '@rspack/core': 1.7.0(@swc/helpers@0.5.15)
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.27.2)(lightningcss@1.31.1)(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.15))(esbuild@0.27.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.6)
@@ -13437,7 +13770,7 @@ snapshots:
     optionalDependencies:
       clean-css: 5.3.3
       esbuild: 0.27.2
-      lightningcss: 1.30.2
+      lightningcss: 1.31.1
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.6):
     dependencies:
@@ -13742,6 +14075,11 @@ snapshots:
       once: 1.4.0
 
   enhanced-resolve@5.18.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
+  enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
@@ -15109,34 +15447,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.31.1:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.31.1:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.31.1:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.31.1:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.31.1:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.31.1:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.31.1:
     optional: true
 
   lightningcss@1.30.2:
@@ -15154,6 +15525,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.31.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.31.1
+      lightningcss-darwin-arm64: 1.31.1
+      lightningcss-darwin-x64: 1.31.1
+      lightningcss-freebsd-x64: 1.31.1
+      lightningcss-linux-arm-gnueabihf: 1.31.1
+      lightningcss-linux-arm64-gnu: 1.31.1
+      lightningcss-linux-arm64-musl: 1.31.1
+      lightningcss-linux-x64-gnu: 1.31.1
+      lightningcss-linux-x64-musl: 1.31.1
+      lightningcss-win32-arm64-msvc: 1.31.1
+      lightningcss-win32-x64-msvc: 1.31.1
 
   lilconfig@3.1.3: {}
 
@@ -17308,6 +17695,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -17834,6 +18225,8 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwindcss@4.2.1: {}
+
   tapable@2.3.0: {}
 
   temp-dir@2.0.0: {}
@@ -18222,7 +18615,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -18234,15 +18627,15 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2
+      lightningcss: 1.31.1
       terser: 5.44.1
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -18259,7 +18652,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary

- New package `@rotorsoft/act-inspector` — a web dashboard for inspecting Act event stores
- **Auto-discovery**: scans ports 5430–5480 for PG servers, detects Act event tables by schema shape (`stream`, `meta`, `version` columns), picks best table per schema (prefers `public.events`, then largest)
- **Connection manager**: save/switch named connections, scan popup with configurable port range
- **Event log explorer**: reverse-chronological list with filters (stream regex, event name pills, time range presets, correlation ID), infinite scroll pagination, expandable JSON detail panels
- Stats bar, `__snapshot__` visibility, URL-synced filters, dark theme with JetBrains Mono

Closes #489

## Test plan

- [ ] `pnpm install && pnpm dev:inspector` starts server (4001) and client (3001)
- [ ] Click Scan... → discovers Act stores on localhost across ports
- [ ] `act.wolfdesk` table found on port 5431 (handles `-1` reltuples via EXISTS fallback)
- [ ] Connection name defaults to `schema.table` (e.g., `act.wolfdesk`)
- [ ] Connect → event log displays with correct columns (ID, Actor, Version, Event, Stream, Time)
- [ ] Filters work: stream regex, event name pills, time presets, correlation ID
- [ ] Scroll to bottom → next page loads (infinite scroll accumulates pages)
- [ ] Expand event row → shows syntax-highlighted JSON for data and meta
- [ ] Switch connection → clears cached data and resets event log
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (inspector files)
- [ ] Vite production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)