### PR TITLE
feat(act): idempotent actions via correlation-based deduplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,25 @@ Dynamic stream discovery through correlation metadata:
 
 **Drain optimization:** At build time, `_reactive_events` collects event names with at least one registered reaction. In `do()`, the `_needs_drain` flag is set when a committed event matches. `drain()` returns immediately when the flag is false — saving 3 DB round-trips (claim, query, ack) per non-reactive cycle. The flag clears only when drain completes with nothing acked, blocked, or errored. Cold start sets the flag in `_init_correlation()` to process historical events. Default `maxPasses` is 1 (single correlate→drain pass per settle).
 
+### Idempotent Actions via Correlation
+
+Client retries over unreliable networks can cause duplicate action execution. Act solves this by reusing the existing `correlation` field in event metadata — no dedicated deduplication tables, TTL, or cleanup required.
+
+Provide a `correlation` ID on the `Target`. Before executing, `action()` queries for existing events with that correlation on the stream. If found, the original events are returned without re-executing:
+
+```typescript
+await app.do("TransferFunds", {
+  stream: "account-42",
+  actor,
+  correlation: "transfer-req-abc-123",  // client-generated, unique per logical request
+}, { amount: 1000 });
+```
+
+- Without `correlation`: current behavior (auto-generated UUID, no dedup check)
+- Same correlation + same stream: returns original events, no re-execution
+- Same correlation + different stream: both execute (correlation is scoped to stream by query)
+- Correlation lives forever in the immutable event log — no TTL needed
+
 ### Invariants
 
 Business rules enforced before actions execute:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ Reactions are processed by polling (`drain()`), not by pub/sub. The store's `cla
 
 At build time, reaction resolvers are classified as static (known target) or dynamic (function). Static targets are subscribed once at init. Dynamic targets are discovered by `correlate()`, which scans new events and registers target streams. When no dynamic resolvers exist, correlation is skipped entirely — zero overhead.
 
+### Idempotency via Correlation, Not Deduplication Tables
+
+Other frameworks (Axon, Eventuous, Marten) use dedicated deduplication stores with TTL and cleanup. Act reuses the existing `correlation` field in event metadata. Provide a client-generated correlation ID on the target — if events with that correlation already exist on the stream, the original events are returned without re-executing the action:
+
+```ts
+// First call — executes normally
+await app.do("TransferFunds", {
+  stream: "account-42", actor,
+  correlation: "transfer-req-abc-123",
+}, { amount: 1000 });
+
+// Retry — returns original events, no re-execution
+await app.do("TransferFunds", {
+  stream: "account-42", actor,
+  correlation: "transfer-req-abc-123",
+}, { amount: 1000 });
+```
+
+No new tables, no TTL, no cleanup — the correlation lives in the immutable event log.
+
 ### Vertical Slices, Not Layers
 
 `slice()` groups a partial state with its reactions into a self-contained feature module. Each slice owns its actions, events, patches, and reaction handlers. Slices compose into the full application via `act().withSlice()`. This keeps related code together instead of scattering it across service/repository/handler layers.

--- a/libs/act/src/event-sourcing.ts
+++ b/libs/act/src/event-sourcing.ts
@@ -150,8 +150,30 @@ export async function action<
   reactingTo?: Committed<Schemas, keyof Schemas>,
   skipValidation = false
 ): Promise<Snapshot<TState, TEvents>[]> {
-  const { stream, expectedVersion, actor } = target;
+  const { stream, expectedVersion, actor, correlation } = target;
   if (!stream) throw new Error("Missing target stream");
+
+  // Idempotency check: if correlation is provided, look for existing events
+  if (correlation) {
+    const existing: Committed<TEvents, keyof TEvents>[] = [];
+    await store().query<TEvents>((e) => existing.push(e), {
+      stream,
+      correlation,
+      stream_exact: true,
+    });
+    if (existing.length) {
+      logger.trace(
+        `🔵 ${stream}.${action as string} deduplicated (correlation: ${correlation})`
+      );
+      const snap = await load(me, stream);
+      return existing.map((event) => ({
+        event: event as Committed<TEvents, string>,
+        state: snap.state,
+        patches: snap.patches,
+        snaps: snap.snaps,
+      }));
+    }
+  }
 
   payload = skipValidation
     ? payload
@@ -199,7 +221,7 @@ export async function action<
   }));
 
   const meta: EventMeta = {
-    correlation: reactingTo?.meta.correlation || randomUUID(),
+    correlation: correlation || reactingTo?.meta.correlation || randomUUID(),
     causation: {
       action: {
         name: action as string,

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -71,6 +71,17 @@ export type Target<TActor extends Actor = Actor> = {
   readonly stream: string;
   readonly actor: TActor;
   readonly expectedVersion?: number;
+  /**
+   * Client-provided correlation ID for idempotent retries.
+   *
+   * When provided, `action()` checks if events with this correlation
+   * already exist on the stream. If found, the original events are
+   * returned without re-executing the action. This enables safe
+   * client retries over unreliable networks.
+   *
+   * When omitted, a random UUID is generated automatically.
+   */
+  readonly correlation?: string;
 };
 
 /**

--- a/libs/act/test/idempotency.spec.ts
+++ b/libs/act/test/idempotency.spec.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import { act, dispose, state, store } from "../src/index.js";
+
+describe("idempotency", () => {
+  beforeEach(async () => {
+    await store().drop();
+  });
+
+  afterAll(async () => {
+    await dispose()();
+  });
+
+  const actor = { id: "a", name: "a" };
+  let streamId = 0;
+  const nextStream = () => `idemp-test-${++streamId}`;
+
+  const Incremented = z.object({ by: z.number() });
+  const Counter = state({ Counter: z.object({ count: z.number() }) })
+    .init(() => ({ count: 0 }))
+    .emits({ Incremented })
+    .patch({
+      Incremented: ({ data }, s) => ({ count: s.count + data.by }),
+    })
+    .on({ increment: z.object({ by: z.number() }) })
+    .emit((action) => ["Incremented", { by: action.by }])
+    .build();
+
+  it("should execute action normally with correlation", async () => {
+    const stream = nextStream();
+    const app = act().withState(Counter).build();
+
+    const result = await app.do(
+      "increment",
+      { stream, actor, correlation: "req-1" },
+      { by: 5 }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].state.count).toBe(5);
+    expect(result[0].event!.meta.correlation).toBe("req-1");
+  });
+
+  it("should return original events on duplicate correlation", async () => {
+    const stream = nextStream();
+    const app = act().withState(Counter).build();
+
+    const first = await app.do(
+      "increment",
+      { stream, actor, correlation: "req-dup" },
+      { by: 10 }
+    );
+
+    // Retry with same correlation — should return original, not re-execute
+    const retry = await app.do(
+      "increment",
+      { stream, actor, correlation: "req-dup" },
+      { by: 10 }
+    );
+
+    expect(retry).toHaveLength(1);
+    expect(retry[0].event!.id).toBe(first[0].event!.id);
+    expect(retry[0].state.count).toBe(10); // not 20
+
+    // Verify only one event was committed
+    const events = await app.query_array({ stream, stream_exact: true });
+    expect(events).toHaveLength(1);
+  });
+
+  it("should allow same correlation on different streams", async () => {
+    const stream1 = nextStream();
+    const stream2 = nextStream();
+    const app = act().withState(Counter).build();
+
+    await app.do(
+      "increment",
+      { stream: stream1, actor, correlation: "shared-corr" },
+      { by: 1 }
+    );
+
+    await app.do(
+      "increment",
+      { stream: stream2, actor, correlation: "shared-corr" },
+      { by: 2 }
+    );
+
+    const snap1 = await app.load(Counter, stream1);
+    const snap2 = await app.load(Counter, stream2);
+    expect(snap1.state.count).toBe(1);
+    expect(snap2.state.count).toBe(2);
+  });
+
+  it("should not deduplicate when no correlation is provided", async () => {
+    const stream = nextStream();
+    const app = act().withState(Counter).build();
+
+    await app.do("increment", { stream, actor }, { by: 5 });
+    await app.do("increment", { stream, actor }, { by: 5 });
+
+    const snap = await app.load(Counter, stream);
+    expect(snap.state.count).toBe(10); // both executed
+  });
+
+  it("should deduplicate multiple events from same action", async () => {
+    const Doubled = z.object({ a: z.number(), b: z.number() });
+    const Multi = state({ Multi: z.object({ total: z.number() }) })
+      .init(() => ({ total: 0 }))
+      .emits({ Doubled })
+      .patch({
+        Doubled: ({ data }, s) => ({ total: s.total + data.a + data.b }),
+      })
+      .on({ doubleInc: z.object({ a: z.number(), b: z.number() }) })
+      .emit((action) => [
+        ["Doubled", { a: action.a, b: action.b }],
+        ["Doubled", { a: action.a, b: action.b }],
+      ])
+      .build();
+
+    const stream = nextStream();
+    const app = act().withState(Multi).build();
+
+    const first = await app.do(
+      "doubleInc",
+      { stream, actor, correlation: "multi-1" },
+      { a: 3, b: 4 }
+    );
+    expect(first).toHaveLength(2);
+
+    // Retry
+    const retry = await app.do(
+      "doubleInc",
+      { stream, actor, correlation: "multi-1" },
+      { a: 3, b: 4 }
+    );
+    expect(retry).toHaveLength(2);
+    expect(retry[0].event!.id).toBe(first[0].event!.id);
+    expect(retry[1].event!.id).toBe(first[1].event!.id);
+
+    // Only 2 events total, not 4
+    const events = await app.query_array({ stream, stream_exact: true });
+    expect(events).toHaveLength(2);
+  });
+
+  it("should store provided correlation in event metadata", async () => {
+    const stream = nextStream();
+    const app = act().withState(Counter).build();
+
+    await app.do(
+      "increment",
+      { stream, actor, correlation: "my-custom-id" },
+      { by: 1 }
+    );
+
+    const events = await app.query_array({ stream, stream_exact: true });
+    expect(events[0].meta.correlation).toBe("my-custom-id");
+  });
+
+  it("should generate random correlation when not provided", async () => {
+    const stream = nextStream();
+    const app = act().withState(Counter).build();
+
+    await app.do("increment", { stream, actor }, { by: 1 });
+    await app.do("increment", { stream, actor }, { by: 2 });
+
+    const events = await app.query_array({ stream, stream_exact: true });
+    expect(events[0].meta.correlation).toBeDefined();
+    expect(events[1].meta.correlation).toBeDefined();
+    expect(events[0].meta.correlation).not.toBe(events[1].meta.correlation);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional `correlation` field to `Target` for safe client retries
- When provided, `action()` checks for existing events with that correlation on the stream before executing — if found, returns original events without re-execution
- Reuses the existing correlation field and index in event metadata — no new store methods, tables, TTL, or cleanup

Other frameworks (Axon, Eventuous, Marten) use dedicated deduplication stores with TTL and background cleanup. Act reuses what's already there — the correlation ID in the immutable event log.

## Test plan

- [x] `pnpm test` — 754 tests pass (7 new idempotency tests)
- [x] `pnpm typecheck` — clean
- [x] Tests cover: dedup on retry, different streams, no-correlation passthrough, multi-event actions, correlation in metadata

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)