### PR TITLE
feat(act): add Store.query_streams for subscription introspection

### DIFF
--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -552,3 +552,27 @@ async reset(streams: string[]): Promise<number> {
 2. Clear projected data (truncate read-model table, flush cache)
 3. `await app.reset(["projection-target"])`
 4. `app.settle()` (or wait on `"settled"`) — drives the catch-up to completion
+
+## 16. Subscription Introspection — store().query_streams()
+
+For operational dashboards (projection lag, blocked subscriptions, in-flight leases), use `store().query_streams()` instead of opening a second DB connection or running raw SQL against the adapter-specific streams table. The method is read-only and adapter-agnostic — works against `InMemoryStore`, `SqliteStore`, and `PostgresStore`.
+
+```typescript
+const { maxEventId, count } = await store().query_streams(
+  (position) => {
+    // position: { stream, source?, at, retry, blocked, error, leased_by?, leased_until? }
+    console.log(`${position.stream}: lag=${maxEventId - position.at}`);
+  },
+  {
+    stream: "^projection-",   // regex by default; pass stream_exact: true for equality
+    source: "user-.*",        // same regex/exact convention via source_exact
+    blocked: true,             // restrict to blocked / unblocked / omit for all
+    after: lastSeenStream,     // keyset cursor — pass last entry's stream for next page
+    limit: 100,                // default 100
+  }
+);
+```
+
+**Use the keyset cursor for paging.** Dynamic reactions can register one subscription per aggregate, so the streams table can grow large. The `after` cursor (last seen stream name, lexicographic) is cheap on big tables — no `OFFSET`. To page through all positions, call repeatedly with `after = lastPage.at(-1).stream` until `count < limit`.
+
+**Filter set is intentionally minimal.** Only what the streams table actually persists (`stream`, `source`, `blocked`). Higher-level classification ("is this a projection vs reaction?", "static vs dynamic resolver?") is an orchestrator concern — the table doesn't store kinds. Layer that on top by joining results with the orchestrator's known projections/reactions registry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -710,6 +710,7 @@ interface Store extends Disposable {
   block(leases): Promise<(Lease & { error })[]>;  // Block failed streams
   reset(streams): Promise<number>;                // Reset watermarks for projection rebuild
   truncate(targets: {stream, snapshot?, meta?}[]): Promise<{deleted, committed}>;  // Atomic truncate + seed
+  query_streams(callback, query?): Promise<{maxEventId, count}>;  // Read-only introspection of subscription positions
   dispose(): Promise<void>;                       // Cleanup resources
 }
 ```

--- a/docs/docs/concepts/configuration.md
+++ b/docs/docs/concepts/configuration.md
@@ -196,8 +196,11 @@ interface Store extends Disposable {
   subscribe(streams): Promise<{ subscribed: number; watermark: number }>;
   ack(leases): Promise<Lease[]>;
   block(leases): Promise<(Lease & { error })[]>;
+  reset(streams): Promise<number>;
+  truncate(targets): Promise<TruncateResult>;
+  query_streams(callback, query?): Promise<{ maxEventId: number; count: number }>;
   dispose(): Promise<void>;
 }
 ```
 
-`claim()` atomically discovers and locks streams for processing using PostgreSQL's `FOR UPDATE SKIP LOCKED` pattern — zero-contention competing consumers where workers never block each other. `subscribe()` registers new streams for reaction processing and returns the count of newly registered streams. Version-based optimistic concurrency must be implemented correctly. See the [PostgresStore source](https://github.com/rotorsoft/act-root/blob/master/libs/act-pg/src/PostgresStore.ts) for a production-grade reference.
+`claim()` atomically discovers and locks streams for processing using PostgreSQL's `FOR UPDATE SKIP LOCKED` pattern — zero-contention competing consumers where workers never block each other. `subscribe()` registers new streams for reaction processing and returns the count of newly registered streams. `query_streams()` is read-only introspection over subscription positions — used by operational dashboards (projection lag, blocked subscriptions) without opening a second connection or running raw SQL against the adapter-specific streams table. Version-based optimistic concurrency must be implemented correctly. See the [PostgresStore source](https://github.com/rotorsoft/act-root/blob/master/libs/act-pg/src/PostgresStore.ts) for a production-grade reference.

--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -5,9 +5,12 @@ import type {
   Logger,
   Message,
   Query,
+  QueryStreams,
+  QueryStreamsResult,
   Schema,
   Schemas,
   Store,
+  StreamPosition,
 } from "@rotorsoft/act";
 import {
   ConcurrencyError,
@@ -700,6 +703,93 @@ export class PostgresStore implements Store {
       [streams]
     );
     return rowCount ?? 0;
+  }
+
+  /**
+   * Streams subscription positions to a callback, ordered by stream name,
+   * along with the highest event id in the store.
+   *
+   * Filters (`stream`, `source`, `blocked`, `after`, `limit`) are applied
+   * server-side. `stream`/`source` are regex by default (`~`), or exact
+   * with `*_exact: true` — same convention as {@link Store.query}.
+   *
+   * @returns `maxEventId` and the `count` of positions emitted.
+   */
+  async query_streams(
+    callback: (position: StreamPosition) => void,
+    query?: QueryStreams
+  ): Promise<QueryStreamsResult> {
+    const limit = query?.limit ?? 100;
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+
+    if (query?.stream !== undefined) {
+      values.push(query.stream);
+      conditions.push(
+        query.stream_exact
+          ? `stream = $${values.length}`
+          : `stream ~ $${values.length}`
+      );
+    }
+    if (query?.source !== undefined) {
+      conditions.push(`source IS NOT NULL`);
+      values.push(query.source);
+      conditions.push(
+        query.source_exact
+          ? `source = $${values.length}`
+          : `source ~ $${values.length}`
+      );
+    }
+    if (query?.blocked !== undefined) {
+      values.push(query.blocked);
+      conditions.push(`blocked = $${values.length}`);
+    }
+    if (query?.after !== undefined) {
+      values.push(query.after);
+      conditions.push(`stream > $${values.length}`);
+    }
+    let sql = `SELECT stream, source, at, retry, blocked, error, leased_by, leased_until FROM ${this._fqs}`;
+    if (conditions.length) sql += " WHERE " + conditions.join(" AND ");
+    values.push(limit);
+    sql += ` ORDER BY stream LIMIT $${values.length}`;
+
+    const client = await this._pool.connect();
+    try {
+      const [streamsResult, maxResult] = await Promise.all([
+        client.query<{
+          stream: string;
+          source: string | null;
+          at: number;
+          retry: number;
+          blocked: boolean;
+          error: string | null;
+          leased_by: string | null;
+          leased_until: Date | null;
+        }>(sql, values),
+        client.query<{ m: number | null }>(
+          `SELECT COALESCE(MAX(id), -1) AS m FROM ${this._fqt}`
+        ),
+      ]);
+
+      let count = 0;
+      for (const row of streamsResult.rows) {
+        callback({
+          stream: row.stream,
+          source: row.source ?? undefined,
+          at: row.at,
+          retry: row.retry,
+          blocked: row.blocked,
+          error: row.error ?? "",
+          leased_by: row.leased_by ?? undefined,
+          leased_until: row.leased_until ?? undefined,
+        });
+        count++;
+      }
+
+      return { maxEventId: Number(maxResult.rows[0].m), count };
+    } finally {
+      client.release();
+    }
   }
 
   /**

--- a/libs/act-pg/test/store.spec.ts
+++ b/libs/act-pg/test/store.spec.ts
@@ -609,6 +609,116 @@ describe("pg store", () => {
       expect(blocked[0].error).toBe("test error");
     });
 
+    it("should query_streams with filters and pagination", async () => {
+      const s = store();
+      await s.subscribe([
+        { stream: "qs-projection-tickets" },
+        { stream: "qs-projection-users" },
+        { stream: "qs-stats-user-1", source: "qs-source-1" },
+        { stream: "qs-stats-user-2", source: "qs-source-2" },
+      ]);
+
+      // No filter beyond the prefix returns all four
+      const all: any[] = [];
+      const result = await s.query_streams((p) => all.push(p), {
+        stream: "^qs-",
+      });
+      expect(result.count).toBe(4);
+      expect(result.maxEventId).toBeGreaterThanOrEqual(0);
+      expect(all.map((p) => p.stream)).toEqual([
+        "qs-projection-tickets",
+        "qs-projection-users",
+        "qs-stats-user-1",
+        "qs-stats-user-2",
+      ]);
+
+      // stream regex
+      const projections: any[] = [];
+      await s.query_streams((p) => projections.push(p), {
+        stream: "^qs-projection-",
+      });
+      expect(projections).toHaveLength(2);
+
+      // stream_exact
+      const exact: any[] = [];
+      await s.query_streams((p) => exact.push(p), {
+        stream: "qs-stats-user-1",
+        stream_exact: true,
+      });
+      expect(exact).toHaveLength(1);
+      expect(exact[0].source).toBe("qs-source-1");
+
+      // source filter
+      const dynamics: any[] = [];
+      await s.query_streams((p) => dynamics.push(p), {
+        stream: "^qs-",
+        source: "^qs-source-",
+      });
+      expect(dynamics).toHaveLength(2);
+      expect(dynamics.every((p) => p.source !== undefined)).toBe(true);
+
+      // source_exact filter
+      const exactSource: any[] = [];
+      await s.query_streams((p) => exactSource.push(p), {
+        stream: "^qs-",
+        source: "qs-source-2",
+        source_exact: true,
+      });
+      expect(exactSource).toHaveLength(1);
+      expect(exactSource[0].stream).toBe("qs-stats-user-2");
+
+      // No filter at all — exercises the empty-conditions branch
+      const noFilter: any[] = [];
+      const noFilterResult = await s.query_streams(
+        (p) => noFilter.push(p),
+        undefined
+      );
+      expect(noFilterResult.count).toBeGreaterThan(0);
+      expect(noFilterResult.maxEventId).toBeGreaterThanOrEqual(0);
+
+      // limit + after pagination
+      const page1: any[] = [];
+      await s.query_streams((p) => page1.push(p), {
+        stream: "^qs-",
+        limit: 2,
+      });
+      expect(page1.map((p) => p.stream)).toEqual([
+        "qs-projection-tickets",
+        "qs-projection-users",
+      ]);
+      const page2: any[] = [];
+      await s.query_streams((p) => page2.push(p), {
+        stream: "^qs-",
+        limit: 2,
+        after: page1.at(-1)!.stream,
+      });
+      expect(page2.map((p) => p.stream)).toEqual([
+        "qs-stats-user-1",
+        "qs-stats-user-2",
+      ]);
+
+      // blocked filter
+      await s.commit("qs-stats-user-1", [{ name: "z", data: {} }], {
+        correlation: "",
+        causation: {},
+      });
+      const claimed = await s.claim(100, 0, "qs-worker", 100000);
+      const target = claimed.find((l) => l.stream === "qs-stats-user-1");
+      expect(target).toBeDefined();
+      const others = claimed.filter((l) => l.stream !== "qs-stats-user-1");
+      if (others.length) await s.ack(others);
+      await s.block([{ ...target!, error: "boom" }]);
+
+      const blocked: any[] = [];
+      await s.query_streams((p) => blocked.push(p), {
+        stream: "^qs-",
+        blocked: true,
+      });
+      expect(blocked).toHaveLength(1);
+      expect(blocked[0].stream).toBe("qs-stats-user-1");
+      expect(blocked[0].error).toBe("boom");
+    });
+
     it("should claim with dual frontiers", async () => {
       const s = store();
       await s.subscribe([{ stream: "dual-frontier-test" }]);

--- a/libs/act-sqlite/src/SqliteStore.ts
+++ b/libs/act-sqlite/src/SqliteStore.ts
@@ -5,8 +5,11 @@ import type {
   Lease,
   Message,
   Query,
+  QueryStreams,
+  QueryStreamsResult,
   Schemas,
   Store,
+  StreamPosition,
 } from "@rotorsoft/act";
 
 /**
@@ -422,6 +425,70 @@ export class SqliteStore implements Store {
       await tx.rollback();
       throw e;
     }
+  }
+
+  // --- query_streams: read-only introspection with filters ---
+  async query_streams(
+    callback: (position: StreamPosition) => void,
+    query?: QueryStreams
+  ): Promise<QueryStreamsResult> {
+    const limit = query?.limit ?? 100;
+    let sql =
+      "SELECT stream, source, at, retry, blocked, error, leased_by, leased_until FROM streams WHERE 1=1";
+    const args: unknown[] = [];
+
+    if (query?.stream !== undefined) {
+      if (query.stream_exact) {
+        sql += " AND stream = ?";
+        args.push(query.stream);
+      } else {
+        sql += " AND stream LIKE ?";
+        args.push(streamPatternToLike(query.stream));
+      }
+    }
+    if (query?.source !== undefined) {
+      sql += " AND source IS NOT NULL";
+      if (query.source_exact) {
+        sql += " AND source = ?";
+        args.push(query.source);
+      } else {
+        sql += " AND source LIKE ?";
+        args.push(streamPatternToLike(query.source));
+      }
+    }
+    if (query?.blocked !== undefined) {
+      sql += " AND blocked = ?";
+      args.push(query.blocked ? 1 : 0);
+    }
+    if (query?.after !== undefined) {
+      sql += " AND stream > ?";
+      args.push(query.after);
+    }
+    sql += " ORDER BY stream LIMIT ?";
+    args.push(limit);
+
+    const [streamsResult, maxResult] = await Promise.all([
+      this.client.execute({ sql, args: args as any[] }),
+      this.client.execute("SELECT COALESCE(MAX(id), -1) AS m FROM events"),
+    ]);
+
+    let count = 0;
+    for (const row of streamsResult.rows) {
+      const leased_until = row.leased_until as string | null;
+      callback({
+        stream: row.stream as string,
+        source: (row.source as string | null) ?? undefined,
+        at: Number(row.at),
+        retry: Number(row.retry),
+        blocked: Number(row.blocked) === 1,
+        error: row.error as string,
+        leased_by: (row.leased_by as string | null) ?? undefined,
+        leased_until: leased_until ? new Date(leased_until) : undefined,
+      });
+      count++;
+    }
+
+    return { maxEventId: Number(maxResult.rows[0].m), count };
   }
 
   // --- truncate: transactional delete + seed ---

--- a/libs/act-sqlite/test/store.spec.ts
+++ b/libs/act-sqlite/test/store.spec.ts
@@ -442,4 +442,122 @@ describe("sqlite store", () => {
     const acked = await store().ack([{ ...target!, by: "owner-2", at: 99 }]);
     expect(acked.length).toBe(0);
   });
+
+  it("should query_streams with filters and pagination", async () => {
+    await store().subscribe([
+      { stream: "qs-projection-tickets" },
+      { stream: "qs-projection-users" },
+      { stream: "qs-stats-user-1", source: "qs-source-1" },
+      { stream: "qs-stats-user-2", source: "qs-source-2" },
+    ]);
+
+    // No filter for the qs- prefix returns all four
+    const all: any[] = [];
+    const result = await store().query_streams((p) => all.push(p), {
+      stream: "^qs-",
+    });
+    expect(result.count).toBe(4);
+    expect(result.maxEventId).toBeGreaterThanOrEqual(0);
+    expect(all.map((p) => p.stream)).toEqual([
+      "qs-projection-tickets",
+      "qs-projection-users",
+      "qs-stats-user-1",
+      "qs-stats-user-2",
+    ]);
+
+    // stream regex (LIKE under the hood)
+    const projections: any[] = [];
+    await store().query_streams((p) => projections.push(p), {
+      stream: "^qs-projection-",
+    });
+    expect(projections).toHaveLength(2);
+
+    // stream_exact
+    const exact: any[] = [];
+    await store().query_streams((p) => exact.push(p), {
+      stream: "qs-stats-user-1",
+      stream_exact: true,
+    });
+    expect(exact).toHaveLength(1);
+    expect(exact[0].source).toBe("qs-source-1");
+
+    // source filter — only rows with source set
+    const dynamics: any[] = [];
+    await store().query_streams((p) => dynamics.push(p), {
+      stream: "^qs-",
+      source: "^qs-source-",
+    });
+    expect(dynamics).toHaveLength(2);
+    expect(dynamics.every((p) => p.source !== undefined)).toBe(true);
+
+    // source_exact filter
+    const exactSource: any[] = [];
+    await store().query_streams((p) => exactSource.push(p), {
+      stream: "^qs-",
+      source: "qs-source-2",
+      source_exact: true,
+    });
+    expect(exactSource).toHaveLength(1);
+    expect(exactSource[0].stream).toBe("qs-stats-user-2");
+
+    // limit + after pagination
+    const page1: any[] = [];
+    await store().query_streams((p) => page1.push(p), {
+      stream: "^qs-",
+      limit: 2,
+    });
+    expect(page1.map((p) => p.stream)).toEqual([
+      "qs-projection-tickets",
+      "qs-projection-users",
+    ]);
+    const page2: any[] = [];
+    await store().query_streams((p) => page2.push(p), {
+      stream: "^qs-",
+      limit: 2,
+      after: page1.at(-1)!.stream,
+    });
+    expect(page2.map((p) => p.stream)).toEqual([
+      "qs-stats-user-1",
+      "qs-stats-user-2",
+    ]);
+
+    // blocked filter — use a non-source projection so claim's source-stream
+    // filter doesn't exclude it
+    await store().commit("qs-projection-tickets", [{ name: "z", data: {} }], {
+      correlation: "",
+      causation: {},
+    });
+    const claimed = await store().claim(100, 0, "qs-worker", 100000);
+    const target = claimed.find((l) => l.stream === "qs-projection-tickets");
+    expect(target).toBeDefined();
+    const others = claimed.filter((l) => l.stream !== "qs-projection-tickets");
+    if (others.length) await store().ack(others);
+    await store().block([{ ...target!, error: "boom" }]);
+
+    const blocked: any[] = [];
+    await store().query_streams((p) => blocked.push(p), {
+      stream: "^qs-",
+      blocked: true,
+    });
+    expect(blocked).toHaveLength(1);
+    expect(blocked[0].stream).toBe("qs-projection-tickets");
+    expect(blocked[0].error).toBe("boom");
+
+    // blocked: false (excludes the blocked stream)
+    const unblocked: any[] = [];
+    await store().query_streams((p) => unblocked.push(p), {
+      stream: "^qs-",
+      blocked: false,
+    });
+    expect(unblocked).toHaveLength(3);
+    expect(
+      unblocked.find((p) => p.stream === "qs-projection-tickets")
+    ).toBeUndefined();
+
+    // No query at all — exercises undefined-query branches
+    const noQuery: any[] = [];
+    const noQueryResult = await store().query_streams((p) => noQuery.push(p));
+    expect(noQueryResult.count).toBeGreaterThan(0);
+    expect(noQueryResult.maxEventId).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/libs/act/src/adapters/InMemoryStore.ts
+++ b/libs/act/src/adapters/InMemoryStore.ts
@@ -16,9 +16,12 @@ import type {
   Lease,
   Message,
   Query,
+  QueryStreams,
+  QueryStreamsResult,
   Schema,
   Schemas,
   Store,
+  StreamPosition,
 } from "../types/index.js";
 import { sleep } from "../utils.js";
 
@@ -48,6 +51,26 @@ class InMemoryStream {
 
   get at() {
     return this._at;
+  }
+
+  get retry() {
+    return this._retry;
+  }
+
+  get blocked() {
+    return this._blocked;
+  }
+
+  get error() {
+    return this._error;
+  }
+
+  get leased_by() {
+    return this._leased_by;
+  }
+
+  get leased_until() {
+    return this._leased_until;
   }
 
   /**
@@ -440,6 +463,69 @@ export class InMemoryStore implements Store {
       }
     }
     return count;
+  }
+
+  /**
+   * Streams registered subscription positions to the callback, ordered by
+   * stream name. Returns the highest event id in the store and the count
+   * of positions emitted.
+   */
+  async query_streams(
+    callback: (position: StreamPosition) => void,
+    query?: QueryStreams
+  ): Promise<QueryStreamsResult> {
+    await sleep();
+    const limit = query?.limit ?? 100;
+    const after = query?.after;
+    const blocked = query?.blocked;
+    const streamRe =
+      query?.stream && !query.stream_exact
+        ? new RegExp(`^${query.stream}$`)
+        : undefined;
+    const sourceRe =
+      query?.source && !query.source_exact
+        ? new RegExp(`^${query.source}$`)
+        : undefined;
+
+    const sorted = [...this._streams.values()].sort((a, b) =>
+      a.stream.localeCompare(b.stream)
+    );
+
+    let count = 0;
+    for (const s of sorted) {
+      if (after !== undefined && s.stream <= after) continue;
+      if (query?.stream !== undefined) {
+        if (
+          query.stream_exact
+            ? s.stream !== query.stream
+            : !streamRe!.test(s.stream)
+        )
+          continue;
+      }
+      if (query?.source !== undefined) {
+        if (s.source === undefined) continue;
+        if (
+          query.source_exact
+            ? s.source !== query.source
+            : !sourceRe!.test(s.source)
+        )
+          continue;
+      }
+      if (blocked !== undefined && s.blocked !== blocked) continue;
+      callback({
+        stream: s.stream,
+        source: s.source,
+        at: s.at,
+        retry: s.retry,
+        blocked: s.blocked,
+        error: s.error,
+        leased_by: s.leased_by,
+        leased_until: s.leased_until,
+      });
+      count++;
+      if (count >= limit) break;
+    }
+    return { maxEventId: this._events.length - 1, count };
   }
 
   /**

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -73,6 +73,85 @@ export type TruncateResult = Map<
 >;
 
 /**
+ * Subscription position for a registered stream.
+ *
+ * Streamed by {@link Store.query_streams} to power operational dashboards
+ * (projection lag, blocked subscriptions, in-flight leases). The shape
+ * mirrors what every adapter already tracks on its `streams` table.
+ *
+ * @property stream - The subscription target (projection or reaction stream)
+ * @property source - Optional source stream filter (for reactions)
+ * @property at - Last processed event id watermark (-1 for fresh streams)
+ * @property retry - Current retry counter
+ * @property blocked - True when the stream is blocked by a poison message
+ * @property error - Last error message (empty string when none)
+ * @property leased_by - Current lease holder UUID (when leased)
+ * @property leased_until - Lease expiration timestamp (when leased)
+ */
+export type StreamPosition = {
+  readonly stream: string;
+  readonly source?: string;
+  readonly at: number;
+  readonly retry: number;
+  readonly blocked: boolean;
+  readonly error: string;
+  readonly leased_by?: string;
+  readonly leased_until?: Date;
+};
+
+/**
+ * Filter options for {@link Store.query_streams}.
+ *
+ * Mirrors the {@link Query} pattern used by {@link Store.query} — pass
+ * filters server-side to keep the cost low on large tables (e.g., dynamic
+ * reactions producing one subscription per aggregate).
+ *
+ * **What the store can filter:** the columns it actually persists —
+ * `stream`, `source`, `blocked`. Higher-level classification ("is this a
+ * projection vs a reaction?", "is this a static or dynamic resolver?")
+ * is an orchestrator concern; the streams table doesn't store kinds.
+ * Layer that on top by joining results with `Act`'s built-in registry.
+ *
+ * @property stream - Stream-name filter. By default treated as a regex
+ *   (PG `~`, SQLite/InMemory `LIKE`-translated). Pass `stream_exact: true`
+ *   for exact string equality.
+ * @property stream_exact - Use exact match instead of pattern match for
+ *   `stream`.
+ * @property source - Source-stream filter (regex by default). Useful to
+ *   isolate dynamic-reaction subscriptions tied to a particular aggregate
+ *   stream. Pass `source_exact: true` for exact equality.
+ * @property source_exact - Use exact match instead of pattern match for
+ *   `source`.
+ * @property blocked - Restrict to blocked (`true`) or unblocked (`false`)
+ *   streams. Omit for all.
+ * @property after - Keyset pagination cursor: returns only streams with
+ *   `stream > after` (lexicographic). Pass the last seen `stream` to fetch
+ *   the next page.
+ * @property limit - Max rows to return (default: 100).
+ */
+export type QueryStreams = {
+  readonly stream?: string;
+  readonly stream_exact?: boolean;
+  readonly source?: string;
+  readonly source_exact?: boolean;
+  readonly blocked?: boolean;
+  readonly after?: string;
+  readonly limit?: number;
+};
+
+/**
+ * Result of a {@link Store.query_streams} call.
+ *
+ * @property maxEventId - Highest event id in the store (-1 when empty).
+ *   UI uses this to compute lag as `maxEventId - position.at`.
+ * @property count - Number of stream positions delivered to the callback.
+ */
+export type QueryStreamsResult = {
+  readonly maxEventId: number;
+  readonly count: number;
+};
+
+/**
  * Interface for event store implementations.
  *
  * The Store interface defines the contract for persistence adapters in Act.
@@ -374,6 +453,53 @@ export interface Store extends Disposable {
       meta?: EventMeta;
     }>
   ) => Promise<TruncateResult>;
+
+  /**
+   * Streams registered subscription positions to a callback, plus the
+   * highest event id in the store.
+   *
+   * Read-only introspection for operational dashboards (Store /
+   * Subscriptions tab, projection lag, blocked subscriptions). Avoids
+   * forcing apps to open a second connection and run raw SQL against
+   * adapter-specific schemas.
+   *
+   * Mirrors the {@link Store.query} callback pattern: the callback is
+   * invoked once per matching position, allowing large result sets to be
+   * processed without buffering. Results are ordered by `stream` name; use
+   * `query.after` (last seen stream name) for keyset pagination on big
+   * tables (dynamic reactions can produce one subscription per aggregate).
+   *
+   * @param callback - Invoked once per matching {@link StreamPosition}.
+   * @param query - Optional {@link QueryStreams} filter (default `limit: 100`).
+   * @returns `maxEventId` and the `count` of positions emitted.
+   *
+   * @example List blocked streams with their lag
+   * ```typescript
+   * const { maxEventId } = await store().query_streams(
+   *   (s) => console.log(`${s.stream}: lag=${maxEventId - s.at} ${s.error}`),
+   *   { blocked: true, limit: 50 }
+   * );
+   * ```
+   *
+   * @example Page through all positions
+   * ```typescript
+   * let after: string | undefined;
+   * for (;;) {
+   *   const page: StreamPosition[] = [];
+   *   const { count } = await store().query_streams(
+   *     (s) => page.push(s),
+   *     { after, limit: 100 }
+   *   );
+   *   if (!count) break;
+   *   // ... use page ...
+   *   after = page.at(-1)?.stream;
+   * }
+   * ```
+   */
+  query_streams: (
+    callback: (position: StreamPosition) => void,
+    query?: QueryStreams
+  ) => Promise<QueryStreamsResult>;
 }
 
 // ---------------------------------------------------------------------------

--- a/libs/act/test/in-memory-store.spec.ts
+++ b/libs/act/test/in-memory-store.spec.ts
@@ -317,6 +317,110 @@ describe("InMemoryStore", () => {
       expect(claimed2.find((l) => l.stream === "L5")).toBeUndefined();
     });
 
+    it("should query_streams with filters and pagination", async () => {
+      const s = store();
+      // Mix of static targets (no source) and dynamic targets (with source)
+      await s.subscribe([
+        { stream: "projection-tickets" },
+        { stream: "projection-users" },
+        { stream: "stats-user-1", source: "user-1" },
+        { stream: "stats-user-2", source: "user-2" },
+        { stream: "stats-user-3", source: "user-3" },
+      ]);
+      // Commit some events so maxEventId > -1
+      await s.commit(
+        "user-1",
+        [
+          { name: "A", data: {} },
+          { name: "B", data: {} },
+        ],
+        { correlation: "c", causation: {} }
+      );
+
+      // No filter — returns all, ordered by stream name
+      const all: any[] = [];
+      const allResult = await s.query_streams((p) => all.push(p));
+      expect(allResult.count).toBe(5);
+      expect(allResult.maxEventId).toBe(1);
+      expect(all.map((p) => p.stream)).toEqual([
+        "projection-tickets",
+        "projection-users",
+        "stats-user-1",
+        "stats-user-2",
+        "stats-user-3",
+      ]);
+
+      // stream regex filter
+      const projections: any[] = [];
+      await s.query_streams((p) => projections.push(p), {
+        stream: "projection-.*",
+      });
+      expect(projections).toHaveLength(2);
+      expect(projections.every((p) => p.stream.startsWith("projection-"))).toBe(
+        true
+      );
+
+      // stream_exact
+      const exact: any[] = [];
+      await s.query_streams((p) => exact.push(p), {
+        stream: "stats-user-1",
+        stream_exact: true,
+      });
+      expect(exact).toHaveLength(1);
+      expect(exact[0].source).toBe("user-1");
+
+      // source filter — only rows with a source match
+      const dynamics: any[] = [];
+      await s.query_streams((p) => dynamics.push(p), { source: "user-.*" });
+      expect(dynamics).toHaveLength(3);
+      expect(dynamics.every((p) => p.source !== undefined)).toBe(true);
+
+      // source_exact filter
+      const exactSource: any[] = [];
+      await s.query_streams((p) => exactSource.push(p), {
+        source: "user-2",
+        source_exact: true,
+      });
+      expect(exactSource).toHaveLength(1);
+      expect(exactSource[0].stream).toBe("stats-user-2");
+
+      // source_exact with no match drops the row
+      const noMatch: any[] = [];
+      await s.query_streams((p) => noMatch.push(p), {
+        source: "user-99",
+        source_exact: true,
+      });
+      expect(noMatch).toHaveLength(0);
+
+      // limit + after (keyset pagination)
+      const page1: any[] = [];
+      await s.query_streams((p) => page1.push(p), { limit: 2 });
+      expect(page1.map((p) => p.stream)).toEqual([
+        "projection-tickets",
+        "projection-users",
+      ]);
+      const page2: any[] = [];
+      await s.query_streams((p) => page2.push(p), {
+        limit: 2,
+        after: page1.at(-1)!.stream,
+      });
+      expect(page2.map((p) => p.stream)).toEqual([
+        "stats-user-1",
+        "stats-user-2",
+      ]);
+
+      // blocked filter
+      const claimed = await s.claim(1, 0, "w", 100000);
+      await s.block([{ ...claimed[0], error: "boom" }]);
+      const blocked: any[] = [];
+      await s.query_streams((p) => blocked.push(p), { blocked: true });
+      expect(blocked).toHaveLength(1);
+      expect(blocked[0].error).toBe("boom");
+      const unblocked: any[] = [];
+      await s.query_streams((p) => unblocked.push(p), { blocked: false });
+      expect(unblocked).toHaveLength(4);
+    });
+
     it("should not ack with wrong lease holder", async () => {
       const s = store();
       await s.subscribe([{ stream: "L6" }]);

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -106,10 +106,10 @@ packages/inspector/
 | `stats` | query | Aggregate counts for current filters |
 | `eventNames` | query | Distinct event names for filter dropdown |
 | `streams` | query | Stream list with event counts and versions |
-| `streamMeta` | query | Stream processing metadata from `_streams` table |
+| `streamMeta` | query | Subscription positions from the streams table |
 | `drainStatus` | query | Drain pipeline health: aggregates, blocked streams, leases, watermark histogram |
 
 - **Event data**: flows through Act's `Store.query()` interface
-- **Processing metadata**: direct PG access to the `_streams` table via `pg.Client`
+- **Processing metadata**: flows through Act's `Store.query_streams()` interface — adapter-agnostic, no second connection
 - **Store management**: own `PostgresStore` instance (not the Act singleton) — enables reconnecting
 - **Read-only**: no mutations, no replays — pure inspection

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -1,4 +1,4 @@
-import type { Committed, Schemas, Store } from "@rotorsoft/act";
+import type { Committed, Schemas, Store, StreamPosition } from "@rotorsoft/act";
 import { PostgresStore } from "@rotorsoft/act-pg";
 import { initTRPC } from "@trpc/server";
 import { createConnection, type Socket } from "net";
@@ -38,20 +38,30 @@ function getStore(): Store {
   return currentStore;
 }
 
-/** Get a raw pg client for streams table queries */
-async function getStreamsClient(): Promise<{ client: pg.Client; fqs: string }> {
-  if (!currentConfig) throw new Error("Not connected to a store");
-  const client = new pg.Client({
-    host: currentConfig.host,
-    port: currentConfig.port,
-    database: currentConfig.database,
-    user: currentConfig.user,
-    password: currentConfig.password,
-    connectionTimeoutMillis: 5000,
-  });
-  await client.connect();
-  const fqs = `"${currentConfig.schema}"."${currentConfig.table}_streams"`;
-  return { client, fqs };
+/** Drain all subscription positions from the store via query_streams pagination. */
+async function loadAllStreamPositions(): Promise<{
+  positions: StreamPosition[];
+  maxEventId: number;
+}> {
+  const s = getStore();
+  const pageSize = 1000;
+  const fetchPage = async (after?: string) => {
+    const page: StreamPosition[] = [];
+    const result = await s.query_streams((p) => page.push(p), {
+      after,
+      limit: pageSize,
+    });
+    return { page, maxEventId: result.maxEventId };
+  };
+
+  const positions: StreamPosition[] = [];
+  let { page, maxEventId } = await fetchPage();
+  positions.push(...page);
+  while (page.length === pageSize) {
+    ({ page, maxEventId } = await fetchPage(page[page.length - 1].stream));
+    positions.push(...page);
+  }
+  return { positions, maxEventId };
 }
 
 // --- Discovery ---
@@ -370,9 +380,7 @@ export const inspectorRouter = t.router({
         const storeConfig = ssl
           ? { ...pgConfig, ssl: { rejectUnauthorized: false } }
           : pgConfig;
-        const newStore = new PostgresStore(
-          storeConfig as Record<string, unknown>
-        );
+        const newStore = new PostgresStore(storeConfig);
         // Test the connection
         await newStore.query<Schemas>(() => {}, { limit: 1 });
         currentStore = newStore;
@@ -540,64 +548,30 @@ export const inspectorRouter = t.router({
         .slice(0, input?.limit ?? 100);
     }),
 
-  /** Get stream processing metadata from the streams table (PG-specific) */
+  /** Get stream processing metadata from the streams table */
   streamMeta: t.procedure.query(async () => {
-    let pgClient: pg.Client | undefined;
     try {
-      const { client, fqs } = await getStreamsClient();
-      pgClient = client;
-      const result = await client.query<{
-        stream: string;
-        source: string | null;
-        at: number;
-        retry: number;
-        blocked: boolean;
-        error: string | null;
-        leased_by: string | null;
-        leased_until: string | null;
-      }>(
-        `SELECT stream, source, at, retry, blocked, error, leased_by, leased_until FROM ${fqs} ORDER BY stream`
-      );
-      return result.rows;
+      const { positions } = await loadAllStreamPositions();
+      return positions.map((p) => ({
+        stream: p.stream,
+        source: p.source ?? null,
+        at: p.at,
+        retry: p.retry,
+        blocked: p.blocked,
+        error: p.error || null,
+        leased_by: p.leased_by ?? null,
+        leased_until: p.leased_until?.toISOString() ?? null,
+      }));
     } catch {
       return [];
-    } finally {
-      if (pgClient) await pgClient.end();
     }
   }),
 
   /** Get drain status: aggregate health + blocked streams + leases + watermark histogram */
   drainStatus: t.procedure.query(async () => {
-    const s = getStore();
-    let pgClient: pg.Client | undefined;
     try {
-      const { client, fqs } = await getStreamsClient();
-      pgClient = client;
-
-      // Get max event ID
-      const events: AnyEvent[] = [];
-      await s.query<Schemas>(collect(events), {
-        limit: 1,
-        backward: true,
-        with_snaps: true,
-      });
-      const maxEventId = events.length > 0 ? events[0].id : 0;
-
-      // Get all stream rows
-      const result = await client.query<{
-        stream: string;
-        source: string | null;
-        at: number;
-        retry: number;
-        blocked: boolean;
-        error: string | null;
-        leased_by: string | null;
-        leased_until: string | null;
-      }>(
-        `SELECT stream, source, at, retry, blocked, error, leased_by, leased_until FROM ${fqs} ORDER BY stream`
-      );
-
-      const rows = result.rows;
+      const { positions, maxEventId: rawMax } = await loadAllStreamPositions();
+      const maxEventId = Math.max(0, rawMax);
       const now = new Date();
 
       // Aggregates
@@ -621,31 +595,27 @@ export const inspectorRouter = t.router({
       }> = [];
       const gaps: number[] = [];
 
-      for (const r of rows) {
-        const gap = Math.max(0, maxEventId - r.at);
+      for (const p of positions) {
+        const gap = Math.max(0, maxEventId - p.at);
         gaps.push(gap);
 
-        if (r.blocked) {
+        if (p.blocked) {
           blocked++;
           blockedStreams.push({
-            stream: r.stream,
-            source: r.source,
-            error: r.error,
-            retry: r.retry,
-            at: r.at,
+            stream: p.stream,
+            source: p.source ?? null,
+            error: p.error || null,
+            retry: p.retry,
+            at: p.at,
             gap,
           });
-        } else if (
-          r.leased_by &&
-          r.leased_until &&
-          new Date(r.leased_until) > now
-        ) {
+        } else if (p.leased_by && p.leased_until && p.leased_until > now) {
           leased++;
           activeLeases.push({
-            stream: r.stream,
-            source: r.source,
-            leased_by: r.leased_by,
-            leased_until: r.leased_until,
+            stream: p.stream,
+            source: p.source ?? null,
+            leased_by: p.leased_by,
+            leased_until: p.leased_until.toISOString(),
           });
         } else if (gap > 10) {
           lagging++;
@@ -672,7 +642,7 @@ export const inspectorRouter = t.router({
       }
 
       return {
-        total: rows.length,
+        total: positions.length,
         healthy,
         blocked,
         leased,
@@ -696,8 +666,6 @@ export const inspectorRouter = t.router({
         histogram: [],
         timestamp: new Date().toISOString(),
       };
-    } finally {
-      if (pgClient) await pgClient.end();
     }
   }),
 
@@ -726,14 +694,14 @@ export const inspectorRouter = t.router({
       const header = CSV_COLUMNS.join(",");
       const rows = events.map((e) =>
         CSV_COLUMNS.map((col) => {
-          const val = e[col as keyof typeof e];
+          const val = e[col];
           if (col === "data" || col === "meta")
             return csvEscape(JSON.stringify(val));
           if (val instanceof Date) return csvEscape(val.toISOString());
           return csvEscape(
             typeof val === "object" && val !== null
               ? JSON.stringify(val)
-              : String(val as string | number | boolean)
+              : String(val)
           );
         }).join(",")
       );


### PR DESCRIPTION
## Summary
- Adds `Store.query_streams(callback, query?)` — read-only introspection over the `streams` table that every adapter already maintains. Returns `{ maxEventId, count }` and streams `StreamPosition` rows (`stream`, `source`, `at`, `retry`, `blocked`, `error`, `leased_by`, `leased_until`) to a callback.
- Mirrors the existing `query()` callback + filter shape: regex-or-exact `stream`/`source` matching, `blocked` toggle, keyset `after` cursor, `limit` (default 100). Implemented in `InMemoryStore`, `SqliteStore`, and `PostgresStore`.
- Refactors `@rotorsoft/act-inspector`: `streamMeta` and `drainStatus` procedures now use this primitive. Drops the `getStreamsClient()` helper that opened a second pg connection and ran raw SQL against the adapter-specific streams table.
- 100% statements / branches / functions / lines coverage on all three adapters.

Closes #614.

## Design notes
- **Filters live where the data lives.** The store-level filter set (`stream`, `source`, `blocked`, `after`, `limit`) covers what the streams table actually persists. Higher-level classification (projection vs reaction, static vs dynamic) is an orchestrator concern — the streams table doesn't store kinds — so apps can layer that on top of these primitives.
- **Pagination matters.** Dynamic reactions can register one subscription per aggregate, so the table can grow large. `query_streams` uses keyset pagination by stream name (`after` cursor) — cheap on big tables, no `OFFSET`.
- **Inspector dropped 83 net lines** while gaining adapter-agnostic support (worked PG-only before).

## Test plan
- [x] InMemoryStore: filters, pagination, source_exact, blocked true/false (`libs/act/test/in-memory-store.spec.ts`)
- [x] SqliteStore: same suite + no-query path (`libs/act-sqlite/test/store.spec.ts`)
- [x] PostgresStore: same suite + empty-conditions path (`libs/act-pg/test/store.spec.ts`, requires live PG on :5431)
- [x] All 841 existing tests still pass
- [x] Coverage: 100% statements / 100% branches / 100% functions / 100% lines
- [x] `pnpm typecheck` clean
- [x] `@rotorsoft/act-inspector` builds clean
- [ ] Manually exercise the Inspector Monitor tab against a live PG store to confirm wire-shape compatibility for `drainStatus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)