### PR TITLE
feat(act): browser-safe ./types subpath export

### DIFF
--- a/libs/act/package.json
+++ b/libs/act/package.json
@@ -21,6 +21,11 @@
       "types": "./dist/@types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./types": {
+      "types": "./dist/@types/types/index.d.ts",
+      "import": "./dist/types/index.js",
+      "require": "./dist/types/index.cjs"
     }
   },
   "engines": {

--- a/libs/act/tsup.config.ts
+++ b/libs/act/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/types/index.ts"],
+  format: ["esm", "cjs"],
+  dts: false,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  target: "es2022",
+  tsconfig: "tsconfig.build.json",
+});


### PR DESCRIPTION
## Summary

- Adds a second tsup entry exposing `src/types/` at the new `@rotorsoft/act/types` subpath, so consumers can share Zod schemas (`ZodEmpty`, `ActorSchema`, `TargetSchema`, `QuerySchema`, `EventMetaSchema`, `CommittedMetaSchema`, `CausationEventSchema`), error classes (`ValidationError`, `InvariantError`, `ConcurrencyError`, `StreamClosedError`), and TS types with browser/client code.
- `src/types/` is already free of Node-only imports (no `node:fs`, `process.*`, `events`, or `EventEmitter`), so the new bundle is browser-safe — no shim layer added.
- Purely additive: the `"."` export is unchanged. `./types` is a new subpath; build outputs to a separate `dist/types/` directory; the existing `dist/index.{js,cjs}` and `dist/@types/index.d.ts` are untouched.

Client usage:
```ts
import { ZodEmpty, ActorSchema, ValidationError } from "@rotorsoft/act/types";
```

Server usage stays the same:
```ts
import { act, state, store } from "@rotorsoft/act";
```

Closes #628

## Test plan

- [x] `pnpm -F @rotorsoft/act build` produces `dist/types/index.{js,cjs}` and `dist/@types/types/index.d.ts`
- [x] Built `dist/types/index.js` and shared `dist/chunk-*.js` contain no `process.*`, `node:`, `events`, or `EventEmitter` references
- [x] `pnpm typecheck` passes
- [x] `vitest run libs/act` passes (843 tests; only failures are unrelated pg-store specs needing a live Postgres on :5431)
- [ ] Reviewer: confirm a downstream client app can `import { ZodEmpty } from "@rotorsoft/act/types"` and bundle for the browser without pulling Node polyfills

🤖 Generated with [Claude Code](https://claude.com/claude-code)