### PR TITLE
ci: bump checkout/setup-node/pnpm-action-setup to v6

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,11 +35,11 @@ jobs:
         ports:
           - 5431:5432
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"
@@ -62,13 +62,13 @@ jobs:
         lib: [act-patch, act, act-sse, act-pg, act-sqlite, act-pino, act-diagram]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
   filter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -36,11 +36,11 @@ jobs:
     if: needs.filter.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,7 +16,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: renovatebot/github-action@v46.0.2
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub deprecated Node 20 on Actions runners on 2025-09-19 and now forces `actions/checkout@v4`, `actions/setup-node@v4`, and `pnpm/action-setup@v4` to run on Node 24, surfacing a deprecation warning on every CI run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

`v6` of all three ships with native Node 24 support.

Bumps applied across:
- `.github/workflows/ci-cd.yml`
- `.github/workflows/deploy-docs.yml`
- `.github/workflows/renovate.yml`

Latest tags confirmed via `gh api`:
- `actions/checkout` → v6.0.2
- `actions/setup-node` → v6.4.0
- `pnpm/action-setup` → v6.0.5

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)