### PR TITLE
feat(act): auto-inject reactingTo in reaction handlers

### DIFF
--- a/.claude/skills/scaffold-act-app/SKILL.md
+++ b/.claude/skills/scaffold-act-app/SKILL.md
@@ -177,7 +177,7 @@ For complete workspace configuration files, see [monorepo-template.md](monorepo-
 2. **Zod schemas mandatory** — All actions, events, and states require Zod schemas. Use `ZodEmpty` for empty payloads.
 3. **Actor context required** — Every `app.do()` needs `Target` with `{ stream, actor: { id, name } }`. Use `withActor<AppActor>()` to enforce typed actors.
 4. **Partial patches** — Patch handlers return only changed fields, not the full state.
-5. **Causation tracking** — Pass triggering event as 4th arg in reactions: `app.do(action, target, payload, event)`.
+5. **Causation tracking** — Inside reaction handlers, `app.do()` auto-injects the triggering event as `reactingTo`, maintaining the correlation chain by default. Pass an explicit `reactingTo` to override: `app.do(action, target, payload, customEvent)`.
 6. **Domain isolation** — `packages/domain` has zero infrastructure deps (except `@rotorsoft/act` and `zod`).
 7. **InMemoryStore + InMemoryCache for tests** — Default store and cache. Call `store().seed()` in `beforeEach` and `dispose()()` in `afterAll`. Call `clear*()` for each projection in `beforeEach`.
 8. **TypeScript strict mode** — All packages use `"strict": true`.

--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -442,8 +442,9 @@ const ItemSlice = slice()
   .withProjection(ItemProjection)  // embed projection (events must be subset of slice events)
   .on("ItemCreated")  // plain string, NOT record shorthand
     .do(async (event, stream, app) => {
-      // app implements IAct — dispatch actions, load state, query events
-      await app.do("SomeAction", { stream, actor: systemActor }, payload, event);
+      // app is a scoped IAct proxy — reactingTo auto-injected for correlation
+      await app.do("SomeAction", { stream, actor: systemActor }, payload);
+      // To override with a custom event: app.do(action, target, payload, customEvent)
       const snapshot = await app.load(Item, stream);
       const events = await app.query_array({ stream });
     })
@@ -456,7 +457,7 @@ const ItemSlice = slice()
 - `.withState(state)` — Register a partial state
 - `.withProjection(proj)` — Embed a built Projection (events must be a subset of slice events)
 - `.on(eventName)` — React to an event (string, not record)
-- `.do(handler)` — Handler receives `(event, stream, app)` where `app` implements `IAct` (do, load, query, query_array)
+- `.do(handler)` — Handler receives `(event, stream, app)` where `app` is a scoped `IAct` proxy (do, load, query, query_array). When `app.do()` is called without `reactingTo`, the triggering event is auto-injected to maintain the correlation chain. Pass an explicit `reactingTo` to override.
 - `.to(resolver)` — Set target stream resolver
 - `.build()` — Returns a `Slice` with `_tag: "Slice"`
 

--- a/.claude/skills/scaffold-act-app/domain.md
+++ b/.claude/skills/scaffold-act-app/domain.md
@@ -152,9 +152,10 @@ export const ItemSlice = slice()
   .withProjection(ItemProjection)
   .on("ItemCreated")  // plain string, NOT record shorthand
   .do(async function notify(event, stream, app) {
-    // app implements IAct — dispatch actions, load state, query events
-    // Pass event as 4th arg for causation tracking
-    await app.do("SomeAction", { stream, actor: systemActor }, payload, event);
+    // app is a scoped IAct proxy — dispatch actions, load state, query events
+    // reactingTo is auto-injected, maintaining the correlation chain
+    await app.do("SomeAction", { stream, actor: systemActor }, payload);
+    // To override with a custom event: app.do(action, target, payload, customEvent)
   })
   .to((event) => ({ target: event.stream }))  // target stream for drain processing
   .build();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ pnpm -F shared drizzle:migrate
    - Include resolver to determine target stream
    - Support retry and error handling
    - Enable event correlation and dynamic stream discovery
+   - **Auto-inject `reactingTo`**: When a reaction handler calls `app.do()` without the `reactingTo` parameter, the framework automatically injects the triggering event, maintaining the correlation chain by default. Pass an explicit `reactingTo` to override.
 
 ### State Builder Pattern
 
@@ -222,7 +223,8 @@ const CreationSlice = slice()
   .withProjection(TicketProjection)  // embed projection (events must be subset of slice events)
   .on("TicketOpened")
     .do(async (event, _stream, app) => {
-      await app.do("AssignTicket", target, payload, event);
+      // reactingTo is auto-injected — no need to pass event explicitly
+      await app.do("AssignTicket", target, payload);
       const snapshot = await app.load(TicketCreation, event.stream);
       const events = await app.query_array({ stream: event.stream });
     })
@@ -234,7 +236,7 @@ const CreationSlice = slice()
 - `.withState(state)` - Register a partial state (include all states whose actions handlers need)
 - `.withProjection(proj)` - Embed a built `Projection` within the slice. The projection's events must be a subset of the slice's state events (enforced at compile time). Projection handlers keep their `(event, stream)` signature — no app interface.
 - `.on(eventName)` - React to an event from the slice's states (string, not record)
-- `.do(handler)` - Handler receives `(event, stream, app)` where `app` implements `IAct` (do, load, query, query_array)
+- `.do(handler)` - Handler receives `(event, stream, app)` where `app` is a scoped `IAct` proxy (do, load, query, query_array). When `app.do()` is called without `reactingTo`, the triggering event is auto-injected to maintain the correlation chain. Pass an explicit `reactingTo` to override.
 - `.to(resolver)` - Set the target stream resolver
 - `.build()` - Returns a `Slice` with `_tag: "Slice"`
 
@@ -428,6 +430,7 @@ This enables high-throughput event processing with eventual consistency guarante
 Dynamic stream discovery through correlation metadata:
 
 - Each action/event includes `correlation` (request ID) and `causation` (what triggered it)
+- **Auto-injected `reactingTo`**: Inside reaction handlers, `app.do()` automatically uses the triggering event as `reactingTo` when omitted. This maintains the correlation chain without developer effort. Explicitly passing `reactingTo` overrides the default.
 - Reactions can discover new streams to process by querying uncommitted events
 - `app.correlate()` - Manual correlation; returns `{ subscribed, last_id }` where `subscribed` is the count of newly registered streams
 - `app.settle()` - Debounced, non-blocking correlate→drain loop; emits `"settled"` when done. Stops when `subscribed === 0` (no new streams discovered)

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -514,30 +514,33 @@ export class Act<
     lease.retry > 0 &&
       logger.warn(`Retrying ${stream}@${at} (${lease.retry}).`);
 
+    // Scoped proxy: auto-injects reactingTo when do() is called without it,
+    // maintaining correlation chains by default (see #587).
+    // Bind stable methods once; only the do() closure changes per event.
+    const doAction = this.do.bind(this);
+    const scopedApp: IAct<TEvents, TActions, TActor> = {
+      do: doAction as IAct<TEvents, TActions, TActor>["do"],
+      load: this.load.bind(this),
+      query: this.query.bind(this),
+      query_array: this.query_array.bind(this),
+    };
+
     for (const payload of payloads) {
       const { event, handler, options } = payload;
-      // Scoped proxy: auto-injects reactingTo when do() is called without it,
-      // maintaining correlation chains by default (see #587)
-      const doAction = this.do.bind(this);
-      const scopedApp: IAct<TEvents, TActions, TActor> = {
-        do: <TKey extends keyof TActions & string>(
-          action: TKey,
-          target: Target<TActor>,
-          payload: Readonly<TActions[TKey]>,
-          reactingTo?: Committed<Schemas, string>,
-          skipValidation?: boolean
-        ) =>
-          doAction(
-            action,
-            target,
-            payload,
-            (reactingTo ?? event) as Committed<TEvents, string & keyof TEvents>,
-            skipValidation
-          ),
-        load: this.load.bind(this),
-        query: this.query.bind(this),
-        query_array: this.query_array.bind(this),
-      };
+      scopedApp.do = <TKey extends keyof TActions & string>(
+        action: TKey,
+        target: Target<TActor>,
+        payload: Readonly<TActions[TKey]>,
+        reactingTo?: Committed<Schemas, string>,
+        skipValidation?: boolean
+      ) =>
+        doAction(
+          action,
+          target,
+          payload,
+          (reactingTo ?? event) as Committed<TEvents, string & keyof TEvents>,
+          skipValidation
+        );
       try {
         await handler(event, stream, scopedApp); // the actual reaction
         at = event.id;

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -247,24 +247,22 @@ export class Act<
    * }
    * ```
    *
-   * @example Reaction triggering another action
+   * @example Reaction triggering another action (reactingTo auto-injected)
    * ```typescript
    * const app = act()
    *   .withState(Order)
    *   .withState(Inventory)
    *   .on("OrderPlaced")
-   *     .do(async (event, context) => {
-   *       // This action is triggered by an event
-   *       const result = await context.app.do(
+   *     .do(async function reduceInventory(event, _stream, app) {
+   *       // Inside reaction handlers, reactingTo is auto-injected when omitted.
+   *       // The triggering event is used by default, maintaining the correlation chain.
+   *       await app.do(
    *         "reduceStock",
-   *         {
-   *           stream: "inventory-1",
-   *           actor: event.meta.causation.action.actor
-   *         },
-   *         { amount: event.data.items.length },
-   *         event // Pass event for correlation tracking
+   *         { stream: "inventory-1", actor: { id: "sys", name: "system" } },
+   *         { amount: event.data.items.length }
    *       );
-   *       return result;
+   *       // To use a different correlation, pass reactingTo explicitly:
+   *       // await app.do("reduceStock", target, payload, customEvent);
    *     })
    *     .to("inventory-1")
    *   .build();
@@ -486,6 +484,11 @@ export class Act<
    * This is called by the main `drain` loop after fetching new events.
    * It handles reactions, supporting retries, blocking, and error handling.
    *
+   * Each handler receives a scoped `IAct` proxy that auto-injects the
+   * triggering event as `reactingTo` when `do()` is called without it,
+   * maintaining correlation chains by default (#587). Handlers can still
+   * pass an explicit `reactingTo` to override this behavior.
+   *
    * @internal
    * @param lease The lease to handle
    * @param payloads The reactions to handle
@@ -513,8 +516,30 @@ export class Act<
 
     for (const payload of payloads) {
       const { event, handler, options } = payload;
+      // Scoped proxy: auto-injects reactingTo when do() is called without it,
+      // maintaining correlation chains by default (see #587)
+      const doAction = this.do.bind(this);
+      const scopedApp: IAct<TEvents, TActions, TActor> = {
+        do: <TKey extends keyof TActions & string>(
+          action: TKey,
+          target: Target<TActor>,
+          payload: Readonly<TActions[TKey]>,
+          reactingTo?: Committed<Schemas, string>,
+          skipValidation?: boolean
+        ) =>
+          doAction(
+            action,
+            target,
+            payload,
+            (reactingTo ?? event) as Committed<TEvents, string & keyof TEvents>,
+            skipValidation
+          ),
+        load: this.load.bind(this),
+        query: this.query.bind(this),
+        query_array: this.query_array.bind(this),
+      };
       try {
-        await handler(event, stream, this); // the actual reaction
+        await handler(event, stream, scopedApp); // the actual reaction
         at = event.id;
         handled++;
       } catch (error) {

--- a/libs/act/test/reacting-to.spec.ts
+++ b/libs/act/test/reacting-to.spec.ts
@@ -1,0 +1,249 @@
+import { z } from "zod";
+import { act, dispose, state, store } from "../src/index.js";
+
+/**
+ * Tests for auto-injection of reactingTo in reaction handlers (#587).
+ *
+ * When a reaction handler calls app.do() without the reactingTo parameter,
+ * the framework auto-injects the triggering event, maintaining the
+ * correlation chain by default.
+ */
+describe("auto-inject reactingTo (#587)", () => {
+  const actor = { id: "a", name: "a" };
+
+  beforeEach(async () => {
+    await store().seed();
+  });
+
+  afterAll(async () => {
+    await dispose()();
+  });
+
+  it("should auto-inject reactingTo when handler omits it", async () => {
+    const Source = state({ Source: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Triggered: z.object({ val: z.number() }) })
+      .on({ trigger: z.object({ val: z.number() }) })
+      .emit("Triggered")
+      .build();
+
+    const Sink = state({ Sink: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Received: z.object({ val: z.number() }) })
+      .patch({ Received: ({ data }) => ({ v: data.val }) })
+      .on({ receive: z.object({ val: z.number() }) })
+      .emit("Received")
+      .build();
+
+    const app_ = act()
+      .withState(Source)
+      .withState(Sink)
+      .on("Triggered")
+      .do(async function onTriggered(event, _stream, app) {
+        // NOT passing reactingTo — framework should auto-inject it
+        await app.do(
+          "receive",
+          { stream: "sink-1", actor: { id: "sys", name: "system" } },
+          { val: event.data.val }
+        );
+      })
+      .to((event) => ({ target: `sink-${event.stream}` }))
+      .build();
+
+    await app_.do("trigger", { stream: "src-1", actor }, { val: 42 });
+    await app_.correlate();
+    await app_.drain();
+
+    // Verify the Received event on the sink stream has correct correlation
+    const srcEvents = await app_.query_array({
+      stream: "src-1",
+      stream_exact: true,
+    });
+    const sinkEvents = await app_.query_array({
+      stream: "sink-1",
+      stream_exact: true,
+    });
+
+    const triggeredEvent = srcEvents.find((e) => e.name === "Triggered")!;
+    const receivedEvent = sinkEvents.find((e) => e.name === "Received")!;
+
+    expect(receivedEvent).toBeDefined();
+    // Correlation chain should be maintained
+    expect(receivedEvent.meta.correlation).toBe(
+      triggeredEvent.meta.correlation
+    );
+    // Causation should point back to the triggering event
+    expect(receivedEvent.meta.causation.event).toEqual({
+      id: triggeredEvent.id,
+      name: "Triggered",
+      stream: "src-1",
+    });
+  });
+
+  it("should respect explicit reactingTo when provided", async () => {
+    const Source = state({ Source2: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Triggered2: z.object({ val: z.number() }) })
+      .on({ trigger2: z.object({ val: z.number() }) })
+      .emit("Triggered2")
+      .build();
+
+    const Sink = state({ Sink2: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Received2: z.object({ val: z.number() }) })
+      .patch({ Received2: ({ data }) => ({ v: data.val }) })
+      .on({ receive2: z.object({ val: z.number() }) })
+      .emit("Received2")
+      .build();
+
+    const customCorrelation = "custom-correlation-id";
+
+    const app_ = act()
+      .withState(Source)
+      .withState(Sink)
+      .on("Triggered2")
+      .do(async function onTriggered2(event, _stream, app) {
+        // Explicitly passing a custom reactingTo — should NOT be overridden
+        const fakeEvent = {
+          ...event,
+          meta: { correlation: customCorrelation, causation: {} },
+        };
+        await app.do(
+          "receive2",
+          { stream: "sink2-1", actor: { id: "sys", name: "system" } },
+          { val: event.data.val },
+          fakeEvent
+        );
+      })
+      .to((event) => ({ target: `sink2-${event.stream}` }))
+      .build();
+
+    await app_.do("trigger2", { stream: "src2-1", actor }, { val: 99 });
+    await app_.correlate();
+    const drained = await app_.drain();
+    expect(drained.acked.length).toBeGreaterThan(0);
+
+    const sinkEvents = await app_.query_array({
+      stream: "sink2-1",
+      stream_exact: true,
+    });
+    const receivedEvent = sinkEvents.find((e) => e.name === "Received2")!;
+
+    expect(receivedEvent).toBeDefined();
+    // Should use the explicitly provided correlation, not the auto-injected one
+    expect(receivedEvent.meta.correlation).toBe(customCorrelation);
+  });
+
+  it("should propagate correlation across multi-step reaction chains", async () => {
+    const Step1 = state({ Step1: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Started: z.object({ val: z.number() }) })
+      .on({ start: z.object({ val: z.number() }) })
+      .emit("Started")
+      .build();
+
+    const Step2 = state({ Step2: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Forwarded: z.object({ val: z.number() }) })
+      .patch({ Forwarded: ({ data }) => ({ v: data.val }) })
+      .on({ forward: z.object({ val: z.number() }) })
+      .emit("Forwarded")
+      .build();
+
+    const Step3 = state({ Step3: z.object({ v: z.number() }) })
+      .init(() => ({ v: 0 }))
+      .emits({ Completed: z.object({ val: z.number() }) })
+      .patch({ Completed: ({ data }) => ({ v: data.val }) })
+      .on({ complete: z.object({ val: z.number() }) })
+      .emit("Completed")
+      .build();
+
+    const app_ = act()
+      .withState(Step1)
+      .withState(Step2)
+      .withState(Step3)
+      // Step 1 → Step 2 (no explicit reactingTo)
+      .on("Started")
+      .do(async function onStarted(event, _stream, app) {
+        await app.do(
+          "forward",
+          { stream: "step2-1", actor: { id: "sys", name: "system" } },
+          { val: event.data.val }
+        );
+      })
+      .to(() => ({ target: "step2-1" }))
+      // Step 2 → Step 3 (no explicit reactingTo)
+      .on("Forwarded")
+      .do(async function onForwarded(event, _stream, app) {
+        await app.do(
+          "complete",
+          { stream: "step3-1", actor: { id: "sys", name: "system" } },
+          { val: event.data.val }
+        );
+      })
+      .to(() => ({ target: "step3-1" }))
+      .build();
+
+    await app_.do("start", { stream: "step1-1", actor }, { val: 7 });
+
+    // Multiple correlate→drain passes to propagate through the chain
+    for (let i = 0; i < 3; i++) {
+      await app_.correlate();
+      await app_.drain();
+    }
+
+    const step1Events = await app_.query_array({
+      stream: "step1-1",
+      stream_exact: true,
+    });
+    const step3Events = await app_.query_array({
+      stream: "step3-1",
+      stream_exact: true,
+    });
+
+    const startedEvent = step1Events.find((e) => e.name === "Started")!;
+    const completedEvent = step3Events.find((e) => e.name === "Completed")!;
+
+    expect(completedEvent).toBeDefined();
+    // The entire chain should share the same correlation ID
+    expect(completedEvent.meta.correlation).toBe(startedEvent.meta.correlation);
+  });
+
+  it("should not affect load, query, and query_array on scoped app", async () => {
+    const Counter = state({ ScopedCounter: z.object({ count: z.number() }) })
+      .init(() => ({ count: 0 }))
+      .emits({ Counted: z.object({ n: z.number() }) })
+      .patch({ Counted: ({ data }, s) => ({ count: s.count + data.n }) })
+      .on({ count: z.object({ n: z.number() }) })
+      .emit("Counted")
+      .build();
+
+    let loadResult: any;
+    let queryResult: any;
+    let queryArrayResult: any;
+
+    const app_ = act()
+      .withState(Counter)
+      .on("Counted")
+      .do(async function onCounted(_event, _stream, app) {
+        // Verify all IAct methods work on the scoped proxy
+        loadResult = await app.load(Counter, "ctr-1");
+        queryResult = await app.query({ stream: "ctr-1", stream_exact: true });
+        queryArrayResult = await app.query_array({
+          stream: "ctr-1",
+          stream_exact: true,
+        });
+      })
+      .to(() => ({ target: "reaction-ctr" }))
+      .build();
+
+    await app_.do("count", { stream: "ctr-1", actor }, { n: 5 });
+    await app_.correlate();
+    await app_.drain();
+
+    expect(loadResult).toBeDefined();
+    expect(loadResult.state.count).toBe(5);
+    expect(queryResult.count).toBeGreaterThan(0);
+    expect(queryArrayResult.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Inside reaction handlers, `app.do()` now automatically injects the triggering event as `reactingTo` when omitted, maintaining correlation chains by default
- Explicit `reactingTo` still takes precedence via nullish coalescing (`??`)
- Updated CLAUDE.md, scaffold skill docs, and JSDoc to document implicit/explicit options

Closes #587

## Test plan
- [x] New test: auto-inject maintains correlation + causation chain when `reactingTo` omitted
- [x] New test: explicit `reactingTo` overrides the auto-injected event
- [x] New test: correlation propagates across a 3-step reaction chain
- [x] New test: `load`, `query`, `query_array` work correctly on the scoped proxy
- [x] All 784 existing tests pass
- [x] TypeScript strict mode passes
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)