### PR TITLE
fix(act, act-pg): add stream_exact query option for exact stream matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -505,6 +505,7 @@ The default `InMemoryCache` is an LRU cache with configurable `maxSize` (default
 - Use `app.on("settled", ...)` to react when `settle()` completes all correlate/drain passes
 - Use `app.on("blocked", ...)` to catch reaction processing failures
 - Query events directly: `await app.query_array({ stream: "mystream" })`
+- Query with exact stream match: `await app.query_array({ stream: "mystream", stream_exact: true })` — by default, `stream` uses regex matching; `stream_exact: true` uses exact string equality. `load()` always uses exact match internally.
 
 ### Performance
 

--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -309,7 +309,11 @@ export class PostgresStore implements Store {
       }
       if (stream) {
         values.push(stream);
-        conditions.push(`stream ~ $${values.length}`);
+        conditions.push(
+          query.stream_exact
+            ? `stream = $${values.length}`
+            : `stream ~ $${values.length}`
+        );
       }
       if (names && names.length) {
         values.push(names);

--- a/libs/act/src/adapters/InMemoryStore.ts
+++ b/libs/act/src/adapters/InMemoryStore.ts
@@ -212,8 +212,11 @@ export class InMemoryStore implements Store {
   }
 
   private in_query<E extends Schemas>(query: Query, e: Committed<E, keyof E>) {
-    if (query.stream && !RegExp(`^${query.stream}$`).test(e.stream))
-      return false;
+    if (query.stream) {
+      if (query.stream_exact) {
+        if (e.stream !== query.stream) return false;
+      } else if (!RegExp(`^${query.stream}$`).test(e.stream)) return false;
+    }
     if (query.names && !query.names.includes(e.name as string)) return false;
     if (query.correlation && e.meta?.correlation !== query.correlation)
       return false;

--- a/libs/act/src/event-sourcing.ts
+++ b/libs/act/src/event-sourcing.ts
@@ -107,7 +107,7 @@ export async function load<
       }
       callback && callback({ event, state, patches, snaps });
     },
-    { stream, with_snaps: !cached, after: cached?.event_id }
+    { stream, with_snaps: !cached, after: cached?.event_id, stream_exact: true }
   );
 
   logger.trace(

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -91,7 +91,8 @@ export type CommittedMeta = z.infer<typeof CommittedMetaSchema>;
 /**
  * Query options for event store queries.
  *
- * @property `stream?` - Filter by stream name
+ * @property `stream?` - Filter by stream name (regex match by default)
+ * @property `stream_exact?` - When true, match stream name exactly instead of regex (used by load)
  * @property `names?` - Filter by event names
  * @property `before?` - Filter events before this id
  * @property `after?` - Filter events after this id

--- a/libs/act/src/types/schemas.ts
+++ b/libs/act/src/types/schemas.ts
@@ -97,5 +97,6 @@ export const QuerySchema = z
     backward: z.boolean().optional(),
     correlation: z.string().optional(),
     with_snaps: z.boolean().optional(),
+    stream_exact: z.boolean().optional(),
   })
   .readonly();

--- a/libs/act/test/in-memory-store.spec.ts
+++ b/libs/act/test/in-memory-store.spec.ts
@@ -158,6 +158,45 @@ describe("InMemoryStore", () => {
       expect(result.length).toBe(6);
     });
 
+    it("should filter by stream_exact without regex matching", async () => {
+      const s = store();
+      await s.commit("ticker-VT", [{ name: "A", data: { a: 1 } }], {
+        correlation: "c1",
+        causation: {},
+      });
+      await s.commit("ticker-VTI", [{ name: "A", data: { a: 2 } }], {
+        correlation: "c2",
+        causation: {},
+      });
+      await s.commit("ticker-VTV", [{ name: "A", data: { a: 3 } }], {
+        correlation: "c3",
+        causation: {},
+      });
+
+      // Regex match with pattern: ticker-VT. matches VTI and VTV
+      let result: any[] = [];
+      await s.query((e) => result.push(e), { stream: "ticker-VT." });
+      expect(result.length).toBe(2); // VTI and VTV
+
+      // Exact match: only ticker-VT
+      result = [];
+      await s.query((e) => result.push(e), {
+        stream: "ticker-VT",
+        stream_exact: true,
+      });
+      expect(result.length).toBe(1);
+      expect(result[0].data.a).toBe(1);
+
+      // Exact match: only ticker-VTI
+      result = [];
+      await s.query((e) => result.push(e), {
+        stream: "ticker-VTI",
+        stream_exact: true,
+      });
+      expect(result.length).toBe(1);
+      expect(result[0].data.a).toBe(2);
+    });
+
     it("should subscribe and claim streams", async () => {
       const s = store();
       const { subscribed } = await s.subscribe([{ stream: "L1" }]);


### PR DESCRIPTION
## Summary
- Adds `stream_exact` option to the `Query` type for exact stream name matching
- `load()` now uses `stream_exact: true` internally, preventing streams with similar prefixes (e.g. `ticker-VT` matching `ticker-VTI`) from polluting each other's state during event replay
- Both `InMemoryStore` and `PostgresStore` respect the new option (`===` and `=` respectively)
- `query_array()` keeps regex matching by default for backward compatibility

## Test plan
- [x] New test in `in-memory-store.spec.ts` verifying exact vs regex behavior
- [x] All 715 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)