### PR TITLE
fix(deps)!: declare @rotorsoft/act as peer dep in adapters

### DIFF
--- a/libs/act-pg/package.json
+++ b/libs/act-pg/package.json
@@ -36,9 +36,11 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@rotorsoft/act": "workspace:^",
     "pg": "^8.20.0",
     "zod": "^4.4.1"
+  },
+  "peerDependencies": {
+    "@rotorsoft/act": ">=0.31.1"
   },
   "devDependencies": {
     "@types/pg": "^8.20.0"

--- a/libs/act-pino/package.json
+++ b/libs/act-pino/package.json
@@ -36,8 +36,10 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@rotorsoft/act": "workspace:^",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3"
+  },
+  "peerDependencies": {
+    "@rotorsoft/act": ">=0.31.1"
   }
 }

--- a/libs/act-sqlite/package.json
+++ b/libs/act-sqlite/package.json
@@ -36,8 +36,10 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@rotorsoft/act": "workspace:^",
     "@libsql/client": "^0.17.3",
     "zod": "^4.4.1"
+  },
+  "peerDependencies": {
+    "@rotorsoft/act": ">=0.31.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ importers:
   libs/act-pg:
     dependencies:
       '@rotorsoft/act':
-        specifier: workspace:^
+        specifier: '>=0.31.1'
         version: link:../act
       pg:
         specifier: ^8.20.0
@@ -270,7 +270,7 @@ importers:
   libs/act-pino:
     dependencies:
       '@rotorsoft/act':
-        specifier: workspace:^
+        specifier: '>=0.31.1'
         version: link:../act
       pino:
         specifier: ^10.3.1
@@ -285,7 +285,7 @@ importers:
         specifier: ^0.17.3
         version: 0.17.3
       '@rotorsoft/act':
-        specifier: workspace:^
+        specifier: '>=0.31.1'
         version: link:../act
       zod:
         specifier: ^4.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/**
   - docs
   - performance/act-performance
+linkWorkspacePackages: true
 onlyBuiltDependencies:
   - "@swc/core"
   - core-js


### PR DESCRIPTION
## Summary

Move `@rotorsoft/act` from `dependencies` to `peerDependencies` in all three adapter packages — `@rotorsoft/act-pg`, `@rotorsoft/act-sqlite`, and `@rotorsoft/act-pino` — with a wide floor (`>=0.31.1`). Consumers' direct `@rotorsoft/act` version now satisfies the adapter peer regardless of which act minor they're on. Single resolution; no recurrence on future act minors.

Closes #632

## Why

At publish time, pnpm rewrites `workspace:^` to a literal `^X.Y.Z` pin matching the workspace's act version. So `act-pg@0.17.1` shipped with `dependencies: { "@rotorsoft/act": "^0.31.1" }`. When a downstream consumer (konsult) later bumped `@rotorsoft/act` to 0.32.0, pnpm couldn't deduplicate — `^0.31.1` does not satisfy `0.32.0` under 0.x semver — so two physical copies of `@rotorsoft/act` ended up in `node_modules/.pnpm/`. TypeScript instantiated the cumulative builder generics in two type universes and OOMed.

Peer-deps shifts the contract: act-pg declares "I work with any act ≥ 0.31.1", not "I require this specific minor." The consumer's choice wins.

## Workspace mechanics

Added `linkWorkspacePackages: true` to `pnpm-workspace.yaml` so the workspace's `libs/act` package satisfies the peer at dev/build time without needing any `dependencies` line in the adapter package.json.

Verified post-install symlinks point at the workspace, not a fetched npm copy:

```
$ for pkg in act-pg act-sqlite act-pino; do
    printf "%-12s -> " "$pkg"; readlink "libs/$pkg/node_modules/@rotorsoft/act"
  done
act-pg       -> ../../../act
act-sqlite   -> ../../../act
act-pino     -> ../../../act
```

## What ships in the published tarball

`pnpm pack` confirmation for `act-pg`:

```json
{
  "dependencies": { "pg": "^8.20.0", "zod": "^4.4.1" },
  "peerDependencies": { "@rotorsoft/act": ">=0.31.1" }
}
```

No `@rotorsoft/act` in `dependencies`. Consumers see the peer requirement, satisfy it with their own direct dep, and pnpm resolves a single act version across the whole tree.

## Breaking change (formal)

Consumers of `@rotorsoft/act-pg`, `@rotorsoft/act-sqlite`, or `@rotorsoft/act-pino` must explicitly declare `@rotorsoft/act` as a direct dependency. In practice every consumer that uses an adapter already imports from `@rotorsoft/act` directly, so this formalizes existing reality. After upgrading to the new adapter versions a single time, future bumps to `@rotorsoft/act` alone are sufficient — adapters follow automatically via the wide peer range.

## Compat coverage strategy

The peer range `>=0.31.1` is open-ended. For 0.x semver where every minor can theoretically be breaking, this trusts that act's `Store`/`Cache` interface (the surface adapters consume) stays stable across minors. Verified by the 0.31 → 0.32 case: that release was an internal trace-decorator refactor with no Store/Cache contract change, and adapters built against 0.31 work at runtime against 0.32.

If a future act release does break adapter compat, the signal is real-world breakage; the response is to bump the affected adapter's major and tighten the peer range floor.

A proposed CI safety net — running each adapter's tests against `@rotorsoft/act@latest` — is not in this PR. Worth adding as a follow-up if you want early warning rather than relying on consumer reports.

## Test plan

- [x] `pnpm install` — workspace symlinks for all three adapters resolve to `../../../act` (workspace), not npm-fetched 0.31.1.
- [x] `pnpm typecheck` — passes.
- [x] `vitest run libs/act libs/act-pg libs/act-sqlite libs/act-pino` — 843 pass, 28 skip. Two pre-existing pg-store failures are unrelated (require live Postgres on :5431).
- [x] `pnpm pack` of act-pg — published `package.json` has `peerDependencies` only, no `dependencies` entry for `@rotorsoft/act`.
- [ ] Reviewer: confirm consumer migration story is acceptable (one-time `pnpm update @rotorsoft/act-pg` after merge, then future act bumps are frictionless).
- [ ] Reviewer: evaluate whether to add the CI smoke-test against `@rotorsoft/act@latest` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)