### PR TITLE
feat(act-inspector): correlation explorer (Phase 3)

### DIFF
--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -42,15 +42,17 @@ Fill in the connection fields directly:
 
 ## Features
 
-### Views (tab navigation: Log | Timeline | Streams)
+### Views (tab navigation: Log | Timeline | Streams | Correlation)
 
-- **Event Log** — reverse-chronological event list with filters (stream regex, event name pills, time range presets, correlation ID), infinite scroll pagination, expandable JSON detail panels
-- **Timeline** — SVG time-axis visualization with stream swimlanes, colored event dots, hover tooltips, density heatmap mode for large datasets (>500 events)
-- **Stream Inspector** — sortable/filterable stream list with health badges (healthy/blocked/leased/retry), click to open detail panel with:
-  - Processing metadata from the `_streams` table (watermark, retry, blocked, lease info)
-  - Full event history for the stream
-  - State evolution diffs between consecutive events
-  - "Open in Log" quick action
+- **Event Log** — reverse-chronological event list with filters (stream regex, event name pills, time range presets, correlation ID), infinite scroll pagination, expandable JSON detail panels, "Trace" button to follow correlation chains
+- **Timeline** — SVG time-axis visualization with stream swimlanes, colored event dots, hover tooltips, zoom/pan, density heatmap mode for large datasets (>500 events)
+- **Stream Inspector** — sortable/filterable stream list, click to open detail panel with compact expanded events and "Open in Log" action
+- **Correlation Explorer** — trace a correlation ID across its full event chain:
+  - **Waterfall view**: time-axis bars with causation indentation, color-coded by stream, gap detection for reaction latency (>1s highlighted)
+  - **DAG graph**: directed acyclic graph of event causation, nodes as colored rectangles with arrows showing cause→effect relationships
+  - **Metadata sidebar**: actor, total events, duration, streams touched, event type breakdown
+  - Toggle between waterfall and graph views
+  - Click any event for full detail in sidebar
 
 ### Core
 

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -60,7 +60,10 @@ export default function App() {
                 {activeTab === "log" && <EventLog onTrace={handleTrace} />}
                 {activeTab === "timeline" && <Timeline />}
                 {activeTab === "streams" && (
-                  <Streams onNavigateToLog={() => setActiveTab("log")} />
+                  <Streams
+                    onNavigateToLog={() => setActiveTab("log")}
+                    onTrace={handleTrace}
+                  />
                 )}
                 {activeTab === "correlation" && (
                   <Correlation initialCorrelation={traceCorrelation} />

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -4,6 +4,7 @@ import { ConnectDialog } from "./components/ConnectDialog.js";
 import { Header } from "./components/Header.js";
 import { TabNav, type Tab } from "./components/TabNav.js";
 import { queryClient, trpc, trpcClient } from "./trpc.js";
+import { Correlation } from "./views/Correlation.js";
 import { EventLog } from "./views/EventLog.js";
 import { Streams } from "./views/Streams.js";
 import { Timeline } from "./views/Timeline.js";
@@ -14,6 +15,9 @@ export default function App() {
   const [connectionName, setConnectionName] = useState("");
   const [connectionKey, setConnectionKey] = useState(0);
   const [activeTab, setActiveTab] = useState<Tab>("log");
+  const [traceCorrelation, setTraceCorrelation] = useState<
+    string | undefined
+  >();
 
   const handleConnected = (name: string) => {
     queryClient.clear();
@@ -21,6 +25,11 @@ export default function App() {
     setConnectionName(name);
     setConnectionKey((k) => k + 1);
     setShowConnect(false);
+  };
+
+  const handleTrace = (correlationId: string) => {
+    setTraceCorrelation(correlationId);
+    setActiveTab("correlation");
   };
 
   return (
@@ -40,12 +49,21 @@ export default function App() {
           )}
           {connected && (
             <>
-              <TabNav active={activeTab} onChange={setActiveTab} />
+              <TabNav
+                active={activeTab}
+                onChange={(tab) => {
+                  setActiveTab(tab);
+                  if (tab !== "correlation") setTraceCorrelation(undefined);
+                }}
+              />
               <div key={connectionKey} className="flex min-h-0 flex-1 flex-col">
-                {activeTab === "log" && <EventLog />}
+                {activeTab === "log" && <EventLog onTrace={handleTrace} />}
                 {activeTab === "timeline" && <Timeline />}
                 {activeTab === "streams" && (
                   <Streams onNavigateToLog={() => setActiveTab("log")} />
+                )}
+                {activeTab === "correlation" && (
+                  <Correlation initialCorrelation={traceCorrelation} />
                 )}
               </div>
             </>

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ConnectDialog } from "./components/ConnectDialog.js";
 import { Header } from "./components/Header.js";
 import { TabNav, type Tab } from "./components/TabNav.js";
@@ -9,16 +9,54 @@ import { EventLog } from "./views/EventLog.js";
 import { Streams } from "./views/Streams.js";
 import { Timeline } from "./views/Timeline.js";
 
+type ViewState = {
+  tab: Tab;
+  correlation?: string;
+  stream?: string;
+};
+
 export default function App() {
   const [connected, setConnected] = useState(false);
   const [showConnect, setShowConnect] = useState(true);
   const [connectionName, setConnectionName] = useState("");
   const [connectionKey, setConnectionKey] = useState(0);
-  const [activeTab, setActiveTab] = useState<Tab>("log");
-  const [traceCorrelation, setTraceCorrelation] = useState<
-    string | undefined
-  >();
-  const [selectedStream, setSelectedStream] = useState<string | undefined>();
+
+  // Navigation history
+  const [view, setView] = useState<ViewState>({ tab: "log" });
+  const historyStack = useRef<ViewState[]>([{ tab: "log" }]);
+  const historyIndex = useRef(0);
+  const isNavigating = useRef(false);
+
+  const navigateTo = useCallback((next: ViewState) => {
+    if (isNavigating.current) return;
+    // Trim forward history and push
+    historyStack.current = historyStack.current.slice(
+      0,
+      historyIndex.current + 1
+    );
+    historyStack.current.push(next);
+    historyIndex.current = historyStack.current.length - 1;
+    setView(next);
+  }, []);
+
+  const canGoBack = historyIndex.current > 0;
+  const canGoForward = historyIndex.current < historyStack.current.length - 1;
+
+  const goBack = useCallback(() => {
+    if (historyIndex.current <= 0) return;
+    isNavigating.current = true;
+    historyIndex.current--;
+    setView(historyStack.current[historyIndex.current]);
+    isNavigating.current = false;
+  }, []);
+
+  const goForward = useCallback(() => {
+    if (historyIndex.current >= historyStack.current.length - 1) return;
+    isNavigating.current = true;
+    historyIndex.current++;
+    setView(historyStack.current[historyIndex.current]);
+    isNavigating.current = false;
+  }, []);
 
   const handleConnected = (name: string) => {
     queryClient.clear();
@@ -26,16 +64,21 @@ export default function App() {
     setConnectionName(name);
     setConnectionKey((k) => k + 1);
     setShowConnect(false);
+    historyStack.current = [{ tab: "log" }];
+    historyIndex.current = 0;
+    setView({ tab: "log" });
+  };
+
+  const handleTabChange = (tab: Tab) => {
+    navigateTo({ tab });
   };
 
   const handleTrace = (correlationId: string) => {
-    setTraceCorrelation(correlationId);
-    setActiveTab("correlation");
+    navigateTo({ tab: "correlation", correlation: correlationId });
   };
 
   const handleStream = (stream: string) => {
-    setSelectedStream(stream);
-    setActiveTab("streams");
+    navigateTo({ tab: "streams", stream });
   };
 
   return (
@@ -46,6 +89,10 @@ export default function App() {
             connected={connected}
             connectionName={connectionName}
             onConnect={() => setShowConnect(true)}
+            canGoBack={canGoBack}
+            canGoForward={canGoForward}
+            onBack={goBack}
+            onForward={goForward}
           />
           {showConnect && (
             <ConnectDialog
@@ -55,33 +102,25 @@ export default function App() {
           )}
           {connected && (
             <>
-              <TabNav
-                active={activeTab}
-                onChange={(tab) => {
-                  setActiveTab(tab);
-                  if (tab !== "correlation") setTraceCorrelation(undefined);
-                  if (tab !== "streams") setSelectedStream(undefined);
-                }}
-              />
+              <TabNav active={view.tab} onChange={handleTabChange} />
               <div key={connectionKey} className="flex min-h-0 flex-1 flex-col">
-                {activeTab === "log" && (
+                {view.tab === "log" && (
                   <EventLog onTrace={handleTrace} onStream={handleStream} />
                 )}
-                {activeTab === "timeline" && (
+                {view.tab === "timeline" && (
                   <Timeline onTrace={handleTrace} onStream={handleStream} />
                 )}
-                {activeTab === "streams" && (
+                {view.tab === "streams" && (
                   <Streams
-                    initialStream={selectedStream}
+                    initialStream={view.stream}
                     onTrace={handleTrace}
                     onStream={handleStream}
                   />
                 )}
-                {activeTab === "correlation" && (
+                {view.tab === "correlation" && (
                   <Correlation
-                    initialCorrelation={traceCorrelation}
+                    initialCorrelation={view.correlation}
                     onStream={handleStream}
-                    onTrace={handleTrace}
                   />
                 )}
               </div>

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -18,6 +18,7 @@ export default function App() {
   const [traceCorrelation, setTraceCorrelation] = useState<
     string | undefined
   >();
+  const [selectedStream, setSelectedStream] = useState<string | undefined>();
 
   const handleConnected = (name: string) => {
     queryClient.clear();
@@ -30,6 +31,11 @@ export default function App() {
   const handleTrace = (correlationId: string) => {
     setTraceCorrelation(correlationId);
     setActiveTab("correlation");
+  };
+
+  const handleStream = (stream: string) => {
+    setSelectedStream(stream);
+    setActiveTab("streams");
   };
 
   return (
@@ -54,19 +60,29 @@ export default function App() {
                 onChange={(tab) => {
                   setActiveTab(tab);
                   if (tab !== "correlation") setTraceCorrelation(undefined);
+                  if (tab !== "streams") setSelectedStream(undefined);
                 }}
               />
               <div key={connectionKey} className="flex min-h-0 flex-1 flex-col">
-                {activeTab === "log" && <EventLog onTrace={handleTrace} />}
-                {activeTab === "timeline" && <Timeline />}
+                {activeTab === "log" && (
+                  <EventLog onTrace={handleTrace} onStream={handleStream} />
+                )}
+                {activeTab === "timeline" && (
+                  <Timeline onTrace={handleTrace} onStream={handleStream} />
+                )}
                 {activeTab === "streams" && (
                   <Streams
-                    onNavigateToLog={() => setActiveTab("log")}
+                    initialStream={selectedStream}
                     onTrace={handleTrace}
+                    onStream={handleStream}
                   />
                 )}
                 {activeTab === "correlation" && (
-                  <Correlation initialCorrelation={traceCorrelation} />
+                  <Correlation
+                    initialCorrelation={traceCorrelation}
+                    onStream={handleStream}
+                    onTrace={handleTrace}
+                  />
                 )}
               </div>
             </>

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -9,11 +9,29 @@ import { EventLog } from "./views/EventLog.js";
 import { Streams } from "./views/Streams.js";
 import { Timeline } from "./views/Timeline.js";
 
-type ViewState = {
+export type ViewState = {
   tab: Tab;
   correlation?: string;
   stream?: string;
 };
+
+/** Human-readable caption for a view state */
+export function viewCaption(v: ViewState): string {
+  if (v.tab === "correlation" && v.correlation) {
+    return `Correlation ${v.correlation.slice(0, 8)}...`;
+  }
+  if (v.tab === "streams" && v.stream) {
+    const short = v.stream.length > 24 ? `...${v.stream.slice(-21)}` : v.stream;
+    return `Stream ${short}`;
+  }
+  const labels: Record<Tab, string> = {
+    log: "Event Log",
+    timeline: "Timeline",
+    streams: "Streams",
+    correlation: "Correlation",
+  };
+  return labels[v.tab];
+}
 
 export default function App() {
   const [connected, setConnected] = useState(false);
@@ -26,10 +44,11 @@ export default function App() {
   const historyStack = useRef<ViewState[]>([{ tab: "log" }]);
   const historyIndex = useRef(0);
   const isNavigating = useRef(false);
+  // Force re-render when history changes (refs don't trigger renders)
+  const [, setHistoryVersion] = useState(0);
 
   const navigateTo = useCallback((next: ViewState) => {
     if (isNavigating.current) return;
-    // Trim forward history and push
     historyStack.current = historyStack.current.slice(
       0,
       historyIndex.current + 1
@@ -37,26 +56,23 @@ export default function App() {
     historyStack.current.push(next);
     historyIndex.current = historyStack.current.length - 1;
     setView(next);
+    setHistoryVersion((v) => v + 1);
   }, []);
+
+  const goTo = useCallback((index: number) => {
+    if (index < 0 || index >= historyStack.current.length) return;
+    isNavigating.current = true;
+    historyIndex.current = index;
+    setView(historyStack.current[index]);
+    setHistoryVersion((v) => v + 1);
+    isNavigating.current = false;
+  }, []);
+
+  const goBack = useCallback(() => goTo(historyIndex.current - 1), [goTo]);
+  const goForward = useCallback(() => goTo(historyIndex.current + 1), [goTo]);
 
   const canGoBack = historyIndex.current > 0;
   const canGoForward = historyIndex.current < historyStack.current.length - 1;
-
-  const goBack = useCallback(() => {
-    if (historyIndex.current <= 0) return;
-    isNavigating.current = true;
-    historyIndex.current--;
-    setView(historyStack.current[historyIndex.current]);
-    isNavigating.current = false;
-  }, []);
-
-  const goForward = useCallback(() => {
-    if (historyIndex.current >= historyStack.current.length - 1) return;
-    isNavigating.current = true;
-    historyIndex.current++;
-    setView(historyStack.current[historyIndex.current]);
-    isNavigating.current = false;
-  }, []);
 
   const handleConnected = (name: string) => {
     queryClient.clear();
@@ -67,19 +83,14 @@ export default function App() {
     historyStack.current = [{ tab: "log" }];
     historyIndex.current = 0;
     setView({ tab: "log" });
+    setHistoryVersion((v) => v + 1);
   };
 
-  const handleTabChange = (tab: Tab) => {
-    navigateTo({ tab });
-  };
-
-  const handleTrace = (correlationId: string) => {
+  const handleTabChange = (tab: Tab) => navigateTo({ tab });
+  const handleTrace = (correlationId: string) =>
     navigateTo({ tab: "correlation", correlation: correlationId });
-  };
-
-  const handleStream = (stream: string) => {
+  const handleStream = (stream: string) =>
     navigateTo({ tab: "streams", stream });
-  };
 
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>
@@ -93,6 +104,9 @@ export default function App() {
             canGoForward={canGoForward}
             onBack={goBack}
             onForward={goForward}
+            history={historyStack.current}
+            historyIndex={historyIndex.current}
+            onGoTo={goTo}
           />
           {showConnect && (
             <ConnectDialog

--- a/packages/inspector/src/client/components/EventRow.tsx
+++ b/packages/inspector/src/client/components/EventRow.tsx
@@ -1,3 +1,4 @@
+import { Database, GitBranch } from "lucide-react";
 import { useState } from "react";
 import { JsonViewer } from "./JsonViewer.js";
 
@@ -66,8 +67,13 @@ function copyToClipboard(text: string) {
   void navigator.clipboard.writeText(text);
 }
 
-/** Clickable link styled text */
-function Link({
+/** Short ID: first 8 chars */
+function shortId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+/** Inline clickable link — small, subtle */
+function NavLink({
   children,
   title,
   onClick,
@@ -83,7 +89,7 @@ function Link({
         onClick();
       }}
       title={title}
-      className="text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 transition hover:text-emerald-300 hover:decoration-emerald-300/50"
+      className="text-emerald-400/70 underline decoration-emerald-400/20 underline-offset-2 transition hover:text-emerald-300 hover:decoration-emerald-300/40"
     >
       {children}
     </button>
@@ -100,6 +106,7 @@ export function EventRow({
 }: EventRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const actor = event.meta?.causation?.action?.actor;
+  const correlation = event.meta?.correlation;
 
   return (
     <div className="border-b border-zinc-800/50 transition hover:bg-zinc-900/50">
@@ -132,21 +139,45 @@ export function EventRow({
           </span>
         </span>
 
-        {/* Stream — clickable link */}
+        {/* Stream */}
         {!hideStream && (
           <span className="min-w-0 flex-1 truncate font-mono text-zinc-300">
-            {onStream ? (
-              <Link
-                title="Open in Streams"
-                onClick={() => onStream(event.stream)}
-              >
-                {event.stream}
-              </Link>
-            ) : (
-              event.stream
+            {event.stream}
+            {onStream && (
+              <>
+                {" "}
+                <NavLink
+                  title="Open in Streams"
+                  onClick={() => onStream(event.stream)}
+                >
+                  <Database size={10} className="inline" />
+                </NavLink>
+              </>
             )}
           </span>
         )}
+
+        {/* Correlation */}
+        {correlation && (
+          <span
+            className="w-20 shrink-0 truncate font-mono text-zinc-500"
+            title={correlation}
+          >
+            {shortId(correlation)}
+            {onTrace && (
+              <>
+                {" "}
+                <NavLink
+                  title="Trace correlation"
+                  onClick={() => onTrace(correlation)}
+                >
+                  <GitBranch size={10} className="inline" />
+                </NavLink>
+              </>
+            )}
+          </span>
+        )}
+        {!correlation && <span className="w-20 shrink-0" />}
 
         {/* Time */}
         <span
@@ -212,54 +243,6 @@ export function EventRow({
                 <JsonViewer data={event.meta} />
               </div>
             </div>
-          </div>
-
-          {/* Quick info bar */}
-          <div className="mt-3 flex flex-wrap gap-4 text-[10px] text-zinc-500">
-            <span>
-              Stream:{" "}
-              {onStream ? (
-                <Link
-                  title="Open in Streams"
-                  onClick={() => onStream(event.stream)}
-                >
-                  {event.stream}
-                </Link>
-              ) : (
-                <button
-                  onClick={() => copyToClipboard(event.stream)}
-                  className="text-zinc-300 hover:text-emerald-400"
-                >
-                  {event.stream}
-                </button>
-              )}
-            </span>
-            {event.meta?.correlation && (
-              <span>
-                Correlation:{" "}
-                {onTrace ? (
-                  <Link
-                    title="Trace correlation chain"
-                    onClick={() => onTrace(event.meta.correlation!)}
-                  >
-                    {event.meta.correlation}
-                  </Link>
-                ) : (
-                  <button
-                    onClick={() => copyToClipboard(event.meta.correlation!)}
-                    className="font-mono text-zinc-300 hover:text-emerald-400"
-                  >
-                    {event.meta.correlation}
-                  </button>
-                )}
-              </span>
-            )}
-            <span>
-              Created:{" "}
-              <span className="text-zinc-300">
-                {new Date(event.created).toISOString()}
-              </span>
-            </span>
           </div>
         </div>
       )}

--- a/packages/inspector/src/client/components/EventRow.tsx
+++ b/packages/inspector/src/client/components/EventRow.tsx
@@ -89,7 +89,7 @@ function NavLink({
         onClick();
       }}
       title={title}
-      className="text-emerald-400/70 underline decoration-emerald-400/20 underline-offset-2 transition hover:text-emerald-300 hover:decoration-emerald-300/40"
+      className="text-emerald-400/70 transition hover:text-emerald-300"
     >
       {children}
     </button>

--- a/packages/inspector/src/client/components/EventRow.tsx
+++ b/packages/inspector/src/client/components/EventRow.tsx
@@ -1,3 +1,4 @@
+import { GitBranch } from "lucide-react";
 import { useState } from "react";
 import { JsonViewer } from "./JsonViewer.js";
 
@@ -120,6 +121,23 @@ export function EventRow({
         >
           {relativeTime(event.created)}
         </span>
+
+        {/* Trace button */}
+        {onTrace && event.meta?.correlation ? (
+          <span
+            role="button"
+            title="Trace correlation"
+            className="w-4 shrink-0 text-zinc-600 transition hover:text-emerald-400"
+            onClick={(e) => {
+              e.stopPropagation();
+              onTrace(event.meta.correlation!);
+            }}
+          >
+            <GitBranch size={12} />
+          </span>
+        ) : (
+          <span className="w-4 shrink-0" />
+        )}
 
         {/* Expand indicator */}
         <span className="w-4 shrink-0 text-zinc-600">

--- a/packages/inspector/src/client/components/EventRow.tsx
+++ b/packages/inspector/src/client/components/EventRow.tsx
@@ -28,6 +28,7 @@ type EventRowProps = {
   defaultExpanded?: boolean;
   compact?: boolean;
   hideStream?: boolean;
+  onTrace?: (correlationId: string) => void;
 };
 
 /** Deterministic color from event name */
@@ -69,6 +70,7 @@ export function EventRow({
   defaultExpanded = false,
   compact = false,
   hideStream = false,
+  onTrace,
 }: EventRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const actor = event.meta?.causation?.action?.actor;
@@ -187,7 +189,7 @@ export function EventRow({
               </button>
             </span>
             {event.meta?.correlation && (
-              <span>
+              <span className="flex items-center gap-1.5">
                 Correlation:{" "}
                 <button
                   onClick={() => copyToClipboard(event.meta.correlation!)}
@@ -195,6 +197,14 @@ export function EventRow({
                 >
                   {event.meta.correlation}
                 </button>
+                {onTrace && (
+                  <button
+                    onClick={() => onTrace(event.meta.correlation!)}
+                    className="rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-zinc-400 transition hover:border-emerald-700 hover:text-emerald-400"
+                  >
+                    Trace
+                  </button>
+                )}
               </span>
             )}
             <span>

--- a/packages/inspector/src/client/components/EventRow.tsx
+++ b/packages/inspector/src/client/components/EventRow.tsx
@@ -1,4 +1,3 @@
-import { GitBranch } from "lucide-react";
 import { useState } from "react";
 import { JsonViewer } from "./JsonViewer.js";
 
@@ -30,6 +29,7 @@ type EventRowProps = {
   compact?: boolean;
   hideStream?: boolean;
   onTrace?: (correlationId: string) => void;
+  onStream?: (stream: string) => void;
 };
 
 /** Deterministic color from event name */
@@ -66,12 +66,37 @@ function copyToClipboard(text: string) {
   void navigator.clipboard.writeText(text);
 }
 
+/** Clickable link styled text */
+function Link({
+  children,
+  title,
+  onClick,
+}: {
+  children: React.ReactNode;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      title={title}
+      className="text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 transition hover:text-emerald-300 hover:decoration-emerald-300/50"
+    >
+      {children}
+    </button>
+  );
+}
+
 export function EventRow({
   event,
   defaultExpanded = false,
   compact = false,
   hideStream = false,
   onTrace,
+  onStream,
 }: EventRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const actor = event.meta?.causation?.action?.actor;
@@ -107,10 +132,19 @@ export function EventRow({
           </span>
         </span>
 
-        {/* Stream */}
+        {/* Stream — clickable link */}
         {!hideStream && (
           <span className="min-w-0 flex-1 truncate font-mono text-zinc-300">
-            {event.stream}
+            {onStream ? (
+              <Link
+                title="Open in Streams"
+                onClick={() => onStream(event.stream)}
+              >
+                {event.stream}
+              </Link>
+            ) : (
+              event.stream
+            )}
           </span>
         )}
 
@@ -122,35 +156,20 @@ export function EventRow({
           {relativeTime(event.created)}
         </span>
 
-        {/* Trace button */}
-        {onTrace && event.meta?.correlation ? (
-          <span
-            role="button"
-            title="Trace correlation"
-            className="w-4 shrink-0 text-zinc-600 transition hover:text-emerald-400"
-            onClick={(e) => {
-              e.stopPropagation();
-              onTrace(event.meta.correlation!);
-            }}
-          >
-            <GitBranch size={12} />
-          </span>
-        ) : (
-          <span className="w-4 shrink-0" />
-        )}
-
         {/* Expand indicator */}
         <span className="w-4 shrink-0 text-zinc-600">
           {expanded ? "▾" : "▸"}
         </span>
       </button>
 
-      {/* Expanded detail */}
+      {/* Expanded detail — compact */}
       {expanded && compact && (
         <div className="border-t border-zinc-800/30 bg-zinc-900/60 px-4 py-1.5 text-xs">
           <JsonViewer data={event.data} />
         </div>
       )}
+
+      {/* Expanded detail — full */}
       {expanded && !compact && (
         <div className="border-t border-zinc-800/30 bg-zinc-900/80 px-4 py-3">
           <div className="grid grid-cols-2 gap-4">
@@ -199,28 +218,38 @@ export function EventRow({
           <div className="mt-3 flex flex-wrap gap-4 text-[10px] text-zinc-500">
             <span>
               Stream:{" "}
-              <button
-                onClick={() => copyToClipboard(event.stream)}
-                className="text-zinc-300 hover:text-emerald-400"
-              >
-                {event.stream}
-              </button>
+              {onStream ? (
+                <Link
+                  title="Open in Streams"
+                  onClick={() => onStream(event.stream)}
+                >
+                  {event.stream}
+                </Link>
+              ) : (
+                <button
+                  onClick={() => copyToClipboard(event.stream)}
+                  className="text-zinc-300 hover:text-emerald-400"
+                >
+                  {event.stream}
+                </button>
+              )}
             </span>
             {event.meta?.correlation && (
-              <span className="flex items-center gap-1.5">
+              <span>
                 Correlation:{" "}
-                <button
-                  onClick={() => copyToClipboard(event.meta.correlation!)}
-                  className="font-mono text-zinc-300 hover:text-emerald-400"
-                >
-                  {event.meta.correlation}
-                </button>
-                {onTrace && (
-                  <button
+                {onTrace ? (
+                  <Link
+                    title="Trace correlation chain"
                     onClick={() => onTrace(event.meta.correlation!)}
-                    className="rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-zinc-400 transition hover:border-emerald-700 hover:text-emerald-400"
                   >
-                    Trace
+                    {event.meta.correlation}
+                  </Link>
+                ) : (
+                  <button
+                    onClick={() => copyToClipboard(event.meta.correlation!)}
+                    className="font-mono text-zinc-300 hover:text-emerald-400"
+                  >
+                    {event.meta.correlation}
                   </button>
                 )}
               </span>

--- a/packages/inspector/src/client/components/Header.tsx
+++ b/packages/inspector/src/client/components/Header.tsx
@@ -1,4 +1,6 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { viewCaption, type ViewState } from "../App.js";
 import { Logo } from "./Logo.js";
 
 type HeaderProps = {
@@ -9,6 +11,9 @@ type HeaderProps = {
   canGoForward?: boolean;
   onBack?: () => void;
   onForward?: () => void;
+  history?: ViewState[];
+  historyIndex?: number;
+  onGoTo?: (index: number) => void;
 };
 
 export function Header({
@@ -19,7 +24,13 @@ export function Header({
   canGoForward,
   onBack,
   onForward,
+  history,
+  historyIndex,
+  onGoTo,
 }: HeaderProps) {
+  const [showHistory, setShowHistory] = useState(false);
+  const hasHistory = history && history.length > 1;
+
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-zinc-800 bg-zinc-925 px-4">
       <div className="flex items-center gap-2.5">
@@ -30,7 +41,7 @@ export function Header({
 
         {/* Navigation */}
         {connected && (
-          <div className="ml-2 flex items-center gap-0.5">
+          <div className="relative ml-2 flex items-center gap-0.5">
             <button
               onClick={onBack}
               disabled={!canGoBack}
@@ -47,6 +58,60 @@ export function Header({
             >
               <ChevronRight size={16} />
             </button>
+
+            {/* History dropdown toggle */}
+            {hasHistory && (
+              <button
+                onClick={() => setShowHistory(!showHistory)}
+                title="Navigation history"
+                className="rounded p-1 text-zinc-600 transition hover:bg-zinc-800 hover:text-zinc-400"
+              >
+                <ChevronDown size={12} />
+              </button>
+            )}
+
+            {/* History dropdown */}
+            {showHistory && history && onGoTo && (
+              <>
+                <div
+                  className="fixed inset-0 z-40"
+                  onClick={() => setShowHistory(false)}
+                />
+                <div className="absolute left-0 top-full z-50 mt-1 max-h-64 w-64 overflow-y-auto rounded-md border border-zinc-700 bg-zinc-900 py-1 shadow-xl">
+                  {history.map((entry, i) => (
+                    <button
+                      key={i}
+                      onClick={() => {
+                        onGoTo(i);
+                        setShowHistory(false);
+                      }}
+                      className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition ${
+                        i === historyIndex
+                          ? "bg-zinc-800 text-emerald-400"
+                          : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+                      }`}
+                    >
+                      {i < (historyIndex ?? 0) && (
+                        <span className="w-3 shrink-0 text-[9px] text-zinc-600">
+                          ←
+                        </span>
+                      )}
+                      {i === historyIndex && (
+                        <span className="w-3 shrink-0 text-[9px] text-emerald-500">
+                          ●
+                        </span>
+                      )}
+                      {i > (historyIndex ?? 0) && (
+                        <span className="w-3 shrink-0 text-[9px] text-zinc-600">
+                          →
+                        </span>
+                      )}
+                      <span className="truncate">{viewCaption(entry)}</span>
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/packages/inspector/src/client/components/Header.tsx
+++ b/packages/inspector/src/client/components/Header.tsx
@@ -1,12 +1,25 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Logo } from "./Logo.js";
 
 type HeaderProps = {
   connected: boolean;
   connectionName: string;
   onConnect: () => void;
+  canGoBack?: boolean;
+  canGoForward?: boolean;
+  onBack?: () => void;
+  onForward?: () => void;
 };
 
-export function Header({ connected, connectionName, onConnect }: HeaderProps) {
+export function Header({
+  connected,
+  connectionName,
+  onConnect,
+  canGoBack,
+  canGoForward,
+  onBack,
+  onForward,
+}: HeaderProps) {
   return (
     <header className="flex h-12 shrink-0 items-center justify-between border-b border-zinc-800 bg-zinc-925 px-4">
       <div className="flex items-center gap-2.5">
@@ -14,6 +27,28 @@ export function Header({ connected, connectionName, onConnect }: HeaderProps) {
         <h1 className="text-sm font-semibold tracking-wide text-zinc-300">
           <span className="text-emerald-400">act</span> inspector
         </h1>
+
+        {/* Navigation */}
+        {connected && (
+          <div className="ml-2 flex items-center gap-0.5">
+            <button
+              onClick={onBack}
+              disabled={!canGoBack}
+              title="Back"
+              className="rounded p-1 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-zinc-500"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <button
+              onClick={onForward}
+              disabled={!canGoForward}
+              title="Forward"
+              className="rounded p-1 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-zinc-500"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        )}
       </div>
       <div className="flex items-center gap-3">
         {connected ? (

--- a/packages/inspector/src/client/components/TabNav.tsx
+++ b/packages/inspector/src/client/components/TabNav.tsx
@@ -1,7 +1,7 @@
-import { Database, GanttChart, List } from "lucide-react";
+import { Database, GanttChart, GitBranch, List } from "lucide-react";
 import type { ReactNode } from "react";
 
-export type Tab = "log" | "timeline" | "streams";
+export type Tab = "log" | "timeline" | "streams" | "correlation";
 
 type TabDef = { id: Tab; label: string; icon: ReactNode };
 
@@ -9,6 +9,7 @@ const tabs: TabDef[] = [
   { id: "log", label: "Log", icon: <List size={14} /> },
   { id: "timeline", label: "Timeline", icon: <GanttChart size={14} /> },
   { id: "streams", label: "Streams", icon: <Database size={14} /> },
+  { id: "correlation", label: "Correlation", icon: <GitBranch size={14} /> },
 ];
 
 type TabNavProps = {

--- a/packages/inspector/src/client/views/Correlation.tsx
+++ b/packages/inspector/src/client/views/Correlation.tsx
@@ -1,5 +1,5 @@
 import { scaleTime } from "d3-scale";
-import { GitBranch, Network } from "lucide-react";
+import { Database, GitBranch, Network } from "lucide-react";
 import { useMemo, useState } from "react";
 import { JsonViewer } from "../components/JsonViewer.js";
 import { trpc } from "../trpc.js";
@@ -354,12 +354,21 @@ export function Correlation({ initialCorrelation, onStream }: Props) {
                     &times;
                   </button>
                 </div>
-                <div className="mb-2 text-xs">
+                <div className="mb-2 flex flex-col gap-1 text-xs">
                   <div className="font-medium text-zinc-200">
                     {selectedEvent.name}
                   </div>
-                  <div className="font-mono text-zinc-400">
+                  <div className="flex items-center gap-1 font-mono text-zinc-400">
                     {selectedEvent.stream}
+                    {onStream && (
+                      <button
+                        onClick={() => onStream(selectedEvent.stream)}
+                        title="Open in Streams"
+                        className="text-emerald-400/70 transition hover:text-emerald-300"
+                      >
+                        <Database size={11} />
+                      </button>
+                    )}
                   </div>
                   <div className="text-zinc-500">
                     v{selectedEvent.version} &middot;{" "}

--- a/packages/inspector/src/client/views/Correlation.tsx
+++ b/packages/inspector/src/client/views/Correlation.tsx
@@ -1,0 +1,735 @@
+import { scaleTime } from "d3-scale";
+import { GitBranch, Network } from "lucide-react";
+import { useMemo, useState } from "react";
+import { JsonViewer } from "../components/JsonViewer.js";
+import { trpc } from "../trpc.js";
+
+// --- Types ---
+
+type EventMeta = {
+  correlation?: string;
+  causation?: {
+    action?: {
+      stream?: string;
+      actor?: { id?: string; name?: string };
+      name?: string;
+    };
+    event?: { id?: number; name?: string; stream?: string };
+  };
+};
+
+type Event = {
+  id: number;
+  name: string;
+  stream: string;
+  version: number;
+  created: string;
+  data: unknown;
+  meta: EventMeta;
+};
+
+type TreeNode = {
+  event: Event;
+  children: TreeNode[];
+  depth: number;
+};
+
+// --- Helpers ---
+
+function streamColor(stream: string): string {
+  const hues = [
+    "#38bdf8",
+    "#fbbf24",
+    "#34d399",
+    "#a78bfa",
+    "#fb7185",
+    "#22d3ee",
+    "#f97316",
+    "#818cf8",
+    "#2dd4bf",
+    "#f472b6",
+  ];
+  let hash = 0;
+  for (let i = 0; i < stream.length; i++) {
+    hash = (hash * 31 + stream.charCodeAt(i)) | 0;
+  }
+  return hues[Math.abs(hash) % hues.length];
+}
+
+function buildCausationTree(events: Event[]): TreeNode[] {
+  const byId = new Map<number, Event>();
+  for (const e of events) byId.set(e.id, e);
+
+  const childMap = new Map<number, Event[]>();
+  const roots: Event[] = [];
+
+  for (const e of events) {
+    const parentId = e.meta?.causation?.event?.id;
+    if (parentId != null && byId.has(parentId)) {
+      const list = childMap.get(parentId);
+      if (list) list.push(e);
+      else childMap.set(parentId, [e]);
+    } else {
+      roots.push(e);
+    }
+  }
+
+  function buildNode(event: Event, depth: number): TreeNode {
+    const children = (childMap.get(event.id) ?? [])
+      .sort((a, b) => a.id - b.id)
+      .map((c) => buildNode(c, depth + 1));
+    return { event, children, depth };
+  }
+
+  return roots.sort((a, b) => a.id - b.id).map((r) => buildNode(r, 0));
+}
+
+function flattenTree(nodes: TreeNode[]): TreeNode[] {
+  const result: TreeNode[] = [];
+  function walk(node: TreeNode) {
+    result.push(node);
+    for (const child of node.children) walk(child);
+  }
+  for (const n of nodes) walk(n);
+  return result;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+// --- Component ---
+
+type Props = {
+  initialCorrelation?: string;
+};
+
+export function Correlation({ initialCorrelation }: Props) {
+  const [correlationId, setCorrelationId] = useState(initialCorrelation ?? "");
+  const [searchInput, setSearchInput] = useState(initialCorrelation ?? "");
+  const [viewMode, setViewMode] = useState<"waterfall" | "graph">("waterfall");
+  const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+
+  const eventsQuery = trpc.query.useQuery(
+    { correlation: correlationId, limit: 500, backward: false },
+    { enabled: correlationId.length > 0, staleTime: 10_000 }
+  );
+
+  const events = (eventsQuery.data?.events ?? []) as unknown as Event[];
+
+  const handleSearch = () => {
+    const trimmed = searchInput.trim();
+    if (trimmed) setCorrelationId(trimmed);
+  };
+
+  // Build tree
+  const tree = useMemo(() => buildCausationTree(events), [events]);
+  const flatNodes = useMemo(() => flattenTree(tree), [tree]);
+
+  // Stats
+  const stats = useMemo(() => {
+    if (events.length === 0) return null;
+    const streams = new Set<string>();
+    const names = new Map<string, number>();
+    let actor: string | undefined;
+    let minTime = Infinity;
+    let maxTime = -Infinity;
+
+    for (const e of events) {
+      streams.add(e.stream);
+      names.set(e.name, (names.get(e.name) ?? 0) + 1);
+      const t = new Date(e.created).getTime();
+      if (t < minTime) minTime = t;
+      if (t > maxTime) maxTime = t;
+    }
+
+    // Actor from first root event
+    if (tree.length > 0) {
+      actor = tree[0].event.meta?.causation?.action?.actor?.name;
+    }
+
+    return {
+      actor,
+      totalEvents: events.length,
+      duration: maxTime - minTime,
+      streams: [...streams],
+      eventTypes: [...names.entries()].sort((a, b) => b[1] - a[1]),
+      minTime,
+      maxTime,
+    };
+  }, [events, tree]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Search bar */}
+      <div className="flex items-center gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-2">
+        <label className="text-[10px] uppercase tracking-wider text-zinc-500">
+          Correlation
+        </label>
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+          placeholder="paste correlation id..."
+          className="w-80 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 font-mono text-xs text-zinc-200 outline-none transition placeholder:text-zinc-600 focus:border-emerald-600"
+        />
+        <button
+          onClick={handleSearch}
+          className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-emerald-500"
+        >
+          Trace
+        </button>
+
+        {events.length > 0 && (
+          <div className="ml-auto flex gap-1">
+            <button
+              onClick={() => setViewMode("waterfall")}
+              className={`rounded p-1.5 transition ${viewMode === "waterfall" ? "bg-zinc-800 text-emerald-400" : "text-zinc-500 hover:text-zinc-300"}`}
+              title="Waterfall"
+            >
+              <GitBranch size={14} />
+            </button>
+            <button
+              onClick={() => setViewMode("graph")}
+              className={`rounded p-1.5 transition ${viewMode === "graph" ? "bg-zinc-800 text-emerald-400" : "text-zinc-500 hover:text-zinc-300"}`}
+              title="Graph"
+            >
+              <Network size={14} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      {!correlationId ? (
+        <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+          Enter a correlation ID to trace an event chain
+        </div>
+      ) : eventsQuery.isLoading ? (
+        <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+          Loading...
+        </div>
+      ) : events.length === 0 ? (
+        <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+          No events found for this correlation
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          {/* Main view */}
+          <div
+            className={`flex-1 overflow-auto ${selectedEvent ? "border-r border-zinc-800" : ""}`}
+          >
+            {viewMode === "waterfall" ? (
+              <WaterfallView
+                nodes={flatNodes}
+                stats={stats!}
+                onSelect={setSelectedEvent}
+                selected={selectedEvent}
+              />
+            ) : (
+              <GraphView
+                tree={tree}
+                events={events}
+                onSelect={setSelectedEvent}
+                selected={selectedEvent}
+              />
+            )}
+          </div>
+
+          {/* Metadata sidebar */}
+          <div className="flex w-80 shrink-0 flex-col overflow-y-auto">
+            {/* Stats */}
+            {stats && (
+              <div className="border-b border-zinc-800 bg-zinc-925 px-4 py-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-[10px] uppercase tracking-wider text-zinc-500">
+                    Chain
+                  </span>
+                  <button
+                    onClick={() =>
+                      void navigator.clipboard.writeText(correlationId)
+                    }
+                    className="font-mono text-[10px] text-zinc-400 hover:text-emerald-400"
+                  >
+                    {correlationId.length > 20
+                      ? `${correlationId.slice(0, 20)}...`
+                      : correlationId}
+                  </button>
+                </div>
+                <div className="flex flex-col gap-1.5 text-xs">
+                  {stats.actor && (
+                    <div>
+                      <span className="text-zinc-500">Actor </span>
+                      <span className="text-zinc-300">{stats.actor}</span>
+                    </div>
+                  )}
+                  <div>
+                    <span className="text-zinc-500">Events </span>
+                    <span className="text-zinc-200">{stats.totalEvents}</span>
+                  </div>
+                  <div>
+                    <span className="text-zinc-500">Duration </span>
+                    <span className="text-zinc-200">
+                      {formatDuration(stats.duration)}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-zinc-500">Streams </span>
+                    <span className="text-zinc-200">
+                      {stats.streams.length}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Streams touched */}
+            {stats && (
+              <div className="border-b border-zinc-800 px-4 py-2">
+                <span className="mb-1.5 block text-[10px] uppercase tracking-wider text-zinc-500">
+                  Streams
+                </span>
+                <div className="flex flex-col gap-1">
+                  {stats.streams.map((s) => (
+                    <div key={s} className="flex items-center gap-2 text-xs">
+                      <span
+                        className="h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: streamColor(s) }}
+                      />
+                      <span className="truncate font-mono text-zinc-300">
+                        {s}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Event types */}
+            {stats && (
+              <div className="border-b border-zinc-800 px-4 py-2">
+                <span className="mb-1.5 block text-[10px] uppercase tracking-wider text-zinc-500">
+                  Event types
+                </span>
+                <div className="flex flex-col gap-1">
+                  {stats.eventTypes.map(([name, count]) => (
+                    <div
+                      key={name}
+                      className="flex items-center justify-between text-xs"
+                    >
+                      <span className="text-zinc-300">{name}</span>
+                      <span className="text-zinc-500">{count}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Selected event detail */}
+            {selectedEvent && (
+              <div className="flex-1 px-4 py-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-[10px] uppercase tracking-wider text-zinc-500">
+                    Event #{selectedEvent.id}
+                  </span>
+                  <button
+                    onClick={() => setSelectedEvent(null)}
+                    className="text-zinc-500 hover:text-zinc-300"
+                  >
+                    &times;
+                  </button>
+                </div>
+                <div className="mb-2 text-xs">
+                  <div className="font-medium text-zinc-200">
+                    {selectedEvent.name}
+                  </div>
+                  <div className="font-mono text-zinc-400">
+                    {selectedEvent.stream}
+                  </div>
+                  <div className="text-zinc-500">
+                    v{selectedEvent.version} &middot;{" "}
+                    {new Date(selectedEvent.created).toLocaleString()}
+                  </div>
+                </div>
+                <div className="mb-2">
+                  <div className="mb-1 text-[10px] uppercase tracking-wider text-zinc-500">
+                    Data
+                  </div>
+                  <div className="rounded-md border border-zinc-800 bg-zinc-950 p-2 text-[10px]">
+                    <JsonViewer data={selectedEvent.data} />
+                  </div>
+                </div>
+                <div>
+                  <div className="mb-1 text-[10px] uppercase tracking-wider text-zinc-500">
+                    Meta
+                  </div>
+                  <div className="rounded-md border border-zinc-800 bg-zinc-950 p-2 text-[10px]">
+                    <JsonViewer data={selectedEvent.meta} />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Waterfall View ---
+
+const BAR_HEIGHT = 24;
+const ROW_HEIGHT = 32;
+const INDENT_PX = 24;
+const LEFT_LABEL = 280;
+
+function WaterfallView({
+  nodes,
+  stats,
+  onSelect,
+  selected,
+}: {
+  nodes: TreeNode[];
+  stats: { minTime: number; maxTime: number };
+  onSelect: (e: Event) => void;
+  selected: Event | null;
+}) {
+  const chartWidth = 600;
+  const totalWidth = LEFT_LABEL + chartWidth + 16;
+
+  const xScale = useMemo(() => {
+    const pad = Math.max((stats.maxTime - stats.minTime) * 0.05, 100);
+    return scaleTime()
+      .domain([new Date(stats.minTime - pad), new Date(stats.maxTime + pad)])
+      .range([LEFT_LABEL, totalWidth - 16]);
+  }, [stats.minTime, stats.maxTime, totalWidth]);
+
+  const ticks = useMemo(() => {
+    return xScale.ticks(5).map((d) => ({
+      x: xScale(d),
+      label: d.toLocaleTimeString(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }),
+    }));
+  }, [xScale]);
+
+  const svgHeight = nodes.length * ROW_HEIGHT + 40;
+
+  return (
+    <svg width={totalWidth} height={svgHeight} className="select-none">
+      {/* Time axis */}
+      <line
+        x1={LEFT_LABEL}
+        y1={20}
+        x2={totalWidth - 16}
+        y2={20}
+        stroke="#3f3f46"
+        strokeWidth={1}
+      />
+      {ticks.map((tick, i) => (
+        <g key={i}>
+          <line
+            x1={tick.x}
+            y1={16}
+            x2={tick.x}
+            y2={24}
+            stroke="#52525b"
+            strokeWidth={1}
+          />
+          <text
+            x={tick.x}
+            y={12}
+            textAnchor="middle"
+            className="fill-zinc-500 text-[9px]"
+          >
+            {tick.label}
+          </text>
+          <line
+            x1={tick.x}
+            y1={24}
+            x2={tick.x}
+            y2={svgHeight}
+            stroke="#27272a"
+            strokeWidth={1}
+            strokeDasharray="2,4"
+          />
+        </g>
+      ))}
+
+      {/* Rows */}
+      {nodes.map((node, i) => {
+        const y = 30 + i * ROW_HEIGHT;
+        const cx = xScale(new Date(node.event.created));
+        const isSelected = selected?.id === node.event.id;
+        const color = streamColor(node.event.stream);
+
+        // Bar width: duration to next sibling or min width
+        const nextNode = nodes[i + 1];
+        let barEnd = cx + 20; // min width
+        if (nextNode) {
+          const nextX = xScale(new Date(nextNode.event.created));
+          barEnd = Math.max(barEnd, nextX - 2);
+        }
+
+        // Gap detection
+        const parentId = node.event.meta?.causation?.event?.id;
+        const parentNode =
+          parentId != null
+            ? nodes.find((n) => n.event.id === parentId)
+            : undefined;
+        const gap = parentNode
+          ? new Date(node.event.created).getTime() -
+            new Date(parentNode.event.created).getTime()
+          : 0;
+        const hasLargeGap = gap > 1000;
+
+        return (
+          <g
+            key={node.event.id}
+            className="cursor-pointer"
+            onClick={() => onSelect(node.event)}
+          >
+            {/* Row background */}
+            {isSelected && (
+              <rect
+                x={0}
+                y={y}
+                width={totalWidth}
+                height={ROW_HEIGHT}
+                fill="#18181b"
+              />
+            )}
+
+            {/* Label */}
+            <text
+              x={node.depth * INDENT_PX + 8}
+              y={y + ROW_HEIGHT / 2 + 1}
+              dominantBaseline="middle"
+              className="fill-zinc-400 text-[10px]"
+            >
+              <tspan className="fill-zinc-300">{node.event.name}</tspan>
+              <tspan className="fill-zinc-600">
+                {" "}
+                {node.event.stream.length > 20
+                  ? `...${node.event.stream.slice(-17)}`
+                  : node.event.stream}
+              </tspan>
+            </text>
+
+            {/* Bar */}
+            <rect
+              x={cx}
+              y={y + (ROW_HEIGHT - BAR_HEIGHT) / 2}
+              width={Math.max(4, barEnd - cx)}
+              height={BAR_HEIGHT}
+              rx={3}
+              fill={color}
+              opacity={isSelected ? 0.9 : 0.5}
+              className="transition-opacity hover:opacity-80"
+            />
+
+            {/* Event name on bar */}
+            <text
+              x={cx + 6}
+              y={y + ROW_HEIGHT / 2 + 1}
+              dominantBaseline="middle"
+              className="fill-white text-[9px] font-medium"
+              style={{ textShadow: "0 1px 2px rgba(0,0,0,0.5)" }}
+            >
+              #{node.event.id}
+            </text>
+
+            {/* Gap indicator */}
+            {hasLargeGap && (
+              <text
+                x={cx - 4}
+                y={y + ROW_HEIGHT / 2 + 1}
+                textAnchor="end"
+                dominantBaseline="middle"
+                className="fill-amber-500 text-[8px]"
+              >
+                +{formatDuration(gap)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+// --- Graph View (DAG) ---
+
+const NODE_W = 140;
+const NODE_H = 36;
+const H_GAP = 40;
+const V_GAP = 20;
+
+function GraphView({
+  tree,
+  events,
+  onSelect,
+  selected,
+}: {
+  tree: TreeNode[];
+  events: Event[];
+  onSelect: (e: Event) => void;
+  selected: Event | null;
+}) {
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    event: Event;
+  } | null>(null);
+
+  // Layout: assign x,y per node based on depth and sibling index
+  const layout = useMemo(() => {
+    const positions = new Map<number, { x: number; y: number }>();
+    const depthCounts = new Map<number, number>();
+
+    function layoutNode(node: TreeNode) {
+      const count = depthCounts.get(node.depth) ?? 0;
+      depthCounts.set(node.depth, count + 1);
+      positions.set(node.event.id, {
+        x: node.depth * (NODE_W + H_GAP) + 20,
+        y: count * (NODE_H + V_GAP) + 20,
+      });
+      for (const child of node.children) layoutNode(child);
+    }
+    for (const root of tree) layoutNode(root);
+
+    // Edges
+    const edges: { from: number; to: number }[] = [];
+    for (const e of events) {
+      const parentId = e.meta?.causation?.event?.id;
+      if (parentId != null && positions.has(parentId)) {
+        edges.push({ from: parentId, to: e.id });
+      }
+    }
+
+    // Compute bounds
+    let maxX = 0;
+    let maxY = 0;
+    for (const pos of positions.values()) {
+      if (pos.x + NODE_W > maxX) maxX = pos.x + NODE_W;
+      if (pos.y + NODE_H > maxY) maxY = pos.y + NODE_H;
+    }
+
+    return { positions, edges, width: maxX + 40, height: maxY + 40 };
+  }, [tree, events]);
+
+  return (
+    <div className="relative overflow-auto">
+      <svg width={layout.width} height={layout.height} className="select-none">
+        {/* Edges */}
+        {layout.edges.map(({ from, to }) => {
+          const fp = layout.positions.get(from);
+          const tp = layout.positions.get(to);
+          if (!fp || !tp) return null;
+          return (
+            <line
+              key={`${from}-${to}`}
+              x1={fp.x + NODE_W}
+              y1={fp.y + NODE_H / 2}
+              x2={tp.x}
+              y2={tp.y + NODE_H / 2}
+              stroke="#3f3f46"
+              strokeWidth={1.5}
+              markerEnd="url(#arrow)"
+            />
+          );
+        })}
+
+        {/* Arrow marker */}
+        <defs>
+          <marker
+            id="arrow"
+            viewBox="0 0 10 10"
+            refX="10"
+            refY="5"
+            markerWidth="8"
+            markerHeight="8"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#52525b" />
+          </marker>
+        </defs>
+
+        {/* Nodes */}
+        {events.map((event) => {
+          const pos = layout.positions.get(event.id);
+          if (!pos) return null;
+          const color = streamColor(event.stream);
+          const isSelected = selected?.id === event.id;
+
+          return (
+            <g
+              key={event.id}
+              className="cursor-pointer"
+              onClick={() => onSelect(event)}
+              onMouseEnter={(ev) =>
+                setTooltip({ x: ev.clientX, y: ev.clientY, event })
+              }
+              onMouseLeave={() => setTooltip(null)}
+            >
+              <rect
+                x={pos.x}
+                y={pos.y}
+                width={NODE_W}
+                height={NODE_H}
+                rx={6}
+                fill={color + "22"}
+                stroke={isSelected ? color : color + "66"}
+                strokeWidth={isSelected ? 2 : 1}
+              />
+              <text
+                x={pos.x + 8}
+                y={pos.y + 14}
+                className="fill-zinc-200 text-[10px] font-medium"
+              >
+                {event.name.length > 18
+                  ? event.name.slice(0, 16) + "..."
+                  : event.name}
+              </text>
+              <text
+                x={pos.x + 8}
+                y={pos.y + 27}
+                className="fill-zinc-500 text-[8px]"
+              >
+                #{event.id}{" "}
+                {event.stream.length > 16
+                  ? `...${event.stream.slice(-13)}`
+                  : event.stream}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="pointer-events-none fixed z-50 max-w-xs rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1.5 text-[10px] shadow-xl"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 10 }}
+        >
+          <div className="font-medium text-zinc-200">{tooltip.event.name}</div>
+          <div className="font-mono text-zinc-400">{tooltip.event.stream}</div>
+          <div className="text-zinc-500">
+            #{tooltip.event.id} v{tooltip.event.version} &middot;{" "}
+            {new Date(tooltip.event.created).toLocaleString()}
+          </div>
+          {tooltip.event.data != null && (
+            <div className="mt-1 border-t border-zinc-800 pt-1 text-[9px]">
+              <JsonViewer data={tooltip.event.data} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/inspector/src/client/views/Correlation.tsx
+++ b/packages/inspector/src/client/views/Correlation.tsx
@@ -301,18 +301,17 @@ export function Correlation({ initialCorrelation, onStream }: Props) {
                         className="h-2 w-2 shrink-0 rounded-full"
                         style={{ backgroundColor: streamColor(s) }}
                       />
-                      {onStream ? (
+                      <span className="truncate font-mono text-zinc-300">
+                        {s}
+                      </span>
+                      {onStream && (
                         <button
                           onClick={() => onStream(s)}
                           title="Open in Streams"
-                          className="truncate font-mono text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 hover:text-emerald-300"
+                          className="shrink-0 text-emerald-400/70 transition hover:text-emerald-300"
                         >
-                          {s}
+                          <Database size={11} />
                         </button>
-                      ) : (
-                        <span className="truncate font-mono text-zinc-300">
-                          {s}
-                        </span>
                       )}
                     </div>
                   ))}

--- a/packages/inspector/src/client/views/Correlation.tsx
+++ b/packages/inspector/src/client/views/Correlation.tsx
@@ -104,9 +104,11 @@ function formatDuration(ms: number): string {
 
 type Props = {
   initialCorrelation?: string;
+  onStream?: (stream: string) => void;
+  onTrace?: (id: string) => void;
 };
 
-export function Correlation({ initialCorrelation }: Props) {
+export function Correlation({ initialCorrelation, onStream }: Props) {
   const [correlationId, setCorrelationId] = useState(initialCorrelation ?? "");
   const [searchInput, setSearchInput] = useState(initialCorrelation ?? "");
   const [viewMode, setViewMode] = useState<"waterfall" | "graph">("waterfall");
@@ -299,9 +301,19 @@ export function Correlation({ initialCorrelation }: Props) {
                         className="h-2 w-2 shrink-0 rounded-full"
                         style={{ backgroundColor: streamColor(s) }}
                       />
-                      <span className="truncate font-mono text-zinc-300">
-                        {s}
-                      </span>
+                      {onStream ? (
+                        <button
+                          onClick={() => onStream(s)}
+                          title="Open in Streams"
+                          className="truncate font-mono text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 hover:text-emerald-300"
+                        >
+                          {s}
+                        </button>
+                      ) : (
+                        <span className="truncate font-mono text-zinc-300">
+                          {s}
+                        </span>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/packages/inspector/src/client/views/EventLog.tsx
+++ b/packages/inspector/src/client/views/EventLog.tsx
@@ -17,8 +17,10 @@ type AnyEvent = {
 
 export function EventLog({
   onTrace,
+  onStream,
 }: {
   onTrace?: (correlationId: string) => void;
+  onStream?: (stream: string) => void;
 }) {
   const [filters] = useFilterStore();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -135,7 +137,12 @@ export function EventLog({
         ) : (
           <>
             {allEvents.map((event) => (
-              <EventRow key={event.id} event={event as any} onTrace={onTrace} />
+              <EventRow
+                key={event.id}
+                event={event as any}
+                onTrace={onTrace}
+                onStream={onStream}
+              />
             ))}
             {eventsQuery.isFetching && (
               <div className="py-4 text-center text-xs text-zinc-600">

--- a/packages/inspector/src/client/views/EventLog.tsx
+++ b/packages/inspector/src/client/views/EventLog.tsx
@@ -115,6 +115,7 @@ export function EventLog({
         <span className="min-w-0 flex-1">Stream</span>
         <span className="w-20 shrink-0 text-right">Time</span>
         <span className="w-4 shrink-0" />
+        <span className="w-4 shrink-0" />
       </div>
 
       {/* Event list */}

--- a/packages/inspector/src/client/views/EventLog.tsx
+++ b/packages/inspector/src/client/views/EventLog.tsx
@@ -15,7 +15,11 @@ type AnyEvent = {
   meta: Record<string, unknown>;
 };
 
-export function EventLog() {
+export function EventLog({
+  onTrace,
+}: {
+  onTrace?: (correlationId: string) => void;
+}) {
   const [filters] = useFilterStore();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [pages, setPages] = useState<AnyEvent[][]>([]);
@@ -130,7 +134,7 @@ export function EventLog() {
         ) : (
           <>
             {allEvents.map((event) => (
-              <EventRow key={event.id} event={event as any} />
+              <EventRow key={event.id} event={event as any} onTrace={onTrace} />
             ))}
             {eventsQuery.isFetching && (
               <div className="py-4 text-center text-xs text-zinc-600">

--- a/packages/inspector/src/client/views/EventLog.tsx
+++ b/packages/inspector/src/client/views/EventLog.tsx
@@ -115,8 +115,8 @@ export function EventLog({
         <span className="w-12 shrink-0 text-right">Version</span>
         <span className="w-36 shrink-0">Event</span>
         <span className="min-w-0 flex-1">Stream</span>
+        <span className="w-20 shrink-0">Correlation</span>
         <span className="w-20 shrink-0 text-right">Time</span>
-        <span className="w-4 shrink-0" />
         <span className="w-4 shrink-0" />
       </div>
 

--- a/packages/inspector/src/client/views/Streams.tsx
+++ b/packages/inspector/src/client/views/Streams.tsx
@@ -12,7 +12,13 @@ type StreamRow = {
 
 type SortKey = "stream" | "eventCount" | "currentVersion" | "lastEvent";
 
-export function Streams({ onNavigateToLog }: { onNavigateToLog: () => void }) {
+export function Streams({
+  onNavigateToLog,
+  onTrace,
+}: {
+  onNavigateToLog: () => void;
+  onTrace?: (id: string) => void;
+}) {
   const [filter, setFilter] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("eventCount");
   const [sortAsc, setSortAsc] = useState(false);
@@ -140,6 +146,7 @@ export function Streams({ onNavigateToLog }: { onNavigateToLog: () => void }) {
               setFilters({ stream: selected });
               onNavigateToLog();
             }}
+            onTrace={onTrace}
             onClose={() => setSelected(null)}
           />
         )}
@@ -151,10 +158,12 @@ export function Streams({ onNavigateToLog }: { onNavigateToLog: () => void }) {
 function StreamDetail({
   stream,
   onOpenInLog,
+  onTrace,
   onClose,
 }: {
   stream: string;
   onOpenInLog: () => void;
+  onTrace?: (id: string) => void;
   onClose: () => void;
 }) {
   const eventsQuery = trpc.query.useQuery(
@@ -217,6 +226,7 @@ function StreamDetail({
                 defaultExpanded
                 compact
                 hideStream
+                onTrace={onTrace}
               />
             ))}
           </div>

--- a/packages/inspector/src/client/views/Streams.tsx
+++ b/packages/inspector/src/client/views/Streams.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { EventRow } from "../components/EventRow.js";
-import { setFilters } from "../stores/filters.js";
 import { trpc } from "../trpc.js";
 
 type StreamRow = {
@@ -13,16 +12,20 @@ type StreamRow = {
 type SortKey = "stream" | "eventCount" | "currentVersion" | "lastEvent";
 
 export function Streams({
-  onNavigateToLog,
+  initialStream,
   onTrace,
+  onStream,
 }: {
-  onNavigateToLog: () => void;
+  initialStream?: string;
   onTrace?: (id: string) => void;
+  onStream?: (stream: string) => void;
 }) {
   const [filter, setFilter] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("eventCount");
   const [sortAsc, setSortAsc] = useState(false);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(
+    initialStream ?? null
+  );
 
   const streamsQuery = trpc.streams.useQuery(
     { limit: 1000 },
@@ -142,11 +145,8 @@ export function Streams({
         {selected && (
           <StreamDetail
             stream={selected}
-            onOpenInLog={() => {
-              setFilters({ stream: selected });
-              onNavigateToLog();
-            }}
             onTrace={onTrace}
+            onStream={onStream}
             onClose={() => setSelected(null)}
           />
         )}
@@ -157,13 +157,13 @@ export function Streams({
 
 function StreamDetail({
   stream,
-  onOpenInLog,
   onTrace,
+  onStream,
   onClose,
 }: {
   stream: string;
-  onOpenInLog: () => void;
   onTrace?: (id: string) => void;
+  onStream?: (stream: string) => void;
   onClose: () => void;
 }) {
   const eventsQuery = trpc.query.useQuery(
@@ -189,12 +189,6 @@ function StreamDetail({
           </button>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={onOpenInLog}
-            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-[10px] text-zinc-400 hover:text-emerald-400"
-          >
-            Open in Log
-          </button>
           <button
             onClick={onClose}
             className="text-zinc-500 hover:text-zinc-300"
@@ -227,6 +221,7 @@ function StreamDetail({
                 compact
                 hideStream
                 onTrace={onTrace}
+                onStream={onStream}
               />
             ))}
           </div>

--- a/packages/inspector/src/client/views/Timeline.tsx
+++ b/packages/inspector/src/client/views/Timeline.tsx
@@ -57,7 +57,12 @@ type TooltipData = {
   event: Event;
 };
 
-export function Timeline() {
+type TimelineProps = {
+  onTrace?: (id: string) => void;
+  onStream?: (stream: string) => void;
+};
+
+export function Timeline({ onTrace, onStream }: TimelineProps) {
   const [filters] = useFilterStore();
   const svgRef = useRef<SVGSVGElement>(null);
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
@@ -455,6 +460,8 @@ export function Timeline() {
           <EventDetailDialog
             event={selectedEvent}
             onClose={() => setSelectedEvent(null)}
+            onTrace={onTrace}
+            onStream={onStream}
           />
         )}
       </div>
@@ -465,10 +472,17 @@ export function Timeline() {
 function EventDetailDialog({
   event,
   onClose,
+  onTrace,
+  onStream,
 }: {
   event: Event;
   onClose: () => void;
+  onTrace?: (id: string) => void;
+  onStream?: (stream: string) => void;
 }) {
+  const meta = event.meta as Record<string, any>;
+  const correlation = meta?.correlation as string | undefined;
+
   return (
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
@@ -502,12 +516,44 @@ function EventDetailDialog({
           </button>
         </div>
 
-        {/* Stream + time + actor */}
+        {/* Stream + correlation + time + actor */}
         <div className="mb-3 flex flex-col gap-1 text-xs">
           <div>
             <span className="text-zinc-500">Stream </span>
-            <span className="font-mono text-zinc-300">{event.stream}</span>
+            {onStream ? (
+              <button
+                onClick={() => {
+                  onStream(event.stream);
+                  onClose();
+                }}
+                title="Open in Streams"
+                className="font-mono text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 hover:text-emerald-300"
+              >
+                {event.stream}
+              </button>
+            ) : (
+              <span className="font-mono text-zinc-300">{event.stream}</span>
+            )}
           </div>
+          {correlation && (
+            <div>
+              <span className="text-zinc-500">Correlation </span>
+              {onTrace ? (
+                <button
+                  onClick={() => {
+                    onTrace(correlation);
+                    onClose();
+                  }}
+                  title="Trace correlation chain"
+                  className="font-mono text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 hover:text-emerald-300"
+                >
+                  {correlation}
+                </button>
+              ) : (
+                <span className="font-mono text-zinc-300">{correlation}</span>
+              )}
+            </div>
+          )}
           <div>
             <span className="text-zinc-500">Created </span>
             <span className="text-zinc-300">

--- a/packages/inspector/src/client/views/Timeline.tsx
+++ b/packages/inspector/src/client/views/Timeline.tsx
@@ -1,5 +1,5 @@
 import { scaleLinear, scaleTime } from "d3-scale";
-import { Maximize2, ZoomIn, ZoomOut } from "lucide-react";
+import { Database, GitBranch, Maximize2, ZoomIn, ZoomOut } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { FilterBar } from "../components/FilterBar.js";
 import { JsonViewer } from "../components/JsonViewer.js";
@@ -518,39 +518,37 @@ function EventDetailDialog({
 
         {/* Stream + correlation + time + actor */}
         <div className="mb-3 flex flex-col gap-1 text-xs">
-          <div>
-            <span className="text-zinc-500">Stream </span>
-            {onStream ? (
+          <div className="flex items-center gap-1">
+            <span className="text-zinc-500">Stream</span>
+            <span className="font-mono text-zinc-300">{event.stream}</span>
+            {onStream && (
               <button
                 onClick={() => {
                   onStream(event.stream);
                   onClose();
                 }}
                 title="Open in Streams"
-                className="font-mono text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 hover:text-emerald-300"
+                className="text-emerald-400/70 transition hover:text-emerald-300"
               >
-                {event.stream}
+                <Database size={11} />
               </button>
-            ) : (
-              <span className="font-mono text-zinc-300">{event.stream}</span>
             )}
           </div>
           {correlation && (
-            <div>
-              <span className="text-zinc-500">Correlation </span>
-              {onTrace ? (
+            <div className="flex items-center gap-1">
+              <span className="text-zinc-500">Correlation</span>
+              <span className="font-mono text-zinc-300">{correlation}</span>
+              {onTrace && (
                 <button
                   onClick={() => {
                     onTrace(correlation);
                     onClose();
                   }}
-                  title="Trace correlation chain"
-                  className="font-mono text-emerald-400/80 underline decoration-emerald-400/30 underline-offset-2 hover:text-emerald-300"
+                  title="Trace correlation"
+                  className="text-emerald-400/70 transition hover:text-emerald-300"
                 >
-                  {correlation}
+                  <GitBranch size={11} />
                 </button>
-              ) : (
-                <span className="font-mono text-zinc-300">{correlation}</span>
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary

- **Correlation tab** added to navigation (Log | Timeline | Streams | Correlation)
- **Waterfall view**: time-axis bars indented by causation depth, color-coded by stream, gap detection highlights reaction latency >1s
- **DAG graph view**: directed acyclic graph with nodes as colored rectangles, arrows showing cause→effect, hover tooltips with event data
- **Metadata sidebar**: actor, event count, chain duration, streams touched, event type breakdown, selected event detail with JSON
- **"Trace" button** in EventRow expanded detail — click to jump to correlation explorer with pre-filled correlation ID
- Toggle between waterfall and graph views for the same correlation chain

Depends on #494, #495
Closes #491

## Test plan

- [ ] Search by correlation ID → shows waterfall with indented causation chain
- [ ] Toggle to graph view → shows DAG with correct edges
- [ ] Click event in waterfall → detail appears in sidebar with data + meta JSON
- [ ] Click event in graph → same detail in sidebar
- [ ] Gap detection shows "+Ns" for reaction latency >1s in waterfall
- [ ] Metadata sidebar shows correct actor, event count, duration, streams, types
- [ ] "Trace" button in log view event detail → navigates to correlation tab
- [ ] Handles single-event correlations and deep chains
- [ ] `pnpm typecheck` passes
- [ ] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)