### PR TITLE
feat(inspector): add CSV backup/restore and fix CORS

### DIFF
--- a/packages/inspector/src/client/components/BackupRestore.tsx
+++ b/packages/inspector/src/client/components/BackupRestore.tsx
@@ -1,0 +1,157 @@
+import { Download, Upload } from "lucide-react";
+import { useRef, useState } from "react";
+import { useFilterStore } from "../stores/filters.js";
+import { queryClient, trpc } from "../trpc.js";
+
+export function BackupRestore() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [filters] = useFilterStore();
+  const [restoring, setRestoring] = useState(false);
+  const [confirm, setConfirm] = useState<{
+    fileName: string;
+    csv: string;
+  } | null>(null);
+
+  const backupMutation = trpc.backup.useMutation({
+    onSuccess(data) {
+      const blob = new Blob([data.csv], { type: "text/csv" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+      a.download = `act-backup-${ts}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+  });
+
+  const restoreMutation = trpc.restore.useMutation({
+    onSuccess() {
+      setConfirm(null);
+      setRestoring(false);
+      void queryClient.invalidateQueries();
+    },
+    onError() {
+      setRestoring(false);
+    },
+  });
+
+  const handleBackup = () => {
+    const hasFilters =
+      filters.stream ||
+      (filters.names && filters.names.length > 0) ||
+      filters.created_after ||
+      filters.created_before ||
+      filters.correlation;
+
+    backupMutation.mutate({
+      stream: filters.stream || undefined,
+      names:
+        filters.names && filters.names.length > 0 ? filters.names : undefined,
+      created_after: hasFilters ? filters.created_after : undefined,
+      created_before: hasFilters ? filters.created_before : undefined,
+      correlation: filters.correlation || undefined,
+    });
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setConfirm({ fileName: file.name, csv: reader.result as string });
+    };
+    reader.readAsText(file);
+    // Reset so the same file can be re-selected
+    e.target.value = "";
+  };
+
+  const handleRestore = () => {
+    if (!confirm) return;
+    setRestoring(true);
+    restoreMutation.mutate({ csv: confirm.csv });
+  };
+
+  return (
+    <>
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".csv"
+        className="hidden"
+        onChange={handleFileSelect}
+      />
+
+      <div className="flex items-center gap-1">
+        <button
+          onClick={handleBackup}
+          disabled={backupMutation.isPending}
+          title="Backup events to CSV"
+          className="rounded p-1.5 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300 disabled:opacity-50"
+        >
+          <Download size={14} />
+        </button>
+        <button
+          onClick={() => fileRef.current?.click()}
+          title="Restore events from CSV"
+          className="rounded p-1.5 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300"
+        >
+          <Upload size={14} />
+        </button>
+      </div>
+
+      {/* Confirmation dialog */}
+      {confirm && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/60"
+            onClick={() => !restoring && setConfirm(null)}
+          />
+          <div className="fixed inset-0 z-50 flex items-center justify-center">
+            <div className="w-96 rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl">
+              <h3 className="text-sm font-semibold text-zinc-200">
+                Restore from CSV
+              </h3>
+              <p className="mt-2 text-xs text-zinc-400">
+                This will{" "}
+                <span className="font-semibold text-red-400">
+                  delete all existing events
+                </span>{" "}
+                and replace them with the contents of:
+              </p>
+              <p className="mt-1 text-xs font-mono text-zinc-300">
+                {confirm.fileName}
+              </p>
+              <p className="mt-2 text-xs text-zinc-500">
+                Event IDs will be re-assigned starting from 1.
+              </p>
+
+              {restoreMutation.isError && (
+                <p className="mt-2 text-xs text-red-400">
+                  {restoreMutation.error.message}
+                </p>
+              )}
+
+              <div className="mt-4 flex justify-end gap-2">
+                <button
+                  onClick={() => setConfirm(null)}
+                  disabled={restoring}
+                  className="rounded-md border border-zinc-700 px-3 py-1.5 text-xs text-zinc-400 transition hover:bg-zinc-800 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleRestore}
+                  disabled={restoring}
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-red-500 disabled:opacity-50"
+                >
+                  {restoring ? "Restoring..." : "Delete & Restore"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/inspector/src/client/components/Header.tsx
+++ b/packages/inspector/src/client/components/Header.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronLeft, ChevronRight, Radio } from "lucide-react";
 import { useState } from "react";
 import { viewCaption, type ViewState } from "../App.js";
+import { BackupRestore } from "./BackupRestore.js";
 import { Logo } from "./Logo.js";
 
 const POLL_OPTIONS = [
@@ -154,6 +155,9 @@ export function Header({
             ))}
           </div>
         )}
+
+        {/* Backup/Restore */}
+        {connected && <BackupRestore />}
 
         {connected ? (
           <button

--- a/packages/inspector/src/client/trpc.ts
+++ b/packages/inspector/src/client/trpc.ts
@@ -21,7 +21,7 @@ export const queryClient = new QueryClient({
 export const trpcClient = trpc.createClient({
   links: [
     httpLink({
-      url: (import.meta.env.VITE_API_URL as string) || "http://localhost:4001",
+      url: (import.meta.env.VITE_API_URL as string) || "/trpc",
     }),
   ],
 });

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -259,6 +259,71 @@ async function discover(
   return stores;
 }
 
+/** CSV column order for backup/restore */
+const CSV_COLUMNS = [
+  "id",
+  "name",
+  "data",
+  "stream",
+  "version",
+  "created",
+  "meta",
+] as const;
+
+/** Escape a value for CSV (RFC 4180) */
+function csvEscape(value: string): string {
+  if (value.includes('"') || value.includes(",") || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Parse a CSV line respecting quoted fields */
+function csvParseLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      fields.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+/** Get a raw pg client for direct queries */
+async function getRawClient(): Promise<pg.Client> {
+  if (!currentConfig) throw new Error("Not connected to a store");
+  const client = new pg.Client({
+    host: currentConfig.host,
+    port: currentConfig.port,
+    database: currentConfig.database,
+    user: currentConfig.user,
+    password: currentConfig.password,
+    connectionTimeoutMillis: 5000,
+  });
+  await client.connect();
+  return client;
+}
+
 export const inspectorRouter = t.router({
   /** Scan host for PG servers and discover Act event stores */
   discover: t.procedure
@@ -632,6 +697,111 @@ export const inspectorRouter = t.router({
       if (pgClient) await pgClient.end();
     }
   }),
+
+  /** Export events as CSV rows */
+  backup: t.procedure
+    .input(
+      z.object({
+        stream: z.string().optional(),
+        names: z.string().array().optional(),
+        created_before: z.string().optional(),
+        created_after: z.string().optional(),
+        correlation: z.string().optional(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const s = getStore();
+      const events: AnyEvent[] = [];
+      await s.query<Schemas>(collect(events), {
+        ...input,
+        created_before: toDate(input.created_before),
+        created_after: toDate(input.created_after),
+        with_snaps: true,
+      });
+
+      // Build CSV
+      const header = CSV_COLUMNS.join(",");
+      const rows = events.map((e) =>
+        CSV_COLUMNS.map((col) => {
+          const val = e[col as keyof typeof e];
+          if (col === "data" || col === "meta")
+            return csvEscape(JSON.stringify(val));
+          if (val instanceof Date) return csvEscape(val.toISOString());
+          return csvEscape(
+            typeof val === "object" && val !== null
+              ? JSON.stringify(val)
+              : String(val as string | number | boolean)
+          );
+        }).join(",")
+      );
+
+      return { csv: [header, ...rows].join("\n"), count: events.length };
+    }),
+
+  /** Restore events from CSV — drops and re-seeds the store, inserts with sequential IDs */
+  restore: t.procedure
+    .input(z.object({ csv: z.string() }))
+    .mutation(async ({ input }) => {
+      if (!currentConfig) throw new Error("Not connected to a store");
+      const fqt = `"${currentConfig.schema}"."${currentConfig.table}"`;
+      const fqs = `"${currentConfig.schema}"."${currentConfig.table}_streams"`;
+
+      // Parse CSV
+      const lines = input.csv.split("\n").filter((l) => l.trim());
+      if (lines.length < 2)
+        throw new Error("CSV must have a header and at least one row");
+
+      const headerFields = lines[0].split(",");
+      const expectedHeader = CSV_COLUMNS.join(",");
+      if (headerFields.join(",") !== expectedHeader)
+        throw new Error(`Invalid CSV header. Expected: ${expectedHeader}`);
+
+      const rows = lines.slice(1).map((line, lineIdx) => {
+        const fields = csvParseLine(line);
+        if (fields.length !== CSV_COLUMNS.length)
+          throw new Error(
+            `Row ${lineIdx + 1}: expected ${CSV_COLUMNS.length} fields, got ${fields.length}`
+          );
+        return {
+          name: fields[1],
+          data: JSON.parse(fields[2]),
+          stream: fields[3],
+          version: parseInt(fields[4], 10),
+          created: fields[5],
+          meta: JSON.parse(fields[6]),
+        };
+      });
+
+      // Drop existing data and re-seed
+      const client = await getRawClient();
+      try {
+        await client.query("BEGIN");
+
+        // Truncate events and streams tables, reset sequence
+        await client.query(`TRUNCATE TABLE ${fqt} RESTART IDENTITY CASCADE`);
+        await client.query(`TRUNCATE TABLE ${fqs}`);
+
+        // Insert events preserving original order (new sequential IDs from 1)
+        for (const row of rows) {
+          await client.query(
+            `INSERT INTO ${fqt}(name, data, stream, version, created, meta)
+             VALUES($1, $2, $3, $4, $5, $6)`,
+            [row.name, row.data, row.stream, row.version, row.created, row.meta]
+          );
+        }
+
+        await client.query("COMMIT");
+        return { ok: true as const, count: rows.length };
+      } catch (error) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw new Error(
+          `Restore failed: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error }
+        );
+      } finally {
+        await client.end();
+      }
+    }),
 });
 
 export type InspectorRouter = typeof inspectorRouter;

--- a/packages/inspector/src/server/server.ts
+++ b/packages/inspector/src/server/server.ts
@@ -6,7 +6,16 @@ const PORT = parseInt(process.env.PORT || "4001", 10);
 
 const server = createHTTPServer({
   middleware: cors({
-    origin: process.env.CORS_ORIGIN || "http://localhost:3001",
+    origin: (origin, callback) => {
+      const allowed = process.env.CORS_ORIGIN;
+      if (allowed) {
+        callback(null, origin === allowed);
+      } else {
+        // In dev, allow any localhost origin (port may vary)
+        const ok = !origin || /^https?:\/\/localhost(:\d+)?$/.test(origin);
+        callback(null, ok);
+      }
+    },
   }),
   router: inspectorRouter,
 });

--- a/packages/inspector/src/server/server.ts
+++ b/packages/inspector/src/server/server.ts
@@ -6,7 +6,7 @@ const PORT = parseInt(process.env.PORT || "4001", 10);
 
 const server = createHTTPServer({
   middleware: cors({
-    origin: process.env.CORS_ORIGIN || "http://localhost:5174",
+    origin: process.env.CORS_ORIGIN || "http://localhost:3001",
   }),
   router: inspectorRouter,
 });

--- a/packages/inspector/vite.config.ts
+++ b/packages/inspector/vite.config.ts
@@ -2,9 +2,18 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const API_URL = process.env.VITE_API_URL || "http://localhost:4001";
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     port: 3001,
+    proxy: {
+      "/trpc": {
+        target: API_URL,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/trpc/, ""),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Add backup/restore feature to export events as CSV and restore them to a store (clearing existing data, re-sequencing IDs from 1)
- Backup respects current filter bar selections (stream, event names, time range, correlation) — no filters = export all
- Restore truncates events + streams tables with `RESTART IDENTITY`, then re-inserts preserving original event data/versions
- Fix CORS origin mismatch (was port 5174, client dev server runs on 3001)

## Test plan
- [ ] Connect to a PG store with events, click download icon — verify CSV downloads with correct columns
- [ ] Apply filters (stream, event name) then backup — verify only filtered events exported
- [ ] Upload the CSV via upload icon — verify confirmation dialog warns about deletion
- [ ] Confirm restore — verify events table is repopulated with IDs starting from 1
- [ ] Verify scan/discover works after CORS fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)