### PR TITLE
feat(act-sqlite): add SQLite event store adapter with 100% coverage

### DIFF
--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -360,8 +360,11 @@ afterAll(async () => {
 ```typescript
 import { store, cache } from "@rotorsoft/act";
 import { PostgresStore } from "@rotorsoft/act-pg";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
 
-store(new PostgresStore({ /* config */ }));  // sets the store adapter
+store(new PostgresStore({ /* config */ }));  // distributed / multi-node
+// or
+store(new SqliteStore({ url: "file:myapp.db" }));  // embedded / single-node
 await store().seed();                         // initializes it
 
 // For distributed deployments, replace the cache:

--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -95,6 +95,19 @@ store(new PostgresStore({
 
 Install: `pnpm -F @my-app/app add @rotorsoft/act-pg`
 
+## Switch to SQLite (libSQL)
+
+Use `@rotorsoft/act-sqlite` for embedded or single-node deployments. SQLite serializes writes at the database level, giving the same single-server semantics as Postgres' `FOR UPDATE SKIP LOCKED`.
+
+```typescript
+import { store } from "@rotorsoft/act";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+
+store(new SqliteStore({ url: process.env.SQLITE_URL ?? "file:myapp.db" }));
+```
+
+Install: `pnpm -F @my-app/app add @rotorsoft/act-sqlite`
+
 ## Cache Strategy
 
 Cache is always-on by default with `InMemoryCache` (LRU, maxSize 1000). It stores the latest state checkpoint per stream, eliminating full event replay on every `load()`. Actions update the cache after each successful commit; concurrency errors invalidate stale entries automatically.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       max-parallel: 1 # prevents concurrent pull/push conflicts on main branch
       matrix:
-        lib: [act-patch, act, act-sse, act-pg, act-pino, act-diagram]
+        lib: [act-patch, act, act-sse, act-pg, act-sqlite, act-pino, act-diagram]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ coverage/
 *.env
 .npmrc
 local.db*
+test-store.db*
 .DS_Store
 *.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This is a pnpm monorepo with two main sections:
 - **`/libs`** - Core framework libraries
   - `@rotorsoft/act` - Core event sourcing framework
   - `@rotorsoft/act-pg` - PostgreSQL adapter for production
+  - `@rotorsoft/act-sqlite` - SQLite adapter (libSQL) for embedded/single-node deployments
   - `@rotorsoft/act-patch` - Immutable deep-merge patch utility
   - `@rotorsoft/act-sse` - Server-Sent Events for incremental state broadcast
 
@@ -368,7 +369,8 @@ The framework uses a port/adapter pattern for persistence and caching via single
 #### Store
 
 - **InMemoryStore** - Default, useful for tests and prototyping
-- **PostgresStore** - Production-ready with atomic claim, snapshots, and connection pooling
+- **PostgresStore** (`@rotorsoft/act-pg`) - Production-ready with atomic claim, snapshots, and connection pooling
+- **SqliteStore** (`@rotorsoft/act-sqlite`) - libSQL-backed adapter for embedded or single-node deployments; serializes writes at the DB level, equivalent to PG's `FOR UPDATE SKIP LOCKED` for single-server
 
 Switch stores using the `store()` singleton:
 
@@ -608,6 +610,10 @@ Events are immutable — their schemas must evolve without breaking historical d
 - **`postgres-store.ts`** - PostgreSQL implementation of Store interface
 - **`types.ts`** - PostgreSQL-specific types and schemas
 
+### SQLite Adapter (`libs/act-sqlite/src`)
+
+- **`SqliteStore.ts`** - libSQL-backed implementation of the Store interface (single-node, embedded)
+
 ### Examples
 
 Each example demonstrates different framework capabilities:
@@ -633,7 +639,7 @@ Each example demonstrates different framework capabilities:
 2. Implement in appropriate module (`state.ts`, `act.ts`, etc.)
 3. Add tests in `__tests__` directory
 4. Update example applications to demonstrate usage
-5. Ensure both InMemoryStore and PostgresStore support the feature
+5. Ensure InMemoryStore, PostgresStore, and SqliteStore all support the feature
 
 ### Documentation Guidelines
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The complexity of modern software design often arises from over-engineering abst
 [![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg)
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg)
 
+### [@rotorsoft/act-sqlite](https://github.com/rotorsoft/act-root/tree/master/libs/act-sqlite)
+[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
+[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
+
 ### [@rotorsoft/act-pino](https://github.com/rotorsoft/act-root/tree/master/libs/act-pino)
 [![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-pino.svg)](https://www.npmjs.com/package/@rotorsoft/act-pino)
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pino.svg)](https://www.npmjs.com/package/@rotorsoft/act-pino)

--- a/docs/docs/concepts/configuration.md
+++ b/docs/docs/concepts/configuration.md
@@ -137,6 +137,10 @@ store(new PostgresStore({
   schema: "public",
   table: "events",
 }));
+
+// Embedded / single-node: SQLite via libSQL
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+store(new SqliteStore({ url: "file:myapp.db" }));
 ```
 
 ### Cache

--- a/docs/docs/concepts/event-sourcing.md
+++ b/docs/docs/concepts/event-sourcing.md
@@ -25,6 +25,7 @@ The event store uses a port/adapter pattern:
 
 - **InMemoryStore** (default) — fast, ephemeral, for development and testing
 - **PostgresStore** (`@rotorsoft/act-pg`) — production-ready with ACID guarantees and connection pooling
+- **SqliteStore** (`@rotorsoft/act-sqlite`) — libSQL-backed adapter for embedded or single-node deployments
 
 ```typescript
 import { store } from "@rotorsoft/act";
@@ -36,6 +37,13 @@ store(new PostgresStore({
   user: "postgres",
   password: "secret",
 }));
+```
+
+```typescript
+import { store } from "@rotorsoft/act";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+
+store(new SqliteStore({ url: "file:myapp.db" }));
 ```
 
 ### Cache

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -61,7 +61,7 @@ console.log(snapshot.state.count); // 5
 Infrastructure uses swappable adapters injected via `log()`, `store()`, and `cache()` port functions:
 
 - **Logger** — `ConsoleLogger` (default) or `PinoLogger` (`@rotorsoft/act-pino`)
-- **Store** — `InMemoryStore` (default) or `PostgresStore` (`@rotorsoft/act-pg`)
+- **Store** — `InMemoryStore` (default), `PostgresStore` (`@rotorsoft/act-pg`), or `SqliteStore` (`@rotorsoft/act-sqlite`)
 - **Cache** — `InMemoryCache` (default, LRU) or custom adapters (e.g., Redis)
 - **Disposal** — `dispose()()` cleans up all registered adapters on shutdown
 
@@ -77,6 +77,7 @@ Infrastructure uses swappable adapters injected via `log()`, `store()`, and `cac
 |---|---|
 | [`@rotorsoft/act`](https://www.npmjs.com/package/@rotorsoft/act) | Core framework |
 | [`@rotorsoft/act-pg`](https://www.npmjs.com/package/@rotorsoft/act-pg) | PostgreSQL store adapter |
+| [`@rotorsoft/act-sqlite`](https://www.npmjs.com/package/@rotorsoft/act-sqlite) | SQLite (libSQL) store adapter |
 | [`@rotorsoft/act-pino`](https://www.npmjs.com/package/@rotorsoft/act-pino) | Pino logger adapter |
 | [`@rotorsoft/act-patch`](https://www.npmjs.com/package/@rotorsoft/act-patch) | Immutable deep-merge patch utility |
 | [`@rotorsoft/act-sse`](https://www.npmjs.com/package/@rotorsoft/act-sse) | Server-Sent Events for incremental state broadcast |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -42,6 +42,11 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "link",
+          label: "@rotorsoft/act-sqlite",
+          href: "/docs/api/act-sqlite/src",
+        },
+        {
+          type: "link",
           label: "@rotorsoft/act-sse",
           href: "/docs/api/act-sse/src",
         },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -13,6 +13,9 @@
       "@rotorsoft/act-pg": [
         "libs/act-pg/src/index.ts"
       ],
+      "@rotorsoft/act-sqlite": [
+        "libs/act-sqlite/src/index.ts"
+      ],
       "@rotorsoft/act-sse": [
         "libs/act-sse/src/index.ts"
       ]
@@ -22,6 +25,7 @@
     "../libs/act/src/**/*",
     "../libs/act-patch/src/**/*",
     "../libs/act-pg/src/**/*",
+    "../libs/act-sqlite/src/**/*",
     "../libs/act-sse/src/**/*"
   ],
   "exclude": [

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -3,6 +3,7 @@
     "../libs/act/src/index.ts",
     "../libs/act-patch/src/index.ts",
     "../libs/act-pg/src/index.ts",
+    "../libs/act-sqlite/src/index.ts",
     "../libs/act-sse/src/index.ts"
   ],
   "out": "docs/api",

--- a/libs/act-sqlite/.releaserc.json
+++ b/libs/act-sqlite/.releaserc.json
@@ -1,0 +1,27 @@
+{
+  "extends": "semantic-release-monorepo",
+  "branches": ["master"],
+  "tagFormat": "@rotorsoft/act-sqlite-v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        { "breaking": true, "release": "minor" },
+        { "type": "feat", "release": "minor" },
+        { "type": "fix", "release": "patch" },
+        { "type": "perf", "release": "patch" },
+        { "type": "refactor", "release": "patch" }
+      ]
+    }],
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/npm", { "npmPublish": false }],
+    ["@semantic-release/exec", {
+      "publishCmd": "pnpm publish --no-git-checks --access public"
+    }],
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "package.json"],
+      "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}

--- a/libs/act-sqlite/README.md
+++ b/libs/act-sqlite/README.md
@@ -1,0 +1,134 @@
+# @rotorsoft/act-sqlite
+
+[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
+[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
+[![Build Status](https://github.com/rotorsoft/act-root/actions/workflows/ci-cd.yml/badge.svg?branch=master)](https://github.com/rotorsoft/act-root/actions/workflows/ci-cd.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+SQLite event store adapter for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act). Provides persistent, file-based event storage with ACID guarantees via [`@libsql/client`](https://github.com/tursodatabase/libsql-client-ts). Ideal for single-server deployments, edge functions, and embedded applications.
+
+## Installation
+
+```sh
+npm install @rotorsoft/act @rotorsoft/act-sqlite
+# or
+pnpm add @rotorsoft/act @rotorsoft/act-sqlite
+```
+
+**Requirements:** Node.js >= 22.18.0
+
+## Usage
+
+```typescript
+import { act, state, store } from "@rotorsoft/act";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+import { z } from "zod";
+
+// Inject the SQLite store before building your app
+store(new SqliteStore({ url: "file:myapp.db" }));
+
+// Initialize tables (creates events table, streams table, and indexes)
+await store().seed();
+
+// Build and use your app as normal
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ amount: z.number() }) })
+  .patch({ Incremented: ({ data }, s) => ({ count: s.count + data.amount }) })
+  .on({ increment: z.object({ by: z.number() }) })
+    .emit((action) => ["Incremented", { amount: action.by }])
+  .build();
+
+const app = act().withState(Counter).build();
+await app.do("increment", { stream: "counter1", actor: { id: "1", name: "User" } }, { by: 1 });
+```
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `url` | `file::memory:` | SQLite connection URL. Use `file:path.db` for persistent storage. |
+| `authToken` | — | Auth token for libSQL server connections (Turso). |
+
+### File-Based Storage
+
+```typescript
+store(new SqliteStore({ url: "file:data/events.db" }));
+```
+
+### In-Memory (Testing)
+
+```typescript
+store(new SqliteStore()); // defaults to file::memory:
+```
+
+### Turso (Edge)
+
+```typescript
+store(new SqliteStore({
+  url: process.env.TURSO_URL!,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+}));
+```
+
+## Features
+
+- **ACID Transactions** — All write operations use SQLite write transactions for atomicity
+- **Optimistic Concurrency** — Version-based conflict detection prevents lost updates
+- **WAL Mode** — Write-Ahead Logging enables concurrent readers during writes
+- **Serialized Writes** — SQLite's single-writer model guarantees mutual exclusion (equivalent to `FOR UPDATE SKIP LOCKED` for single-server use)
+- **Auto Schema Setup** — `seed()` creates all required tables and indexes
+- **Zero Dependencies** — Only requires `@libsql/client` (no native bindings)
+- **Edge-Ready** — Works with Turso for distributed SQLite at the edge
+
+## Database Schema
+
+Calling `seed()` creates two tables:
+
+**Events table** (`events`) — stores all committed events:
+- `id` (INTEGER PRIMARY KEY) — global event sequence (autoincrement)
+- `name` — event type name
+- `data` (TEXT/JSON) — event payload
+- `stream` — stream identifier
+- `version` — per-stream sequence number
+- `created` — ISO 8601 timestamp
+- `meta` (TEXT/JSON) — correlation, causation, and actor metadata
+
+**Streams table** (`streams`) — tracks stream processing state:
+- `stream` — stream identifier (PRIMARY KEY)
+- `source` — source stream pattern for reactions
+- `at` — last processed event position (watermark)
+- `leased_by` / `leased_until` — processing claim info
+- `blocked` / `error` — error tracking for failed streams
+
+## Concurrency Model
+
+SQLite serializes all write transactions at the database level. This means:
+
+- **No lock contention** — write transactions queue automatically
+- **Equivalent guarantees** — for single-server deployments, this provides the same isolation as PostgreSQL's `FOR UPDATE SKIP LOCKED`
+- **Lease ownership** — `ack()` and `block()` validate `leased_by` to prevent stale workers from interfering
+
+For multi-server deployments requiring distributed stream processing, use [@rotorsoft/act-pg](https://www.npmjs.com/package/@rotorsoft/act-pg) instead.
+
+## SQLite vs PostgreSQL
+
+| Feature | act-sqlite | act-pg |
+|---------|-----------|--------|
+| Deployment | Single server, edge | Multi-server, distributed |
+| Setup | Zero config (file path) | Connection pool config |
+| Concurrency | Serialized writes | `FOR UPDATE SKIP LOCKED` |
+| JSON storage | TEXT + `json_extract()` | Native JSONB |
+| Streaming | Callback pattern | Callback pattern |
+| Performance | Fast for moderate loads | Scales horizontally |
+
+## Related
+
+- [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act) — Core framework
+- [@rotorsoft/act-pg](https://www.npmjs.com/package/@rotorsoft/act-pg) — PostgreSQL adapter
+- [Documentation](https://rotorsoft.github.io/act-root/)
+- [Examples](https://github.com/rotorsoft/act-root/tree/master/packages)
+
+## License
+
+[MIT](https://github.com/rotorsoft/act-root/blob/master/LICENSE)

--- a/libs/act-sqlite/package.json
+++ b/libs/act-sqlite/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@rotorsoft/act-sqlite",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "act sqlite adapters",
+  "author": "rotorsoft",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rotorsoft/act-root.git",
+    "directory": "libs/act-sqlite"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/@types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/@types/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "types": "tsc --build tsconfig.build.json --emitDeclarationOnly",
+    "build": "pnpm clean && tsup && pnpm types"
+  },
+  "dependencies": {
+    "@rotorsoft/act": "workspace:^",
+    "@libsql/client": "^0.17.2",
+    "zod": "^4.3.6"
+  }
+}

--- a/libs/act-sqlite/src/SqliteStore.ts
+++ b/libs/act-sqlite/src/SqliteStore.ts
@@ -1,0 +1,472 @@
+import { createClient, type Client } from "@libsql/client";
+import type {
+  Committed,
+  EventMeta,
+  Lease,
+  Message,
+  Query,
+  Schemas,
+  Store,
+} from "@rotorsoft/act";
+
+/**
+ * SQLite store configuration
+ */
+export interface SqliteConfig {
+  /** Path to the SQLite database file (default: ":memory:") */
+  url: string;
+  /** Auth token for libSQL server connections (optional) */
+  authToken?: string;
+}
+
+const DEFAULT_CONFIG: SqliteConfig = {
+  url: "file::memory:",
+};
+
+/**
+ * SQLite event store adapter for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act).
+ *
+ * Provides persistent event storage using SQLite via `@libsql/client`.
+ * All write operations use transactions for ACID guarantees.
+ * Since SQLite serializes writes at the database level, the concurrency
+ * model is equivalent to PostgreSQL's `FOR UPDATE SKIP LOCKED` for
+ * single-server deployments.
+ *
+ * @example
+ * ```typescript
+ * import { store } from "@rotorsoft/act";
+ * import { SqliteStore } from "@rotorsoft/act-sqlite";
+ *
+ * store(new SqliteStore({ url: "file:myapp.db" }));
+ * await store().seed();
+ * ```
+ */
+export class SqliteStore implements Store {
+  private client: Client;
+
+  constructor(config: Partial<SqliteConfig> = {}) {
+    const cfg = { ...DEFAULT_CONFIG, ...config };
+    this.client = createClient({
+      url: cfg.url,
+      authToken: cfg.authToken,
+    });
+  }
+
+  async seed() {
+    await this.client.execute("PRAGMA journal_mode=WAL");
+    await this.client.execute(`
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        stream TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        data TEXT NOT NULL,
+        meta TEXT NOT NULL,
+        created TEXT NOT NULL,
+        UNIQUE(stream, version)
+      )
+    `);
+    await this.client.execute(
+      "CREATE INDEX IF NOT EXISTS idx_events_stream ON events(stream)"
+    );
+    await this.client.execute(
+      "CREATE INDEX IF NOT EXISTS idx_events_name ON events(name)"
+    );
+    await this.client.execute(`
+      CREATE TABLE IF NOT EXISTS streams (
+        stream TEXT PRIMARY KEY,
+        source TEXT,
+        at INTEGER NOT NULL DEFAULT -1,
+        retry INTEGER NOT NULL DEFAULT 0,
+        blocked INTEGER NOT NULL DEFAULT 0,
+        error TEXT NOT NULL DEFAULT '',
+        leased_by TEXT,
+        leased_until TEXT
+      )
+    `);
+  }
+
+  async drop() {
+    await this.client.execute("DROP TABLE IF EXISTS events");
+    await this.client.execute("DROP TABLE IF EXISTS streams");
+  }
+
+  async dispose() {
+    await Promise.resolve();
+    this.client.close();
+  }
+
+  // --- commit: transaction + optimistic concurrency ---
+  async commit<E extends Schemas>(
+    stream: string,
+    msgs: Message<E, keyof E>[],
+    meta: EventMeta,
+    expectedVersion?: number
+  ): Promise<Committed<E, keyof E>[]> {
+    const tx = await this.client.transaction("write");
+    try {
+      const versionRow = await tx.execute({
+        sql: "SELECT COALESCE(MAX(version), -1) as v FROM events WHERE stream = ?",
+        args: [stream],
+      });
+      const currentVersion = Number(versionRow.rows[0].v);
+
+      if (
+        typeof expectedVersion === "number" &&
+        currentVersion !== expectedVersion
+      ) {
+        const { ConcurrencyError } = await import("@rotorsoft/act");
+        throw new ConcurrencyError(
+          stream,
+          currentVersion,
+          msgs as Message<Schemas, keyof Schemas>[],
+          expectedVersion
+        );
+      }
+
+      const now = new Date().toISOString();
+      const committed: Committed<E, keyof E>[] = [];
+      let version = currentVersion + 1;
+
+      for (const { name, data } of msgs) {
+        const result = await tx.execute({
+          sql: "INSERT INTO events (stream, version, name, data, meta, created) VALUES (?, ?, ?, ?, ?, ?)",
+          args: [
+            stream,
+            version,
+            name as string,
+            JSON.stringify(data),
+            JSON.stringify(meta),
+            now,
+          ],
+        });
+        committed.push({
+          id: Number(result.lastInsertRowid),
+          stream,
+          version,
+          created: new Date(now),
+          name,
+          data,
+          meta,
+        });
+        version++;
+      }
+
+      await tx.commit();
+      return committed;
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  }
+
+  // --- query: read-only, no transaction needed ---
+  async query<E extends Schemas>(
+    callback: (event: Committed<E, keyof E>) => void,
+    query?: Query
+  ): Promise<number> {
+    let sql = "SELECT * FROM events WHERE 1=1";
+    const args: unknown[] = [];
+
+    if (query?.stream) {
+      if (query.stream_exact) {
+        sql += " AND stream = ?";
+        args.push(query.stream);
+      } else {
+        // Convert regex-style patterns to SQL LIKE
+        const likePattern = query.stream
+          .replace(/\.\*/g, "%")
+          .replace(/\./g, "_");
+        sql += " AND stream LIKE ?";
+        args.push(likePattern);
+      }
+    }
+    if (query?.names) {
+      sql += ` AND name IN (${query.names.map(() => "?").join(",")})`;
+      args.push(...query.names);
+    }
+    if ((query as any)?.correlation) {
+      sql += " AND json_extract(meta, '$.correlation') = ?";
+      args.push((query as any).correlation);
+    }
+    if (query?.after !== undefined) {
+      sql += " AND id > ?";
+      args.push(query.after);
+    }
+    if (query?.before !== undefined) {
+      sql += " AND id < ?";
+      args.push(query.before);
+    }
+    if (query?.created_after) {
+      sql += " AND created > ?";
+      args.push(query.created_after.toISOString());
+    }
+    if (query?.created_before) {
+      sql += " AND created < ?";
+      args.push(query.created_before.toISOString());
+    }
+    if (!query?.with_snaps) {
+      sql += " AND name != '__snapshot__'";
+    }
+
+    sql += query?.backward ? " ORDER BY id DESC" : " ORDER BY id ASC";
+
+    if (query?.limit) {
+      sql += " LIMIT ?";
+      args.push(query.limit);
+    }
+
+    const result = await this.client.execute({ sql, args: args as any[] });
+    let count = 0;
+
+    for (const row of result.rows) {
+      callback({
+        id: Number(row.id),
+        stream: row.stream as string,
+        version: Number(row.version),
+        created: new Date(row.created as string),
+        name: row.name as string,
+        data: JSON.parse(row.data as string),
+        meta: JSON.parse(row.meta as string),
+      });
+      count++;
+    }
+
+    return count;
+  }
+
+  // --- subscribe: idempotent INSERT OR IGNORE (= PG ON CONFLICT DO NOTHING) ---
+  async subscribe(streams: Array<{ stream: string; source?: string }>) {
+    const tx = await this.client.transaction("write");
+    try {
+      let subscribed = 0;
+      for (const { stream, source } of streams) {
+        const result = await tx.execute({
+          sql: "INSERT OR IGNORE INTO streams (stream, source) VALUES (?, ?)",
+          args: [stream, source ?? null],
+        });
+        if (result.rowsAffected > 0) subscribed++;
+      }
+      const wm = await tx.execute(
+        "SELECT COALESCE(MAX(at), -1) as w FROM streams"
+      );
+      await tx.commit();
+      return { subscribed, watermark: Number(wm.rows[0].w) };
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  }
+
+  // --- claim: write transaction (SQLite serializes writes = equivalent
+  //     to PG FOR UPDATE SKIP LOCKED for single-server) ---
+  async claim(lagging: number, leading: number, by: string, millis: number) {
+    const tx = await this.client.transaction("write");
+    try {
+      const now = new Date().toISOString();
+
+      const result = await tx.execute({
+        sql: `SELECT stream, source, at FROM streams
+              WHERE blocked = 0 AND (leased_until IS NULL OR leased_until <= ?)
+              ORDER BY at ASC`,
+        args: [now],
+      });
+
+      const candidates: {
+        stream: string;
+        source: string | undefined;
+        at: number;
+      }[] = [];
+      for (const row of result.rows) {
+        const stream = row.stream as string;
+        const source = row.source as string | null;
+        const at = Number(row.at);
+
+        let hasEvents: boolean;
+        if (source) {
+          const likePattern = source.replace(/\.\*/g, "%").replace(/\./g, "_");
+          const check = await tx.execute({
+            sql: `SELECT 1 FROM events WHERE id > ? AND name != '__snapshot__' AND stream LIKE ? LIMIT 1`,
+            args: [at, likePattern],
+          });
+          hasEvents = check.rows.length > 0;
+        } else {
+          const check = await tx.execute({
+            sql: `SELECT 1 FROM events WHERE id > ? AND name != '__snapshot__' LIMIT 1`,
+            args: [at],
+          });
+          hasEvents = check.rows.length > 0;
+        }
+
+        if (hasEvents) {
+          candidates.push({ stream, source: source ?? undefined, at });
+        }
+      }
+
+      // Dual frontier: lagging (oldest first) + leading (newest first)
+      const lag = candidates.slice(0, lagging);
+      const lead = [...candidates]
+        .sort((a, b) => b.at - a.at)
+        .slice(0, leading);
+      const seen = new Set<string>();
+      const combined = [...lag, ...lead].filter((p) => {
+        if (seen.has(p.stream)) return false;
+        seen.add(p.stream);
+        return true;
+      });
+
+      const leases: Lease[] = [];
+      const until = new Date(Date.now() + millis).toISOString();
+      for (const row of combined) {
+        await tx.execute({
+          sql: "UPDATE streams SET leased_by = ?, leased_until = ?, retry = retry + 1 WHERE stream = ?",
+          args: [by, until, row.stream],
+        });
+        leases.push({
+          stream: row.stream,
+          source: row.source,
+          at: row.at,
+          by,
+          retry: 0,
+          lagging: row.at < 0,
+        });
+      }
+
+      await tx.commit();
+      return leases;
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  }
+
+  // --- ack: transaction + ownership check (= PG WHERE leased_by) ---
+  async ack(leases: Lease[]) {
+    const tx = await this.client.transaction("write");
+    try {
+      const result: Lease[] = [];
+      for (const l of leases) {
+        const r = await tx.execute({
+          sql: `UPDATE streams SET at = ?, leased_by = NULL, leased_until = NULL, retry = -1
+                WHERE stream = ? AND leased_by = ?`,
+          args: [l.at, l.stream, l.by],
+        });
+        if (r.rowsAffected > 0) result.push(l);
+      }
+      await tx.commit();
+      return result;
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  }
+
+  // --- block: transaction + ownership + idempotent (= PG) ---
+  async block(leases: Array<Lease & { error: string }>) {
+    const tx = await this.client.transaction("write");
+    try {
+      const result: Array<Lease & { error: string }> = [];
+      for (const l of leases) {
+        const r = await tx.execute({
+          sql: `UPDATE streams SET blocked = 1, error = ?
+                WHERE stream = ? AND leased_by = ? AND blocked = 0`,
+          args: [l.error, l.stream, l.by],
+        });
+        if (r.rowsAffected > 0) result.push(l);
+      }
+      await tx.commit();
+      return result;
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  }
+
+  // --- reset: transactional ---
+  async reset(streams: string[]) {
+    const tx = await this.client.transaction("write");
+    try {
+      let count = 0;
+      for (const stream of streams) {
+        const r = await tx.execute({
+          sql: `UPDATE streams SET at = -1, retry = 0, blocked = 0, error = '',
+                leased_by = NULL, leased_until = NULL WHERE stream = ?`,
+          args: [stream],
+        });
+        count += r.rowsAffected;
+      }
+      await tx.commit();
+      return count;
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  }
+
+  // --- truncate: transactional delete + seed ---
+  async truncate(
+    targets: Array<{
+      stream: string;
+      snapshot?: Record<string, unknown>;
+      meta?: EventMeta;
+    }>
+  ) {
+    const result = new Map<
+      string,
+      { deleted: number; committed: Committed<Schemas, keyof Schemas> }
+    >();
+
+    const tx = await this.client.transaction("write");
+    try {
+      for (const { stream, snapshot, meta } of targets) {
+        const countRow = await tx.execute({
+          sql: "SELECT COUNT(*) as c FROM events WHERE stream = ?",
+          args: [stream],
+        });
+        const deleted = Number(countRow.rows[0].c);
+        await tx.execute({
+          sql: "DELETE FROM events WHERE stream = ?",
+          args: [stream],
+        });
+        await tx.execute({
+          sql: "DELETE FROM streams WHERE stream = ?",
+          args: [stream],
+        });
+
+        const eventName =
+          snapshot !== undefined ? "__snapshot__" : "__tombstone__";
+        const eventMeta = meta ?? { correlation: "", causation: {} };
+        const now = new Date().toISOString();
+        const ins = await tx.execute({
+          sql: "INSERT INTO events (stream, version, name, data, meta, created) VALUES (?, 0, ?, ?, ?, ?)",
+          args: [
+            stream,
+            eventName,
+            JSON.stringify(snapshot ?? {}),
+            JSON.stringify(eventMeta),
+            now,
+          ],
+        });
+
+        result.set(stream, {
+          deleted,
+          committed: {
+            id: Number(ins.lastInsertRowid),
+            stream,
+            version: 0,
+            created: new Date(now),
+            name: eventName,
+            data: snapshot ?? {},
+            meta: eventMeta,
+          },
+        });
+      }
+      await tx.commit();
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+
+    return result;
+  }
+}

--- a/libs/act-sqlite/src/index.ts
+++ b/libs/act-sqlite/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @packageDocumentation
+ * @module act-sqlite
+ * Main entry point for the Act-SQLite adapter. Re-exports all core APIs
+ */
+export * from "./SqliteStore.js";

--- a/libs/act-sqlite/test/app.ts
+++ b/libs/act-sqlite/test/app.ts
@@ -1,0 +1,54 @@
+import { act, ReactionHandler, sleep, state, ZodEmpty } from "@rotorsoft/act";
+import z from "zod";
+
+const counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ incremented: ZodEmpty, decremented: ZodEmpty })
+  .patch({
+    incremented: (_, state) => ({ count: state.count + 1 }),
+    decremented: (_, state) => ({ count: state.count - 1 }),
+  })
+  .on({ increment: ZodEmpty })
+  .emit(() => ["incremented", {}])
+  .on({ decrement: ZodEmpty })
+  .emit(() => ["decremented", {}])
+  .build();
+
+export const onIncremented = vi.fn().mockImplementation(async () => {
+  await sleep(100);
+  console.log("onIncremented OK");
+});
+export const onDecremented = vi.fn().mockImplementation(async () => {
+  await sleep(100);
+  throw new Error("onDecremented failed");
+});
+
+export const app = act()
+  .withState(counter)
+  .on("incremented")
+  .do(
+    onIncremented as ReactionHandler<
+      {
+        incremented: Record<string, never>;
+        decremented: Record<string, never>;
+      },
+      "incremented"
+    >
+  )
+  .on("decremented")
+  .do(
+    onDecremented as ReactionHandler<
+      {
+        incremented: Record<string, never>;
+        decremented: Record<string, never>;
+      },
+      "decremented"
+    >,
+    {
+      maxRetries: 2,
+      blockOnError: true,
+    }
+  )
+  .build();
+
+export const actor = { id: "a", name: "a" };

--- a/libs/act-sqlite/test/store.error.spec.ts
+++ b/libs/act-sqlite/test/store.error.spec.ts
@@ -1,0 +1,212 @@
+import { ConcurrencyError } from "@rotorsoft/act";
+import { SqliteStore } from "../src/index.js";
+
+type Stmt = string | { sql: string; args?: unknown[] };
+
+const sqlOf = (s: Stmt) => (typeof s === "string" ? s : s.sql);
+
+const okExecute = (stmt?: Stmt) => {
+  void stmt;
+  return Promise.resolve({
+    rows: [],
+    rowsAffected: 0,
+    lastInsertRowid: 0,
+    columns: [],
+    columnTypes: [],
+    toJSON: () => ({}),
+  });
+};
+
+const txOk = () => ({
+  execute: vi.fn<(stmt: Stmt) => Promise<unknown>>(okExecute),
+  commit: vi.fn(() => Promise.resolve()),
+  rollback: vi.fn(() => Promise.resolve()),
+  close: vi.fn(),
+});
+
+/**
+ * Build a mock libsql Client whose write transaction fails on `execute()`
+ * for SQL statements containing `failOn`. All other executes resolve to a
+ * neutral "no rows" result so prior steps in each method succeed.
+ */
+function mockClientFailOn(failOn: string) {
+  const tx = {
+    rollback: vi.fn(() => Promise.resolve()),
+    commit: vi.fn(() => Promise.resolve()),
+    close: vi.fn(),
+    execute: vi.fn((stmt: Stmt) => {
+      const sql = sqlOf(stmt);
+      if (sql.includes(failOn))
+        return Promise.reject(new Error(`mocked ${failOn} error`));
+      // Provide neutral defaults for SELECTs
+      if (sql.includes("MAX(version)")) {
+        return Promise.resolve({
+          rows: [{ v: -1 }],
+          rowsAffected: 0,
+          lastInsertRowid: 0,
+        });
+      }
+      if (sql.includes("MAX(at)")) {
+        return Promise.resolve({
+          rows: [{ w: -1 }],
+          rowsAffected: 0,
+          lastInsertRowid: 0,
+        });
+      }
+      if (sql.includes("COUNT(*)")) {
+        return Promise.resolve({
+          rows: [{ c: 0 }],
+          rowsAffected: 0,
+          lastInsertRowid: 0,
+        });
+      }
+      if (sql.includes("SELECT stream, source, at FROM streams")) {
+        return Promise.resolve({
+          rows: [],
+          rowsAffected: 0,
+          lastInsertRowid: 0,
+        });
+      }
+      if (sql.includes("SELECT 1 FROM events")) {
+        return Promise.resolve({
+          rows: [],
+          rowsAffected: 0,
+          lastInsertRowid: 0,
+        });
+      }
+      return Promise.resolve({
+        rows: [],
+        rowsAffected: 1,
+        lastInsertRowid: 1,
+      });
+    }),
+  };
+  return {
+    transaction: vi.fn(() => Promise.resolve(tx)),
+    execute: vi.fn(okExecute),
+    close: vi.fn(),
+    _tx: tx,
+  };
+}
+
+describe("SqliteStore error paths", () => {
+  let db: SqliteStore;
+
+  beforeEach(() => {
+    db = new SqliteStore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("constructs with default config (in-memory)", () => {
+    const s = new SqliteStore();
+    expect(s).toBeInstanceOf(SqliteStore);
+  });
+
+  it("accepts a custom url and authToken", () => {
+    const s = new SqliteStore({ url: "file::memory:", authToken: "tok" });
+    expect(s).toBeInstanceOf(SqliteStore);
+  });
+
+  it("commit: rolls back and rethrows on INSERT failure", async () => {
+    const client = mockClientFailOn("INSERT INTO events");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(
+      db.commit("s", [{ name: "E", data: {} }], {
+        correlation: "",
+        causation: {},
+      })
+    ).rejects.toThrow(/mocked INSERT INTO events error/);
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+
+  it("commit: throws ConcurrencyError when expectedVersion mismatches", async () => {
+    const tx = txOk();
+    tx.execute.mockImplementation((stmt: Stmt) => {
+      const sql = sqlOf(stmt);
+      if (sql.includes("MAX(version)")) {
+        return Promise.resolve({
+          rows: [{ v: 5 }],
+          rowsAffected: 0,
+          lastInsertRowid: 0,
+        });
+      }
+      return okExecute();
+    });
+    (db as unknown as { client: unknown }).client = {
+      transaction: () => Promise.resolve(tx),
+      execute: okExecute,
+      close: () => {},
+    };
+    await expect(
+      db.commit(
+        "s",
+        [{ name: "E", data: {} }],
+        { correlation: "", causation: {} },
+        0
+      )
+    ).rejects.toThrow(ConcurrencyError);
+    expect(tx.rollback).toHaveBeenCalled();
+  });
+
+  it("subscribe: rolls back and rethrows on INSERT failure", async () => {
+    const client = mockClientFailOn("INSERT OR IGNORE INTO streams");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(db.subscribe([{ stream: "x" }])).rejects.toThrow(
+      /INSERT OR IGNORE/
+    );
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+
+  it("claim: rolls back and rethrows on SELECT failure", async () => {
+    const client = mockClientFailOn("SELECT stream, source, at FROM streams");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(db.claim(1, 0, "w", 1000)).rejects.toThrow(/SELECT stream/);
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+
+  it("ack: rolls back and rethrows on UPDATE failure", async () => {
+    const client = mockClientFailOn("UPDATE streams SET at");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(
+      db.ack([{ stream: "x", at: 1, by: "w", retry: 0, lagging: false }])
+    ).rejects.toThrow(/UPDATE streams SET at/);
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+
+  it("block: rolls back and rethrows on UPDATE failure", async () => {
+    const client = mockClientFailOn("UPDATE streams SET blocked");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(
+      db.block([
+        {
+          stream: "x",
+          at: 0,
+          by: "w",
+          retry: 0,
+          lagging: false,
+          error: "e",
+        },
+      ])
+    ).rejects.toThrow(/UPDATE streams SET blocked/);
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+
+  it("reset: rolls back and rethrows on UPDATE failure", async () => {
+    const client = mockClientFailOn("UPDATE streams SET at = -1");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(db.reset(["x"])).rejects.toThrow(/UPDATE streams SET at = -1/);
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+
+  it("truncate: rolls back and rethrows on DELETE failure", async () => {
+    const client = mockClientFailOn("DELETE FROM events");
+    (db as unknown as { client: unknown }).client = client;
+    await expect(db.truncate([{ stream: "x" }])).rejects.toThrow(
+      /DELETE FROM events/
+    );
+    expect(client._tx.rollback).toHaveBeenCalled();
+  });
+});

--- a/libs/act-sqlite/test/store.spec.ts
+++ b/libs/act-sqlite/test/store.spec.ts
@@ -201,4 +201,177 @@ describe("sqlite store", () => {
     expect(events.filter((e) => e.name === "incremented").length).toBe(2);
     expect(events.filter((e) => e.name === "decremented").length).toBe(1);
   });
+
+  it("should query with no params", async () => {
+    const count = await store().query(() => {});
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it("should query with non-exact stream pattern (LIKE)", async () => {
+    await store().commit("regex-A", [{ name: "rt", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    await store().commit("regex-B", [{ name: "rt", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const result: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => result.push(e), { stream: "regex-.*" });
+    expect(result.length).toBe(2);
+    // single-char wildcard via "."
+    const result2: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => result2.push(e), { stream: "regex-." });
+    expect(result2.length).toBe(2);
+  });
+
+  it("should query by correlation", async () => {
+    const correlation = chance.guid();
+    await store().commit("corr-test", [{ name: "ct", data: {} }], {
+      correlation,
+      causation: {},
+    });
+    const result: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => result.push(e), { correlation });
+    expect(result.length).toBe(1);
+  });
+
+  it("should query with before id", async () => {
+    const all: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => all.push(e));
+    const cutoff = all[2].id;
+    const result: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => result.push(e), { before: cutoff });
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((e) => e.id < cutoff)).toBe(true);
+  });
+
+  it("should query with after id", async () => {
+    const result: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => result.push(e), { after: 1, limit: 3 });
+    expect(result.length).toBe(3);
+    expect(result.every((e) => e.id > 1)).toBe(true);
+  });
+
+  it("should commit empty events array", async () => {
+    const result = await store().commit("empty-test", [], {
+      correlation: "",
+      causation: {},
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("should re-subscribing existing stream returns 0", async () => {
+    await store().subscribe([{ stream: "resub-test" }]);
+    const { subscribed } = await store().subscribe([{ stream: "resub-test" }]);
+    expect(subscribed).toBe(0);
+  });
+
+  it("should reset empty array", async () => {
+    const count = await store().reset([]);
+    expect(count).toBe(0);
+  });
+
+  it("should reset non-existent streams returns 0", async () => {
+    const count = await store().reset(["does-not-exist-xyz"]);
+    expect(count).toBe(0);
+  });
+
+  it("should truncate with tombstone (no snapshot)", async () => {
+    const stream = "tombstone-test";
+    await store().commit(stream, [{ name: "e1", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const result = await store().truncate([{ stream }]);
+    expect(result.get(stream)?.deleted).toBe(1);
+    expect(result.get(stream)?.committed.name).toBe("__tombstone__");
+  });
+
+  it("should truncate with custom meta", async () => {
+    const stream = "trunc-meta";
+    await store().commit(stream, [{ name: "e", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const meta = {
+      correlation: "X",
+      causation: {
+        action: { stream, name: "n", actor: { id: "1", name: "u" } },
+      },
+    };
+    const result = await store().truncate([{ stream, meta }]);
+    expect(result.get(stream)?.committed.meta.correlation).toBe("X");
+  });
+
+  it("should claim with leading frontier (dual frontiers)", async () => {
+    await store().subscribe([{ stream: "lead-test" }]);
+    await store().commit(
+      "lead-test",
+      [
+        { name: "x", data: {} },
+        { name: "x", data: {} },
+      ],
+      { correlation: "", causation: {} }
+    );
+    const claimed = await store().claim(0, 10, "leader-1", 30000);
+    expect(claimed.length).toBeGreaterThan(0);
+    if (claimed.length)
+      await store().ack(claimed.map((l) => ({ ...l, at: 0 })));
+  });
+
+  it("should not claim blocked streams", async () => {
+    await store().subscribe([{ stream: "blocked-not-claimed" }]);
+    await store().commit("blocked-not-claimed", [{ name: "z", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const claimed = await store().claim(100, 0, "w-block", 30000);
+    const target = claimed.find((l) => l.stream === "blocked-not-claimed");
+    expect(target).toBeDefined();
+    const others = claimed.filter((l) => l.stream !== "blocked-not-claimed");
+    if (others.length) await store().ack(others);
+    await store().block([{ ...target!, error: "boom" }]);
+
+    const claimed2 = await store().claim(100, 100, "w-block-2", 30000);
+    expect(
+      claimed2.find((l) => l.stream === "blocked-not-claimed")
+    ).toBeUndefined();
+    if (claimed2.length) await store().ack(claimed2);
+    await store().reset(["blocked-not-claimed"]);
+  });
+
+  it("should not block a stream leased by a different drainer", async () => {
+    await store().subscribe([{ stream: "block-wrong-drainer" }]);
+    await store().commit("block-wrong-drainer", [{ name: "z", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const claimed = await store().claim(100, 0, "actor-1", 100000);
+    const target = claimed.find((l) => l.stream === "block-wrong-drainer");
+    expect(target).toBeDefined();
+    const others = claimed.filter((l) => l.stream !== "block-wrong-drainer");
+    if (others.length) await store().ack(others);
+
+    const blocked = await store().block([
+      { ...target!, by: "actor-2", error: "wrong drainer" },
+    ]);
+    expect(blocked.length).toBe(0);
+  });
+
+  it("should not ack a lease owned by a different drainer", async () => {
+    await store().subscribe([{ stream: "ack-wrong-drainer" }]);
+    await store().commit("ack-wrong-drainer", [{ name: "z", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const claimed = await store().claim(100, 0, "owner-1", 100000);
+    const target = claimed.find((l) => l.stream === "ack-wrong-drainer");
+    expect(target).toBeDefined();
+    const others = claimed.filter((l) => l.stream !== "ack-wrong-drainer");
+    if (others.length) await store().ack(others);
+
+    const acked = await store().ack([{ ...target!, by: "owner-2", at: 99 }]);
+    expect(acked.length).toBe(0);
+  });
 });

--- a/libs/act-sqlite/test/store.spec.ts
+++ b/libs/act-sqlite/test/store.spec.ts
@@ -1,0 +1,204 @@
+import {
+  Committed,
+  ConcurrencyError,
+  SNAP_EVENT,
+  Schemas,
+  dispose,
+  sleep,
+  store,
+} from "@rotorsoft/act";
+import { Chance } from "chance";
+import { SqliteStore } from "../src/index.js";
+import { actor, app } from "./app.js";
+
+const chance = new Chance();
+const a1 = chance.guid();
+const a2 = chance.guid();
+const a3 = chance.guid();
+let created_before: Date;
+let created_after: Date;
+
+describe("sqlite store", () => {
+  beforeAll(async () => {
+    store(new SqliteStore({ url: "file:test-store.db" }));
+    await store().drop();
+    await store().seed();
+  });
+
+  afterAll(async () => {
+    await dispose()();
+    // Clean up test DB
+    const fs = await import("fs");
+    try {
+      fs.unlinkSync("test-store.db");
+    } catch {
+      // file may not exist
+    }
+  });
+
+  it("should commit and query", async () => {
+    const query_correlation = chance.guid();
+
+    await store().commit(a1, [{ name: "test1", data: { value: "1" } }], {
+      correlation: "",
+      causation: {
+        action: { stream: a1, name: "", actor: { id: "pm", name: "" } },
+      },
+    });
+    created_after = new Date();
+    await sleep(200);
+
+    await store().commit(a1, [{ name: "test1", data: { value: "2" } }], {
+      correlation: query_correlation,
+      causation: {},
+    });
+    await store().commit(a2, [{ name: "test2", data: { value: "3" } }], {
+      correlation: "",
+      causation: {
+        action: { stream: a2, name: "", actor: { id: "pm", name: "" } },
+      },
+    });
+    await store().commit(a3, [{ name: "test1", data: { value: "4" } }], {
+      correlation: "",
+      causation: {},
+    });
+
+    await sleep(200);
+    created_before = new Date();
+
+    // Query all events
+    const events: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => events.push(e));
+    expect(events.length).toBe(4);
+
+    // Query by stream (exact)
+    const streamEvents: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => streamEvents.push(e), {
+      stream: a1,
+      stream_exact: true,
+    });
+    expect(streamEvents.length).toBe(2);
+
+    // Query by name filter
+    const nameEvents: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => nameEvents.push(e), { names: ["test1"] });
+    expect(nameEvents.length).toBe(3);
+
+    // Query by time range
+    const timeEvents: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => timeEvents.push(e), {
+      created_after,
+      created_before,
+    });
+    expect(timeEvents.length).toBe(3);
+
+    // Query with limit
+    const limitEvents: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => limitEvents.push(e), { limit: 2 });
+    expect(limitEvents.length).toBe(2);
+
+    // Query backward
+    const backEvents: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => backEvents.push(e), { backward: true });
+    expect(backEvents[0].id).toBeGreaterThan(backEvents[1].id);
+  });
+
+  it("should detect concurrency errors", async () => {
+    await expect(
+      store().commit(
+        a1,
+        [{ name: "test1", data: { value: "conflict" } }],
+        { correlation: "", causation: {} },
+        0 // wrong expected version
+      )
+    ).rejects.toThrow(ConcurrencyError);
+  });
+
+  it("should subscribe, claim, and ack", async () => {
+    const { subscribed, watermark: _wm } = await store().subscribe([
+      { stream: "sub-1", source: a1 },
+      { stream: "sub-2", source: a2 },
+    ]);
+    expect(subscribed).toBe(2);
+
+    // Claim streams with pending events
+    const leases = await store().claim(10, 0, "worker-1", 30000);
+    expect(leases.length).toBeGreaterThan(0);
+
+    // Ack first lease
+    const acked = await store().ack(leases.map((l) => ({ ...l, at: 999 })));
+    expect(acked.length).toBe(leases.length);
+
+    // After ack, no more events to claim
+    const leases2 = await store().claim(10, 0, "worker-1", 30000);
+    expect(leases2.length).toBe(0);
+  });
+
+  it("should block streams on error", async () => {
+    await store().subscribe([{ stream: "block-test" }]);
+    // Reset to make it claimable
+    await store().reset(["block-test"]);
+
+    const leases = await store().claim(10, 0, "worker-1", 30000);
+    const blockTarget = leases.find((l) => l.stream === "block-test");
+    if (blockTarget) {
+      const blocked = await store().block([
+        { ...blockTarget, error: "test error" },
+      ]);
+      expect(blocked.length).toBe(1);
+
+      // Blocked streams should not be claimable
+      await store().reset(["block-test"]); // reset clears blocked flag
+    }
+  });
+
+  it("should reset streams", async () => {
+    const count = await store().reset(["sub-1", "sub-2"]);
+    expect(count).toBe(2);
+  });
+
+  it("should truncate streams", async () => {
+    const stream = "truncate-test";
+    await store().commit(stream, [{ name: "e1", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    await store().commit(stream, [{ name: "e2", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+
+    const result = await store().truncate([
+      { stream, snapshot: { count: 42 } },
+    ]);
+    const entry = result.get(stream);
+    expect(entry?.deleted).toBe(2);
+    expect(entry?.committed.name).toBe(SNAP_EVENT);
+
+    // Verify only snapshot remains
+    const events: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => events.push(e), {
+      stream,
+      stream_exact: true,
+      with_snaps: true,
+    });
+    expect(events.length).toBe(1);
+    expect(events[0].name).toBe(SNAP_EVENT);
+  });
+
+  it("should work with the act app", async () => {
+    await app.do("increment", { stream: "c1", actor }, {});
+    await app.do("increment", { stream: "c1", actor }, {});
+    await app.do("decrement", { stream: "c1", actor }, {});
+
+    // Query events for the stream to verify
+    const events: Committed<Schemas, keyof Schemas>[] = [];
+    await store().query((e) => events.push(e), {
+      stream: "c1",
+      stream_exact: true,
+    });
+    expect(events.length).toBe(3);
+    expect(events.filter((e) => e.name === "incremented").length).toBe(2);
+    expect(events.filter((e) => e.name === "decremented").length).toBe(1);
+  });
+});

--- a/libs/act-sqlite/tsconfig.build.json
+++ b/libs/act-sqlite/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declarationDir": "dist/@types",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "references": [
+    {
+      "path": "../act/tsconfig.build.json"
+    }
+  ],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "test",
+    "dist",
+    "node_modules"
+  ]
+}

--- a/libs/act-sqlite/tsconfig.json
+++ b/libs/act-sqlite/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "references": [
+    {
+      "path": "../act"
+    }
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,18 @@ importers:
         specifier: ^13.1.3
         version: 13.1.3
 
+  libs/act-sqlite:
+    dependencies:
+      '@libsql/client':
+        specifier: ^0.17.2
+        version: 0.17.3
+      '@rotorsoft/act':
+        specifier: workspace:^
+        version: link:../act
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
   libs/act-sse:
     dependencies:
       '@rotorsoft/act-patch':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "./libs/act-pg"
     },
     {
+      "path": "./libs/act-sqlite"
+    },
+    {
       "path": "./libs/act-sse"
     }
   ]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         __dirname,
         "libs/act-pino/src/index.ts"
       ),
+      "@rotorsoft/act-sqlite": path.resolve(
+        __dirname,
+        "libs/act-sqlite/src/index.ts"
+      ),
       "@rotorsoft/act": path.resolve(__dirname, "libs/act/src/index.ts"),
     },
   },


### PR DESCRIPTION
## Summary
- Adds `@rotorsoft/act-sqlite` — a libSQL-backed Store adapter for embedded / single-node deployments. Serializes writes at the DB level (equivalent to PG's `FOR UPDATE SKIP LOCKED` for single-server).
- Test suite reaches 100% statements / 100% branches / 100% functions / 100% lines on `SqliteStore.ts`. Mirrors the patterns in `act-pg` tests (integration paths + mocked error/rollback paths).
- Wires the new adapter into the root README, `CLAUDE.md`, docs site (intro, event-sourcing, configuration, sidebars, typedoc, tsconfig), and the `scaffold-act-app` skill.

## Test plan
- [x] `pnpm vitest run libs/act-sqlite --coverage --coverage.include='libs/act-sqlite/src/**'` → 32 tests, 100% across the board
- [x] `pnpm vitest run libs/act-sqlite libs/act` → 797 tests pass
- [x] `pnpm typecheck` clean
- [ ] Smoke-test docs build (`pnpm -F docs build`)
- [ ] Verify the typedoc API page for `@rotorsoft/act-sqlite` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)