### PR TITLE
fix(act): arm drain flag on reset so settled apps replay

### DIFF
--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -508,3 +508,41 @@ const result = await app.close([{ stream: "s1" }]);
 expect(result.truncated.has("s1")).toBe(true);
 await expect(app.do("increment", { stream: "s1", actor }, { by: 1 })).rejects.toThrow(StreamClosedError);
 ```
+
+## 15. Projection Rebuild — Replay Events Through Updated Projections
+
+When a projection's logic changes, reset its watermark so the next drain replays every event through the updated handler.
+
+```typescript
+// 1. Clear the read-model side effects (DB rows, cache, in-memory map)
+await db.delete(items);
+clearItems();
+
+// 2. Reset the projection stream watermark AND arm the orchestrator's drain flag
+await app.reset(["items"]);
+
+// 3. Drain (or settle) — events replay through the projection
+await app.drain({ eventLimit: 1000 });
+// or: await new Promise(r => app.on("settled", r); app.settle());
+```
+
+**Always use `app.reset(...)` — never `store().reset(...)` directly.**
+
+Both reset the watermark, but only `app.reset(...)` raises the orchestrator's internal `_needs_drain` flag. After a settled app (no recent commits) has caught up, `_needs_drain === false` and any subsequent `drain()`/`settle()` short-circuits and returns immediately. `store().reset(...)` alone leaves the flag unchanged, so the replay never runs. `app.reset(...)` wraps the store call and arms the flag in one step:
+
+```typescript
+// libs/act/src/act.ts
+async reset(streams: string[]): Promise<number> {
+  const count = await store().reset(streams);
+  if (count > 0 && this._reactive_events.size > 0) {
+    this._needs_drain = true;
+  }
+  return count;
+}
+```
+
+**Typical production workflow:**
+1. Deploy updated projection code
+2. Clear projected data (truncate read-model table, flush cache)
+3. `await app.reset(["projection-target"])`
+4. Normal `drain()` or `settle()` cycle replays through the new logic

--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -523,11 +523,8 @@ clearItems();
 // 2. Reset the projection stream watermark AND arm the orchestrator's drain flag
 await app.reset(["items"]);
 
-// 3. settle() loops correlate→drain until caught up, then emits "settled"
-await new Promise<void>((resolve) => {
-  app.on("settled", () => resolve());
-  app.settle({ eventLimit: 1000 });
-});
+// 3. Trigger settle — it loops correlate→drain until caught up, then emits "settled"
+app.settle({ eventLimit: 1000 });
 ```
 
 **Always use `app.reset(...)` — never `store().reset(...)` directly.**

--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -199,7 +199,7 @@ app.on("settled", (drain) => {
 app.settle({
   debounceMs: 10,                      // debounce window (default: 10ms)
   correlate: { after: -1, limit: 100 }, // correlate query (default)
-  maxPasses: 1,                         // max correlate→drain loops (default: 1)
+  maxPasses: Infinity,                  // kill-switch cap (default: Infinity)
   streamLimit: 10,                      // passed to drain()
   eventLimit: 100,                      // passed to drain()
 });
@@ -209,6 +209,8 @@ app.settle({
 - **Non-blocking**: `settle()` returns immediately — mutations don't wait for drain
 - **Debounced**: Multiple rapid `app.do()` calls coalesce into one settle cycle (10ms window)
 - **Guarded**: Internal `_settling` flag prevents concurrent settle cycles
+- **Drains to completion**: loops correlate→drain until a pass makes no progress (no new subscriptions, no acks, no blocks). Paginated catch-up after `app.reset(...)` works without a manual loop.
+- **`maxPasses` is a kill-switch**, not a tuning knob — it caps runtime if a reaction handler keeps emitting events that re-trigger itself. Default `Infinity` means the natural exit always wins.
 - **Lifecycle event**: `"settled"` fires only after all correlate/drain iterations finish, so SSE clients see a consistent view
 
 **In tests:** Call `correlate()` + `drain()` directly (synchronous, no debounce):
@@ -223,7 +225,7 @@ it("should process reactions", async () => {
 **In bootstrap:** Wire `app.on("committed", () => app.settle())` before the initial settle. This ensures reaction chains fully propagate — when a reaction produces new events during drain, the `committed` listener triggers another settle cycle to process those events through projections and further reactions. Without this, projection streams lag behind after reaction chains.
 
 ```typescript
-const settleOpts = { maxPasses: 10, streamLimit: 100, eventLimit: 1000 };
+const settleOpts = { streamLimit: 100, eventLimit: 1000 };
 app.on("committed", () => app.settle(settleOpts));
 ```
 
@@ -511,7 +513,7 @@ await expect(app.do("increment", { stream: "s1", actor }, { by: 1 })).rejects.to
 
 ## 15. Projection Rebuild — Replay Events Through Updated Projections
 
-When a projection's logic changes, reset its watermark so the next drain replays every event through the updated handler.
+When a projection's logic changes, reset its watermark and let `settle()` replay every event through the updated handler.
 
 ```typescript
 // 1. Clear the read-model side effects (DB rows, cache, in-memory map)
@@ -521,9 +523,11 @@ clearItems();
 // 2. Reset the projection stream watermark AND arm the orchestrator's drain flag
 await app.reset(["items"]);
 
-// 3. Drain (or settle) — events replay through the projection
-await app.drain({ eventLimit: 1000 });
-// or: await new Promise(r => app.on("settled", r); app.settle());
+// 3. settle() loops correlate→drain until caught up, then emits "settled"
+await new Promise<void>((resolve) => {
+  app.on("settled", () => resolve());
+  app.settle({ eventLimit: 1000 });
+});
 ```
 
 **Always use `app.reset(...)` — never `store().reset(...)` directly.**
@@ -541,8 +545,10 @@ async reset(streams: string[]): Promise<number> {
 }
 ```
 
+**`settle()` drains to completion by default.** The `maxPasses` cap defaults to `Infinity` — settle exits naturally when a pass makes no progress (no new subscriptions, no acks, no blocks). One `settle()` call fully catches up paginated streams of any length; the cap only acts as a kill-switch for runaway reaction loops.
+
 **Typical production workflow:**
 1. Deploy updated projection code
 2. Clear projected data (truncate read-model table, flush cache)
 3. `await app.reset(["projection-target"])`
-4. Normal `drain()` or `settle()` cycle replays through the new logic
+4. `app.settle()` (or wait on `"settled"`) — drives the catch-up to completion

--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -679,7 +679,7 @@ async function bootstrap() {
   await initDb();
   await store().seed();
 
-  const settleOpts = { maxPasses: 10, streamLimit: 100, eventLimit: 1000 };
+  const settleOpts = { streamLimit: 100, eventLimit: 1000 };
 
   // Settle after every commit — ensures reaction chains fully propagate
   app.on("committed", () => app.settle(settleOpts));

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,17 +514,22 @@ Projections are derived data — disposable by design. When a projection's logic
 // Reset the projection stream watermark to -1 and arm the drain flag
 await app.reset(["my-projection"]);
 
-// Next drain replays all events through the projection handlers
-await app.drain({ eventLimit: 1000 });   // or app.settle()
+// settle() loops correlate→drain until caught up, then emits "settled"
+await new Promise<void>((resolve) => {
+  app.on("settled", () => resolve());
+  app.settle({ eventLimit: 1000 });
+});
 ```
 
 **Always call `app.reset(...)` — never `store().reset(...)` directly.** Both reset the watermark, but only `app.reset(...)` raises the orchestrator's internal `_needs_drain` flag. A settled app (no recent commits) has `_needs_drain === false`, so `drain()`/`settle()` short-circuit and skip the replay if you reset at the store level. `app.reset(...)` wraps `store().reset(...)` and arms the flag in one call.
+
+**`settle()` drains to completion by default.** It loops correlate→drain until a pass produces no progress (no new subscriptions, no acks, no blocks). `maxPasses` defaults to `Infinity` and only acts as a kill-switch for runaway reaction loops — for ordinary catch-up, the natural exit handles paginated streams of any length. A single `app.settle()` after `app.reset(...)` is enough.
 
 **Typical production workflow:**
 1. Deploy updated projection code
 2. Clear projected data (truncate read-model table, flush cache)
 3. Call `await app.reset(["projection-target"])` to reset watermarks and arm drain
-4. Normal `drain()` or `settle()` replays all events through the updated handlers
+4. Call `app.settle()` once — it drives the catch-up to completion
 
 ### Event Schema Evolution
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,22 +508,22 @@ Snap writes are fire-and-forget — the cache is updated synchronously within `a
 
 ### Projection Rebuild
 
-Projections are derived data — disposable by design. When a projection's logic changes (new fields, bug fix, different aggregation), reset its watermark with `store().reset()` and let the existing drain machinery replay all events from the beginning:
+Projections are derived data — disposable by design. When a projection's logic changes (new fields, bug fix, different aggregation), reset its watermark with `app.reset(...)` and let the existing drain machinery replay all events from the beginning:
 
 ```typescript
-// Reset the projection stream watermark to -1
-await store().reset(["my-projection"]);
+// Reset the projection stream watermark to -1 and arm the drain flag
+await app.reset(["my-projection"]);
 
 // Next drain replays all events through the projection handlers
-await app.drain({ eventLimit: 1000 });
+await app.drain({ eventLimit: 1000 });   // or app.settle()
 ```
 
-`store().reset(streams)` sets `at = -1`, clears `retry`, `blocked`, `error`, and lease state for the given streams. This makes them eligible for `claim()` from the beginning. The framework's existing drain cycle handles the replay — no special rebuild API is needed.
+**Always call `app.reset(...)` — never `store().reset(...)` directly.** Both reset the watermark, but only `app.reset(...)` raises the orchestrator's internal `_needs_drain` flag. A settled app (no recent commits) has `_needs_drain === false`, so `drain()`/`settle()` short-circuit and skip the replay if you reset at the store level. `app.reset(...)` wraps `store().reset(...)` and arms the flag in one call.
 
 **Typical production workflow:**
 1. Deploy updated projection code
 2. Clear projected data (truncate read-model table, flush cache)
-3. Call `store().reset(["projection-target"])` to reset watermarks
+3. Call `await app.reset(["projection-target"])` to reset watermarks and arm drain
 4. Normal `drain()` or `settle()` replays all events through the updated handlers
 
 ### Event Schema Evolution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,11 +514,8 @@ Projections are derived data — disposable by design. When a projection's logic
 // Reset the projection stream watermark to -1 and arm the drain flag
 await app.reset(["my-projection"]);
 
-// settle() loops correlate→drain until caught up, then emits "settled"
-await new Promise<void>((resolve) => {
-  app.on("settled", () => resolve());
-  app.settle({ eventLimit: 1000 });
-});
+// Trigger settle — it loops correlate→drain until caught up, then emits "settled"
+app.settle({ eventLimit: 1000 });
 ```
 
 **Always call `app.reset(...)` — never `store().reset(...)` directly.** Both reset the watermark, but only `app.reset(...)` raises the orchestrator's internal `_needs_drain` flag. A settled app (no recent commits) has `_needs_drain === false`, so `drain()`/`settle()` short-circuit and skip the replay if you reset at the store level. `app.reset(...)` wraps `store().reset(...)` and arms the flag in one call.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ When `.emits()` declares events, every event gets a default passthrough reducer:
 
 ### Projections Are Disposable
 
-Projections are derived data — you should be able to throw one away and rebuild it from the event log at any time. Reset the watermark with `store().reset(["projection-target"])` and the next `drain()` replays all events from the beginning. No special rebuild API needed — the existing drain machinery handles it.
+Projections are derived data — you should be able to throw one away and rebuild it from the event log at any time. Reset the watermark with `app.reset(["projection-target"])` and the next `drain()` (or `settle()`) replays all events from the beginning. The existing drain machinery handles it — `app.reset()` also arms the orchestrator's drain flag, which `store().reset()` alone does not (a settled app would otherwise short-circuit and skip the replay).
 
 ### Snapshots and Cache: Two Layers
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ When `.emits()` declares events, every event gets a default passthrough reducer:
 
 ### Projections Are Disposable
 
-Projections are derived data — you should be able to throw one away and rebuild it from the event log at any time. Reset the watermark with `app.reset(["projection-target"])` and the next `drain()` (or `settle()`) replays all events from the beginning. The existing drain machinery handles it — `app.reset()` also arms the orchestrator's drain flag, which `store().reset()` alone does not (a settled app would otherwise short-circuit and skip the replay).
+Projections are derived data — you should be able to throw one away and rebuild it from the event log at any time. Reset the watermark with `app.reset(["projection-target"])` and the next `app.settle()` replays all events from the beginning. `settle()` loops correlate→drain until a pass makes no progress, so a single call fully catches up paginated streams. `app.reset()` also arms the orchestrator's drain flag, which `store().reset()` alone does not (a settled app would otherwise short-circuit and skip the replay).
 
 ### Snapshots and Cache: Two Layers
 

--- a/libs/act/PERFORMANCE.md
+++ b/libs/act/PERFORMANCE.md
@@ -226,7 +226,7 @@ The filter eliminates wasted claims — only streams with pending events are ret
 4. **Flag cleared** when drain completes with nothing acked, blocked, or errored, or when claim returns no streams
 5. **Cold start:** flag set in `_init_correlation()` to ensure historical events are processed
 
-Also changed `maxPasses` default from 5 to 1 — most apps need a single correlate→drain pass per settle. Apps with reaction chains can opt into `maxPasses: N`.
+`maxPasses` defaults to `Infinity` and acts as a kill-switch for runaway reaction loops. `settle()` exits naturally when a pass makes no progress (no new subscriptions, no acks, no blocks), so the cap rarely matters in practice — paginated catch-up after `app.reset(...)` works without manual loops.
 
 ### Benchmark (PostgreSQL, local, 18 event types / 7 reactive)
 

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -305,7 +305,7 @@ app.on("settled", (drain) => {
 
 Drain cycles continue until all reactions have caught up to the latest events. Consumers only process new work — acknowledged events are skipped, and failed streams are re-claimed automatically.
 
-The `settle()` method is the recommended production pattern — it debounces rapid commits (10ms default), runs correlate→drain (default `maxPasses: 1`), and emits a `"settled"` event when done.
+The `settle()` method is the recommended production pattern — it debounces rapid commits (10ms default), loops correlate→drain until a pass makes no progress (default `maxPasses: Infinity`, which acts only as a kill-switch for runaway reaction loops), and emits a `"settled"` event when done. A single `settle()` call after `app.reset(...)` fully catches up paginated streams.
 
 **Drain skip optimization:** At build time, Act classifies which event names have registered reactions. When `do()` commits events that have no reactions, `drain()` returns immediately — zero DB round-trips. This eliminates wasted claim/query/ack cycles for high-frequency events that don't need reaction processing. See [PERFORMANCE.md](PERFORMANCE.md) for benchmarks.
 

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -1036,16 +1036,31 @@ export class Act<
    * `store().reset(...)` alone leaves the flag untouched, so a settled app
    * would short-circuit and skip the replay.
    *
+   * Pair with `app.settle()` (or a single `app.drain()` for small streams).
+   * `settle()` loops correlate→drain until no progress is made, so one call
+   * fully catches up paginated streams without forcing callers to roll
+   * their own loop.
+   *
    * @param streams - Reaction target streams (e.g., projection names) to reset
    * @returns Count of streams that were actually reset
    *
-   * @example Rebuild a projection
+   * @example Rebuild a projection (production)
    * ```typescript
    * await app.reset(["my-projection"]);
-   * await app.drain({ eventLimit: 1000 });   // or app.settle()
+   * await new Promise<void>((resolve) => {
+   *   app.on("settled", () => resolve());
+   *   app.settle({ eventLimit: 1000 });
+   * });
+   * ```
+   *
+   * @example Rebuild a projection (tests / scripts)
+   * ```typescript
+   * await app.reset(["my-projection"]);
+   * await app.drain({ eventLimit: 1000 });   // small streams: one pass is enough
    * ```
    *
    * @see {@link Store.reset} for the underlying store primitive
+   * @see {@link settle} for the debounced full-catch-up loop
    */
   async reset(streams: string[]): Promise<number> {
     const count = await store().reset(streams);
@@ -1251,15 +1266,19 @@ export class Act<
   /**
    * Debounced, non-blocking correlate→drain cycle.
    *
-   * Call this after `app.do()` to schedule a background drain. Multiple rapid
-   * calls within the debounce window are coalesced into a single cycle. Runs
-   * correlate→drain in a loop until the system reaches a consistent state,
-   * then emits the `"settled"` lifecycle event.
+   * Call this after `app.do()` (or `app.reset()`) to schedule a background
+   * drain. Multiple rapid calls within the debounce window are coalesced
+   * into a single cycle. Runs correlate→drain in a loop until a pass makes
+   * no progress — no new subscriptions, no acks, no blocks — then emits
+   * the `"settled"` lifecycle event. This means a single `settle()` call
+   * fully catches up paginated streams (e.g. after `reset()` on a long
+   * projection) without forcing callers to loop.
    *
    * @param options - Settle configuration options
    * @param options.debounceMs - Debounce window in milliseconds (default: 10)
    * @param options.correlate - Query filter for correlation scans (default: `{ after: -1, limit: 100 }`)
-   * @param options.maxPasses - Maximum correlate→drain loops (default: 1)
+   * @param options.maxPasses - Cap on correlate→drain loops (default: `Infinity`).
+   *   Early-exit on no-progress means the cap only matters in pathological cases.
    * @param options.streamLimit - Maximum streams per drain cycle (default: 10)
    * @param options.eventLimit - Maximum events per stream (default: 10)
    * @param options.leaseMillis - Lease duration in milliseconds (default: 10000)
@@ -1281,7 +1300,7 @@ export class Act<
     const {
       debounceMs = 10,
       correlate: correlateQuery = { after: -1, limit: 100 },
-      maxPasses = 1,
+      maxPasses = Infinity,
       ...drainOptions
     } = options;
 
@@ -1294,14 +1313,21 @@ export class Act<
       (async () => {
         await this._init_correlation();
         let lastDrain: Drain<TEvents> | undefined;
+        // Loop correlate→drain until a pass produces no work — this fully
+        // catches up paginated streams (e.g. after `reset()` on a long
+        // projection) without forcing callers to roll their own loop.
+        // `maxPasses` caps runtime in pathological cases.
         for (let i = 0; i < maxPasses; i++) {
           const { subscribed } = await this.correlate({
             ...correlateQuery,
             after: this._correlation_checkpoint,
           });
-          if (subscribed === 0 && i > 0) break;
           lastDrain = await this.drain(drainOptions);
-          if (!lastDrain.acked.length && !lastDrain.blocked.length) break;
+          const made_progress =
+            subscribed > 0 ||
+            lastDrain.acked.length > 0 ||
+            lastDrain.blocked.length > 0;
+          if (!made_progress) break;
         }
         if (lastDrain) this.emit("settled", lastDrain);
       })()

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -1027,6 +1027,35 @@ export class Act<
   }
 
   /**
+   * Reset reaction stream watermarks and request a drain on the next
+   * `drain()` / `settle()` cycle.
+   *
+   * Use this to replay events through projections (or other reaction targets)
+   * after changing handler logic. Equivalent to calling `store().reset(streams)`
+   * directly, but also raises the orchestrator's internal "needs drain" flag —
+   * `store().reset(...)` alone leaves the flag untouched, so a settled app
+   * would short-circuit and skip the replay.
+   *
+   * @param streams - Reaction target streams (e.g., projection names) to reset
+   * @returns Count of streams that were actually reset
+   *
+   * @example Rebuild a projection
+   * ```typescript
+   * await app.reset(["my-projection"]);
+   * await app.drain({ eventLimit: 1000 });   // or app.settle()
+   * ```
+   *
+   * @see {@link Store.reset} for the underlying store primitive
+   */
+  async reset(streams: string[]): Promise<number> {
+    const count = await store().reset(streams);
+    if (count > 0 && this._reactive_events.size > 0) {
+      this._needs_drain = true;
+    }
+    return count;
+  }
+
+  /**
    * Close the books — guard, archive, truncate, and optionally restart streams.
    *
    * Safely removes historical events from the operational store:

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -1047,10 +1047,7 @@ export class Act<
    * @example Rebuild a projection (production)
    * ```typescript
    * await app.reset(["my-projection"]);
-   * await new Promise<void>((resolve) => {
-   *   app.on("settled", () => resolve());
-   *   app.settle({ eventLimit: 1000 });
-   * });
+   * app.settle({ eventLimit: 1000 });   // emits "settled" when fully replayed
    * ```
    *
    * @example Rebuild a projection (tests / scripts)

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -332,18 +332,24 @@ export interface Store extends Disposable {
    * for replay from the beginning. Also clears retry, blocked, error,
    * and lease state so the streams can be claimed immediately.
    *
-   * Used by `Act.rebuild()` to replay events through updated projections.
+   * **Prefer `Act.reset()` over calling this directly.** This primitive
+   * only resets the store; it does not raise the orchestrator's internal
+   * "needs drain" flag, so a settled `Act` instance will short-circuit and
+   * skip the replay. `Act.reset()` wraps this and arms the flag.
    *
    * @param streams - Stream names to reset
    * @returns Count of streams that were actually reset
    *
    * @example
    * ```typescript
-   * const count = await store().reset(["my-projection"]);
-   * console.log(`Reset ${count} streams for replay`);
+   * // Recommended
+   * await app.reset(["my-projection"]);
+   *
+   * // Low-level (does NOT trigger replay on settled apps)
+   * await store().reset(["my-projection"]);
    * ```
    *
-   * @see {@link Act.rebuild} for the high-level rebuild API
+   * @see {@link Act.reset} for the high-level rebuild API
    */
   reset: (streams: string[]) => Promise<number>;
 

--- a/libs/act/src/types/reaction.ts
+++ b/libs/act/src/types/reaction.ts
@@ -302,7 +302,10 @@ export type Drain<TEvents extends Schemas> = {
  *
  * @property debounceMs - Debounce window in milliseconds (default: 10)
  * @property correlate - Query filter for correlation scans (default: `{ after: -1, limit: 100 }`)
- * @property maxPasses - Maximum correlate→drain loops (default: 1)
+ * @property maxPasses - Cap on correlate→drain loops (default: `Infinity`).
+ *   Settle exits early as soon as a pass makes no progress (no new
+ *   subscriptions, no acks, no blocks), so the cap only matters in
+ *   pathological cases.
  */
 export type SettleOptions = DrainOptions & {
   readonly debounceMs?: number;

--- a/libs/act/test/act.spec.ts
+++ b/libs/act/test/act.spec.ts
@@ -441,31 +441,45 @@ describe("act", () => {
       app.off("settled", settledListener);
     });
 
-    it("should break early when correlate returns no subscriptions on second pass", async () => {
+    it("should keep draining when correlate yields no new subs but drain is still acking", async () => {
+      // Regression: previous behavior broke after one pass when correlate
+      // returned 0 subscriptions, even if drain was still paginating work.
+      // That made settle a no-op for catch-up scenarios (e.g. after reset).
       const settledListener = vi.fn();
       app.on("settled", settledListener);
 
-      // Mock correlate: first call returns subscriptions so loop continues,
-      // second call returns 0 → triggers i>0 break
-      let correlateCount = 0;
-      const correlateSpy = vi.spyOn(app, "correlate").mockImplementation(() => {
-        correlateCount++;
-        if (correlateCount === 1)
-          return Promise.resolve({ subscribed: 1, last_id: 0 } as any);
-        return Promise.resolve({ subscribed: 0, last_id: 0 } as any);
-      });
-      // Mock drain to return acked work so the loop doesn't break at line 882
-      const drainSpy = vi.spyOn(app, "drain").mockResolvedValue({
-        fetched: [],
-        leased: [],
-        acked: [{ stream: "x", at: 1, by: "test", retry: 0, lagging: false }],
-        blocked: [],
+      const correlateSpy = vi
+        .spyOn(app, "correlate")
+        .mockResolvedValue({ subscribed: 0, last_id: 0 });
+      // Drain reports work on first 2 passes, then nothing → loop exits.
+      let drainCount = 0;
+      const drainSpy = vi.spyOn(app, "drain").mockImplementation(() => {
+        drainCount++;
+        return Promise.resolve({
+          fetched: [],
+          leased: [],
+          acked:
+            drainCount <= 2
+              ? [
+                  {
+                    stream: "x",
+                    source: "x",
+                    at: drainCount,
+                    by: "t",
+                    retry: 0,
+                    lagging: false,
+                  },
+                ]
+              : [],
+          blocked: [],
+        });
       });
 
-      app.settle({ debounceMs: 1, maxPasses: 5 });
+      app.settle({ debounceMs: 1, maxPasses: 10 });
       await sleep(300);
       expect(settledListener).toHaveBeenCalledTimes(1);
-      expect(correlateCount).toBe(2); // ran 2 passes, broke on second
+      // 2 productive passes + 1 final empty pass that triggers the exit
+      expect(drainCount).toBe(3);
 
       correlateSpy.mockRestore();
       drainSpy.mockRestore();

--- a/libs/act/test/rebuild.spec.ts
+++ b/libs/act/test/rebuild.spec.ts
@@ -103,12 +103,10 @@ describe("Store.reset", () => {
       await new Promise((r) => setTimeout(r, 5));
     }
 
-    // Fix the handler, reset, and re-correlate to trigger drain
+    // Fix the handler and reset — app.reset() raises the drain flag.
     shouldFail = false;
     handler.mockClear();
-    await store().reset(["fail-proj"]);
-    // Emit another event so drain flag is set
-    await app.do("increment", { stream, actor }, { by: 2 });
+    await app.reset(["fail-proj"]);
     const result = await app.drain({ eventLimit: 100 });
 
     expect(handler).toHaveBeenCalled();
@@ -186,5 +184,80 @@ describe("Store.reset", () => {
 
     expect(firstRun).toEqual(secondRun);
     expect(firstRun).toEqual([10, 20]);
+  });
+
+  it("should replay events when drain runs after reset on a settled app", async () => {
+    const stream = nextStream();
+    const projected: number[] = [];
+
+    const CounterProjection = projection("settled-reset-proj")
+      .on({ Incremented })
+      .do(async function project(event) {
+        await Promise.resolve();
+        projected.push(event.data.by);
+      })
+      .build();
+
+    const app = act()
+      .withState(Counter)
+      .withProjection(CounterProjection)
+      .build();
+
+    await app.do("increment", { stream, actor }, { by: 1 });
+    await app.do("increment", { stream, actor }, { by: 2 });
+    await app.correlate();
+    // First drain processes events; second drain leaves the orchestrator
+    // fully settled (_needs_drain cleared because nothing left to do).
+    await app.drain({ eventLimit: 100 });
+    await app.drain({ eventLimit: 100 });
+
+    expect(projected).toEqual([1, 2]);
+
+    projected.length = 0;
+    const count = await app.reset(["settled-reset-proj"]);
+    expect(count).toBe(1);
+    const result = await app.drain({ eventLimit: 100 });
+
+    expect(projected).toEqual([1, 2]);
+    expect(result.acked.length).toBe(1);
+  });
+
+  it("should replay events when settle runs after reset on a settled app", async () => {
+    const stream = nextStream();
+    const projected: number[] = [];
+
+    const CounterProjection = projection("settled-reset-settle-proj")
+      .on({ Incremented })
+      .do(async function project(event) {
+        await Promise.resolve();
+        projected.push(event.data.by);
+      })
+      .build();
+
+    const app = act()
+      .withState(Counter)
+      .withProjection(CounterProjection)
+      .build();
+
+    await app.do("increment", { stream, actor }, { by: 7 });
+    await app.do("increment", { stream, actor }, { by: 8 });
+
+    await new Promise<void>((resolve) => {
+      app.on("settled", () => resolve());
+      app.settle();
+    });
+    expect(projected).toEqual([7, 8]);
+    // Second settle drives _needs_drain to false (no work left).
+    await app.drain({ eventLimit: 100 });
+
+    projected.length = 0;
+    await app.reset(["settled-reset-settle-proj"]);
+
+    await new Promise<void>((resolve) => {
+      app.on("settled", () => resolve());
+      app.settle();
+    });
+
+    expect(projected).toEqual([7, 8]);
   });
 });

--- a/libs/act/test/rebuild.spec.ts
+++ b/libs/act/test/rebuild.spec.ts
@@ -260,4 +260,26 @@ describe("Store.reset", () => {
 
     expect(projected).toEqual([7, 8]);
   });
+
+  it("app.reset returns 0 and skips arming the drain flag for unknown streams", async () => {
+    const app = act().withState(Counter).build();
+    const count = await app.reset(["does-not-exist"]);
+    expect(count).toBe(0);
+    expect((app as unknown as { _needs_drain: boolean })._needs_drain).toBe(
+      false
+    );
+  });
+
+  it("app.reset does not arm the drain flag when the app has no reactions", async () => {
+    // Static target subscription happens via withProjection, so we can reset
+    // a real stream — but with no reactive events, _needs_drain should stay
+    // false (drain would be a no-op anyway).
+    const app = act().withState(Counter).build();
+    await store().subscribe([{ stream: "no-reactions-proj" }]);
+    const count = await app.reset(["no-reactions-proj"]);
+    expect(count).toBe(1);
+    expect((app as unknown as { _needs_drain: boolean })._needs_drain).toBe(
+      false
+    );
+  });
 });

--- a/packages/calculator/src/rebuild-demo.ts
+++ b/packages/calculator/src/rebuild-demo.ts
@@ -1,15 +1,15 @@
 /**
  * Projection Rebuild Demo
  *
- * Demonstrates how store().reset() enables projection rebuilds:
+ * Demonstrates how app.reset() enables projection rebuilds:
  * 1. Build a counter app with a projection that sums increments
  * 2. Process events through the projection normally
- * 3. Reset the projection watermark with store().reset()
+ * 3. Reset the projection watermark with app.reset()
  * 4. Re-drain to replay all events through the (potentially updated) projection
  *
  * Run: pnpm -F calculator dev:rebuild
  */
-import { act, dispose, projection, state, store } from "@rotorsoft/act";
+import { act, dispose, projection, state } from "@rotorsoft/act";
 import { z } from "zod";
 
 const Incremented = z.object({ by: z.number() });
@@ -67,7 +67,7 @@ async function main() {
   totalEvents = 0;
   totalSum = 0;
 
-  const resetCount = await store().reset(["sum-proj"]);
+  const resetCount = await app.reset(["sum-proj"]);
   console.log(`  Reset ${resetCount} stream(s)`);
 
   // Re-drain replays all events from the beginning
@@ -87,7 +87,7 @@ async function main() {
   console.log(`\n=== Second rebuild (idempotent) ===`);
   totalEvents = 0;
   totalSum = 0;
-  await store().reset(["sum-proj"]);
+  await app.reset(["sum-proj"]);
   await app.drain({ eventLimit: 100 });
   console.log(`  Events re-processed: ${totalEvents}`);
   console.log(`  Sum: ${totalSum}`);


### PR DESCRIPTION
## Summary

Two related fixes for the reset/replay flow on the orchestrator:

1. **`Act.reset(streams)`** — wraps `store().reset(...)` and arms the orchestrator's internal `_needs_drain` flag. Calling `store().reset(...)` directly leaves the flag untouched, so a settled app short-circuits in `drain()`/`settle()` and silently skips the replay.
2. **`settle()` drains to completion by default** — `maxPasses` default changed from `1` → `Infinity`, and the loop now exits on "no progress" (no new subscriptions AND no acks AND no blocks). The previous early-exit bailed out before draining paginated work whenever `correlate` returned 0 subs on iteration > 0. `maxPasses` remains as a kill-switch for runaway reaction chains.

Together: a single `await app.reset([...])` followed by `app.settle()` (or one `drain()` for small streams) fully catches up paginated streams of any length, with no caller-side loop.

## Reproducer

Two new tests in `libs/act/test/rebuild.spec.ts` exercise the full settle-then-reset path. Both fail on master and pass with this fix:

- `should replay events when drain runs after reset on a settled app`
- `should replay events when settle runs after reset on a settled app`

The pre-existing `act.spec.ts` test "should break early when correlate returns no subscriptions on second pass" was asserting the old buggy paginated-drain behavior — replaced with a regression test that proves settle keeps draining as long as drain is still acking.

## Docs / pattern

Updated to consistently recommend `app.reset(...)` + `settle()`:

- `CLAUDE.md` § Projection Rebuild
- `README.md` § Projections Are Disposable
- `libs/act/README.md` § Settle (debounce + completion semantics)
- `libs/act/PERFORMANCE.md` (reflects new maxPasses default)
- `Store.reset` JSDoc points at `Act.reset` as the high-level API
- `.claude/skills/scaffold-act-app/act-api.md` — new § 15 plus updated settle docs
- `.claude/skills/scaffold-act-app/server.md` — drops manual `maxPasses: 10`

## Test plan

- [x] New reproducer tests fail on master, pass on this branch
- [x] All 786 existing tests still pass (`npx vitest run`)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)