### PR TITLE
fix(act-sqlite): reset version to 0.1.0 baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,6 +641,21 @@ Each example demonstrates different framework capabilities:
 4. Update example applications to demonstrate usage
 5. Ensure InMemoryStore, PostgresStore, and SqliteStore all support the feature
 
+### Adding a New Library to `/libs`
+
+When introducing a brand-new package (e.g., `@rotorsoft/act-foo`), seed a baseline tag **before** the first PR merges to `master` — otherwise `semantic-release` defaults the very first release to `1.0.0` (regardless of the version in `package.json`).
+
+```bash
+# After creating the package on a feature branch and BEFORE the first merge:
+git tag @rotorsoft/act-foo-v0.0.0 <commit-on-master-or-pre-feature>
+git push origin @rotorsoft/act-foo-v0.0.0
+```
+
+Also remember to:
+- Add the package name to the `cd` matrix in `.github/workflows/ci-cd.yml`
+- Copy `.releaserc.json` from a sibling lib and update `tagFormat`
+- Wire it into the root `README.md`, `CLAUDE.md`, `docs/sidebars.ts`, `docs/typedoc.json`, `docs/tsconfig.json`, and any relevant skills under `.claude/skills/`
+
 ### Documentation Guidelines
 
 - **README** — shows current patterns and strategies only, not historical benchmarks

--- a/libs/act-sqlite/CHANGELOG.md
+++ b/libs/act-sqlite/CHANGELOG.md
@@ -1,6 +1,0 @@
-# @rotorsoft/act-sqlite-v1.0.0 (2026-04-26)
-
-
-### Features
-
-* **act-sqlite:** add SQLite event store adapter ([69ae0d2](https://github.com/rotorsoft/act-root/commit/69ae0d2aae8e1b7f11ef9e2f977fcbbf4a771c20))

--- a/libs/act-sqlite/package.json
+++ b/libs/act-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rotorsoft/act-sqlite",
   "type": "module",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "act sqlite adapters",
   "author": "rotorsoft",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- The first CI run after #610 published `@rotorsoft/act-sqlite` as **v1.0.0** because no `@rotorsoft/act-sqlite-v*` tag existed on origin when semantic-release ran. Per its log: _"There is no previous release, the next release version is 1.0.0"_.
- The `@rotorsoft/act-sqlite-v1.0.0` tag and GitHub release have been deleted; the npm registry shows 404.
- A baseline tag `@rotorsoft/act-sqlite-v0.1.0` (at the original feat commit) has been pushed to origin.
- This PR resets `libs/act-sqlite/package.json` to `0.1.0` and deletes the auto-generated `CHANGELOG.md`, so when this `fix(...)` commit lands on `master`, semantic-release computes the next release from the v0.1.0 baseline as **v0.1.1**.
- Documents the gotcha in `CLAUDE.md` so future new libs seed a baseline tag before their first PR merges.

## Test plan
- [ ] Merge → CI publishes `@rotorsoft/act-sqlite@0.1.1`
- [ ] `npm view @rotorsoft/act-sqlite version` returns `0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)