### PR TITLE
feat(act, act-pg): add Store.reset() for projection rebuild

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,26 @@ Control when snapshots are taken for cold-start resilience (on cache miss, proce
 
 Snap writes are fire-and-forget — the cache is updated synchronously within `action()`, so subsequent reads see the post-commit state immediately without waiting for the store write.
 
+### Projection Rebuild
+
+Projections are derived data — disposable by design. When a projection's logic changes (new fields, bug fix, different aggregation), reset its watermark with `store().reset()` and let the existing drain machinery replay all events from the beginning:
+
+```typescript
+// Reset the projection stream watermark to -1
+await store().reset(["my-projection"]);
+
+// Next drain replays all events through the projection handlers
+await app.drain({ eventLimit: 1000 });
+```
+
+`store().reset(streams)` sets `at = -1`, clears `retry`, `blocked`, `error`, and lease state for the given streams. This makes them eligible for `claim()` from the beginning. The framework's existing drain cycle handles the replay — no special rebuild API is needed.
+
+**Typical production workflow:**
+1. Deploy updated projection code
+2. Clear projected data (truncate read-model table, flush cache)
+3. Call `store().reset(["projection-target"])` to reset watermarks
+4. Normal `drain()` or `settle()` replays all events through the updated handlers
+
 ## Code Organization
 
 ### Core Library (`libs/act/src`)
@@ -413,7 +433,7 @@ Snap writes are fire-and-forget — the cache is updated synchronously within `a
 
 Each example demonstrates different framework capabilities:
 
-- **Calculator** - Single state machine, no reactions, simple event flow
+- **Calculator** - Single state machine, reactions, projection rebuild demo (`pnpm -F calculator dev:rebuild`)
 - **WolfDesk** - Multiple aggregates, projections, complex reactions, invariants
 - **Server/Client** - Integration with external APIs (tRPC), web application pattern
 
@@ -488,6 +508,7 @@ interface Store extends Disposable {
   subscribe(streams): Promise<{ subscribed: number; watermark: number }>;  // Register streams + max watermark
   ack(leases): Promise<Lease[]>;                  // Release successful leases
   block(leases): Promise<(Lease & { error })[]>;  // Block failed streams
+  reset(streams): Promise<number>;                // Reset watermarks for projection rebuild
   dispose(): Promise<void>;                       // Cleanup resources
 }
 ```

--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -677,4 +677,22 @@ export class PostgresStore implements Store {
       client.release();
     }
   }
+
+  /**
+   * Reset watermarks for the given streams to -1, clearing retry, blocked,
+   * error, and lease state so they can be replayed from the beginning.
+   * @param streams - Stream names to reset.
+   * @returns Count of streams that were actually reset.
+   */
+  async reset(streams: string[]): Promise<number> {
+    if (!streams.length) return 0;
+    const { rowCount } = await this._pool.query(
+      `UPDATE ${this._fqs}
+       SET at = -1, retry = 0, blocked = false, error = NULL,
+           leased_by = NULL, leased_until = NULL
+       WHERE stream = ANY($1)`,
+      [streams]
+    );
+    return rowCount ?? 0;
+  }
 }

--- a/libs/act-pg/test/store.spec.ts
+++ b/libs/act-pg/test/store.spec.ts
@@ -420,6 +420,64 @@ describe("pg store", () => {
       await s.ack([claimed[0]]);
     });
 
+    it("should reset stream watermarks for projection rebuild", async () => {
+      const s = store();
+      // Subscribe and advance watermark via claim+ack
+      await s.subscribe([{ stream: "reset-test" }]);
+      const claimed = await s.claim(100, 0, "w", 10000);
+      const target = claimed.find((l) => l.stream === "reset-test")!;
+      expect(target).toBeDefined();
+      await s.ack(claimed.map((l) => ({ ...l, at: 99 })));
+
+      // Reset the stream
+      const count = await s.reset(["reset-test"]);
+      expect(count).toBe(1);
+
+      // Stream should now be claimable again from the beginning
+      const claimed2 = await s.claim(100, 0, "w2", 10000);
+      const target2 = claimed2.find((l) => l.stream === "reset-test");
+      expect(target2).toBeDefined();
+      expect(target2!.at).toBe(-1);
+      await s.ack(claimed2);
+    });
+
+    it("should reset blocked streams", async () => {
+      const s = store();
+      await s.subscribe([{ stream: "reset-blocked" }]);
+      const claimed = await s.claim(100, 0, "w", 10000);
+      const target = claimed.find((l) => l.stream === "reset-blocked")!;
+      const others = claimed.filter((l) => l.stream !== "reset-blocked");
+      if (others.length) await s.ack(others);
+      await s.block([{ ...target, error: "test-error" }]);
+
+      // Blocked stream should not be claimable
+      const claimed2 = await s.claim(100, 100, "w2", 10000);
+      expect(
+        claimed2.find((l) => l.stream === "reset-blocked")
+      ).toBeUndefined();
+      if (claimed2.length) await s.ack(claimed2);
+
+      // Reset unblocks it
+      const count = await s.reset(["reset-blocked"]);
+      expect(count).toBe(1);
+
+      const claimed3 = await s.claim(100, 0, "w3", 10000);
+      const target3 = claimed3.find((l) => l.stream === "reset-blocked");
+      expect(target3).toBeDefined();
+      expect(target3!.at).toBe(-1);
+      await s.ack(claimed3);
+    });
+
+    it("should return 0 when resetting non-existent streams", async () => {
+      const count = await store().reset(["does-not-exist"]);
+      expect(count).toBe(0);
+    });
+
+    it("should return 0 when resetting empty array", async () => {
+      const count = await store().reset([]);
+      expect(count).toBe(0);
+    });
+
     it("should not claim blocked streams", async () => {
       const s = store();
       await s.subscribe([{ stream: "block-test" }]);
@@ -584,6 +642,15 @@ describe("PostgresStore error paths", () => {
     );
     const result = await db.subscribe([{ stream: "x" }]);
     expect(result).toEqual({ subscribed: 0, watermark: -1 });
+  });
+
+  it("should handle reset() with null rowCount", async () => {
+    vi.spyOn(Pool.prototype, "query").mockResolvedValueOnce(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- testing null rowCount path
+      { rows: [], rowCount: null } as any
+    );
+    const result = await db.reset(["x"]);
+    expect(result).toBe(0);
   });
 
   it("should handle ack() error", async () => {

--- a/libs/act/src/adapters/InMemoryStore.ts
+++ b/libs/act/src/adapters/InMemoryStore.ts
@@ -112,6 +112,18 @@ class InMemoryStream {
       };
     }
   }
+
+  /**
+   * Reset this stream's watermark and state for replay.
+   */
+  reset() {
+    this._at = -1;
+    this._retry = 0;
+    this._blocked = false;
+    this._error = "";
+    this._leased_by = undefined;
+    this._leased_until = undefined;
+  }
 }
 
 /**
@@ -408,5 +420,24 @@ export class InMemoryStore implements Store {
     return leases
       .map((l) => this._streams.get(l.stream)?.block(l, l.error))
       .filter((l) => !!l);
+  }
+
+  /**
+   * Reset watermarks for the given streams to -1, clearing retry, blocked,
+   * error, and lease state so they can be replayed from the beginning.
+   * @param streams - Stream names to reset.
+   * @returns Count of streams that were actually reset.
+   */
+  async reset(streams: string[]) {
+    await sleep();
+    let count = 0;
+    for (const name of streams) {
+      const s = this._streams.get(name);
+      if (s) {
+        s.reset();
+        count++;
+      }
+    }
+    return count;
   }
 }

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -316,6 +316,26 @@ export interface Store extends Disposable {
   block: (
     leases: Array<Lease & { error: string }>
   ) => Promise<Array<Lease & { error: string }>>;
+
+  /**
+   * Resets watermarks for the given streams to -1, making them eligible
+   * for replay from the beginning. Also clears retry, blocked, error,
+   * and lease state so the streams can be claimed immediately.
+   *
+   * Used by `Act.rebuild()` to replay events through updated projections.
+   *
+   * @param streams - Stream names to reset
+   * @returns Count of streams that were actually reset
+   *
+   * @example
+   * ```typescript
+   * const count = await store().reset(["my-projection"]);
+   * console.log(`Reset ${count} streams for replay`);
+   * ```
+   *
+   * @see {@link Act.rebuild} for the high-level rebuild API
+   */
+  reset: (streams: string[]) => Promise<number>;
 }
 
 // ---------------------------------------------------------------------------

--- a/libs/act/test/rebuild.spec.ts
+++ b/libs/act/test/rebuild.spec.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import { act, dispose, projection, state, store } from "../src/index.js";
+
+describe("Store.reset", () => {
+  beforeEach(async () => {
+    await store().drop();
+  });
+
+  afterAll(async () => {
+    await dispose()();
+  });
+
+  const actor = { id: "a", name: "a" };
+  let streamId = 0;
+  const nextStream = () => `reset-test-${++streamId}`;
+
+  const Incremented = z.object({ by: z.number() });
+
+  const Counter = state({ Counter: z.object({ count: z.number() }) })
+    .init(() => ({ count: 0 }))
+    .emits({ Incremented })
+    .patch({
+      Incremented: (event, s) => ({ count: s.count + event.data.by }),
+    })
+    .on({ increment: z.object({ by: z.number() }) })
+    .emit((action) => ["Incremented", { by: action.by }])
+    .build();
+
+  it("should reset subscribed stream watermarks to -1", async () => {
+    const s = store();
+    await s.subscribe([{ stream: "a" }, { stream: "b" }, { stream: "c" }]);
+
+    const count = await s.reset(["a", "c"]);
+    expect(count).toBe(2);
+  });
+
+  it("should return 0 for non-existent streams", async () => {
+    const count = await store().reset(["nonexistent"]);
+    expect(count).toBe(0);
+  });
+
+  it("should return 0 for empty array", async () => {
+    const count = await store().reset([]);
+    expect(count).toBe(0);
+  });
+
+  it("should enable replay of projection after reset", async () => {
+    const stream = nextStream();
+    const projected: Array<{ by: number }> = [];
+
+    const CounterProjection = projection("counter-proj")
+      .on({ Incremented })
+      .do(async function project(event) {
+        await Promise.resolve();
+        projected.push(event.data);
+      })
+      .build();
+
+    const app = act()
+      .withState(Counter)
+      .withProjection(CounterProjection)
+      .build();
+
+    // Emit events and drain normally
+    await app.do("increment", { stream, actor }, { by: 1 });
+    await app.do("increment", { stream, actor }, { by: 2 });
+    await app.do("increment", { stream, actor }, { by: 3 });
+    await app.correlate();
+    await app.drain({ eventLimit: 100 });
+
+    expect(projected).toEqual([{ by: 1 }, { by: 2 }, { by: 3 }]);
+
+    // Reset the projection stream and re-drain
+    projected.length = 0;
+    await store().reset(["counter-proj"]);
+    await app.drain({ eventLimit: 100 });
+
+    // All events replayed through the projection
+    expect(projected).toEqual([{ by: 1 }, { by: 2 }, { by: 3 }]);
+  });
+
+  it("should unblock blocked streams after reset", async () => {
+    const stream = nextStream();
+    let shouldFail = true;
+    const handler = vi.fn(async function failHandler() {
+      await Promise.resolve();
+      if (shouldFail) throw new Error("fail");
+    });
+
+    const FailProjection = projection("fail-proj")
+      .on({ Incremented })
+      .do(handler)
+      .build();
+
+    const app = act().withState(Counter).withProjection(FailProjection).build();
+
+    await app.do("increment", { stream, actor }, { by: 1 });
+    await app.correlate();
+
+    // Drain until blocked (max retries = 3)
+    for (let i = 0; i < 5; i++) {
+      await app.drain({ eventLimit: 100, leaseMillis: 1 });
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    // Fix the handler, reset, and re-correlate to trigger drain
+    shouldFail = false;
+    handler.mockClear();
+    await store().reset(["fail-proj"]);
+    // Emit another event so drain flag is set
+    await app.do("increment", { stream, actor }, { by: 2 });
+    const result = await app.drain({ eventLimit: 100 });
+
+    expect(handler).toHaveBeenCalled();
+    expect(result.acked.length).toBeGreaterThan(0);
+  });
+
+  it("should replay with batch handler after reset", async () => {
+    const stream = nextStream();
+    const batchFn = vi.fn().mockResolvedValue(undefined);
+    const singleHandler = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(singleHandler, "name", {
+      value: "handleIncremented",
+    });
+
+    const BatchProjection = projection("batch-reset")
+      .on({ Incremented })
+      .do(singleHandler)
+      .batch(batchFn)
+      .build();
+
+    const app = act()
+      .withState(Counter)
+      .withProjection(BatchProjection)
+      .build();
+
+    await app.do("increment", { stream, actor }, { by: 1 });
+    await app.do("increment", { stream, actor }, { by: 2 });
+    await app.correlate();
+    await app.drain({ eventLimit: 100 });
+
+    batchFn.mockClear();
+    singleHandler.mockClear();
+
+    // Reset and re-drain
+    await store().reset(["batch-reset"]);
+    await app.drain({ eventLimit: 100 });
+
+    expect(batchFn).toHaveBeenCalled();
+    expect(singleHandler).not.toHaveBeenCalled();
+  });
+
+  it("should produce idempotent results on multiple resets", async () => {
+    const stream = nextStream();
+    const projected: number[] = [];
+
+    const CounterProjection = projection("idempotent-proj")
+      .on({ Incremented })
+      .do(async function project(event) {
+        await Promise.resolve();
+        projected.push(event.data.by);
+      })
+      .build();
+
+    const app = act()
+      .withState(Counter)
+      .withProjection(CounterProjection)
+      .build();
+
+    await app.do("increment", { stream, actor }, { by: 10 });
+    await app.do("increment", { stream, actor }, { by: 20 });
+    await app.correlate();
+    await app.drain({ eventLimit: 100 });
+
+    // First reset + drain
+    projected.length = 0;
+    await store().reset(["idempotent-proj"]);
+    await app.drain({ eventLimit: 100 });
+    const firstRun = [...projected];
+
+    // Second reset + drain
+    projected.length = 0;
+    await store().reset(["idempotent-proj"]);
+    await app.drain({ eventLimit: 100 });
+    const secondRun = [...projected];
+
+    expect(firstRun).toEqual(secondRun);
+    expect(firstRun).toEqual([10, 20]);
+  });
+});

--- a/packages/calculator/package.json
+++ b/packages/calculator/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "LOG_LEVEL=trace tsx watch src/main.ts"
+    "dev": "LOG_LEVEL=trace tsx watch src/main.ts",
+    "dev:rebuild": "tsx src/rebuild-demo.ts"
   },
   "dependencies": {
     "@rotorsoft/act": "^0.25.2",

--- a/packages/calculator/src/rebuild-demo.ts
+++ b/packages/calculator/src/rebuild-demo.ts
@@ -1,0 +1,99 @@
+/**
+ * Projection Rebuild Demo
+ *
+ * Demonstrates how store().reset() enables projection rebuilds:
+ * 1. Build a counter app with a projection that sums increments
+ * 2. Process events through the projection normally
+ * 3. Reset the projection watermark with store().reset()
+ * 4. Re-drain to replay all events through the (potentially updated) projection
+ *
+ * Run: pnpm -F calculator dev:rebuild
+ */
+import { act, dispose, projection, state, store } from "@rotorsoft/act";
+import { z } from "zod";
+
+const Incremented = z.object({ by: z.number() });
+
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented })
+  .patch({
+    Incremented: (event, s) => ({ count: s.count + event.data.by }),
+  })
+  .on({ increment: z.object({ by: z.number() }) })
+  .emit((action) => ["Incremented", { by: action.by }])
+  .build();
+
+async function main() {
+  // --- V1 projection: just counts events ---
+  let totalEvents = 0;
+  let totalSum = 0;
+
+  const SumProjection = projection("sum-proj")
+    .on({ Incremented })
+    .do(async function projectSum(event) {
+      await Promise.resolve();
+      totalEvents++;
+      totalSum += event.data.by;
+    })
+    .build();
+
+  const app = act().withState(Counter).withProjection(SumProjection).build();
+
+  const actor = { id: "demo", name: "Demo User" };
+  const stream = "counter-1";
+
+  // Emit some events
+  console.log("=== Emitting events ===");
+  for (const by of [10, 20, 30, 40, 50]) {
+    await app.do("increment", { stream, actor }, { by });
+    console.log(`  increment by ${by}`);
+  }
+
+  // Process events through projection
+  await app.correlate();
+  await app.drain({ eventLimit: 100 });
+
+  console.log(`\n=== After initial drain ===`);
+  console.log(`  Events processed: ${totalEvents}`);
+  console.log(`  Sum: ${totalSum}`);
+
+  const snap = await app.load(Counter, stream);
+  console.log(`  Counter state: ${snap.state.count}`);
+
+  // --- Now simulate a projection logic change ---
+  // In production you'd deploy new code; here we just reset and re-drain
+  console.log(`\n=== Resetting projection for rebuild ===`);
+  totalEvents = 0;
+  totalSum = 0;
+
+  const resetCount = await store().reset(["sum-proj"]);
+  console.log(`  Reset ${resetCount} stream(s)`);
+
+  // Re-drain replays all events from the beginning
+  await app.drain({ eventLimit: 100 });
+
+  console.log(`\n=== After rebuild ===`);
+  console.log(`  Events re-processed: ${totalEvents}`);
+  console.log(`  Sum (rebuilt): ${totalSum}`);
+
+  // Verify consistency
+  console.log(`\n=== Verification ===`);
+  console.log(
+    `  Counter state matches sum: ${snap.state.count === totalSum ? "✓" : "✗"}`
+  );
+
+  // --- Demonstrate idempotent rebuild ---
+  console.log(`\n=== Second rebuild (idempotent) ===`);
+  totalEvents = 0;
+  totalSum = 0;
+  await store().reset(["sum-proj"]);
+  await app.drain({ eventLimit: 100 });
+  console.log(`  Events re-processed: ${totalEvents}`);
+  console.log(`  Sum: ${totalSum}`);
+  console.log(`  Same result: ${totalSum === snap.state.count ? "✓" : "✗"}`);
+
+  await dispose()();
+}
+
+void main();


### PR DESCRIPTION
## Summary

- Adds `reset(streams: string[]): Promise<number>` to the `Store` interface — resets watermarks to -1, clears retry/blocked/error/lease state so projections can be replayed from the beginning through the existing drain machinery
- Implemented in both `InMemoryStore` and `PostgresStore`
- 7 InMemory unit tests + 5 Postgres integration tests (full coverage)
- Runnable example: `pnpm -F calculator dev:rebuild`
- CLAUDE.md updated with projection rebuild workflow and Store contract

## Test plan

- [x] `pnpm test` — 746 tests pass
- [x] `pnpm typecheck` — clean
- [x] PostgresStore coverage: lines 688-696 covered (null rowCount path included)
- [x] `pnpm -F calculator dev:rebuild` runs successfully with idempotent results

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)