### PR TITLE
refactor(act): internal/ cleanup — bugs, dedupe, modularization

### DIFF
--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -1,4 +1,5 @@
 import type {
+  BlockedLease,
   Committed,
   EventMeta,
   Lease,
@@ -639,9 +640,7 @@ export class PostgresStore implements Store {
    * @param leases - Leases to block, including lease holder and last error message.
    * @returns Blocked leases.
    */
-  async block(
-    leases: Array<Lease & { error: string }>
-  ): Promise<(Lease & { error: string })[]> {
+  async block(leases: BlockedLease[]): Promise<BlockedLease[]> {
     const client = await this._pool.connect();
     try {
       await client.query("BEGIN");

--- a/libs/act-pg/test/cache.bench.ts
+++ b/libs/act-pg/test/cache.bench.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument -- bench helpers use any to avoid State name branding */
 import { bench, describe } from "vitest";
 import { z } from "zod";
-import { action, load } from "../../act/src/internal/index.js";
+import { action, load } from "../../act/src/internal/event-sourcing.js";
 import { dispose, store } from "../../act/src/ports.js";
 import { state } from "../../act/src/state-builder.js";
 import { PostgresStore } from "../src/PostgresStore.js";

--- a/libs/act-sqlite/src/SqliteStore.ts
+++ b/libs/act-sqlite/src/SqliteStore.ts
@@ -1,5 +1,6 @@
 import { createClient, type Client } from "@libsql/client";
 import type {
+  BlockedLease,
   Committed,
   EventMeta,
   Lease,
@@ -386,10 +387,10 @@ export class SqliteStore implements Store {
   }
 
   // --- block: transaction + ownership + idempotent (= PG) ---
-  async block(leases: Array<Lease & { error: string }>) {
+  async block(leases: BlockedLease[]) {
     const tx = await this.client.transaction("write");
     try {
-      const result: Array<Lease & { error: string }> = [];
+      const result: BlockedLease[] = [];
       for (const l of leases) {
         const r = await tx.execute({
           sql: `UPDATE streams SET blocked = 1, error = ?

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -18,6 +18,7 @@ import type {
   DrainOptions,
   IAct,
   Lease,
+  Logger,
   Query,
   ReactionPayload,
   Registry,
@@ -29,8 +30,6 @@ import type {
   State,
   Target,
 } from "./types/index.js";
-
-const logger = log();
 
 /**
  * @category Orchestrator
@@ -157,6 +156,8 @@ export class Act<
   private readonly _es: EsOps;
   /** Correlate/drain pipeline ops, optionally wrapped with trace decorators */
   private readonly _cd: DrainOps<TEvents>;
+  /** Logger resolved at construction time (after user port configuration) */
+  private readonly _logger: Logger = log();
 
   constructor(
     public readonly registry: Registry<TSchemaReg, TEvents, TActions>,
@@ -164,9 +165,8 @@ export class Act<
     batchHandlers: Map<string, BatchHandler<any>> = new Map()
   ) {
     this._batch_handlers = batchHandlers;
-    const level = log().level;
-    this._es = buildEs(level);
-    this._cd = buildDrain<TEvents>(level);
+    this._es = buildEs(this._logger);
+    this._cd = buildDrain<TEvents>(this._logger);
     // Classify resolvers and reactive events at build time
     const statics: Array<{ stream: string; source?: string }> = [];
     for (const [name, register] of Object.entries(this.registry.events)) {
@@ -515,7 +515,7 @@ export class Act<
       handled = 0;
 
     lease.retry > 0 &&
-      logger.warn(`Retrying ${stream}@${at} (${lease.retry}).`);
+      this._logger.warn(`Retrying ${stream}@${at} (${lease.retry}).`);
 
     // Scoped proxy: auto-injects reactingTo when do() is called without it,
     // maintaining correlation chains by default (see #587).
@@ -549,10 +549,12 @@ export class Act<
         at = event.id;
         handled++;
       } catch (error) {
-        logger.error(error);
+        this._logger.error(error);
         const block = lease.retry >= options.maxRetries && options.blockOnError;
         block &&
-          logger.error(`Blocking ${stream} after ${lease.retry} retries.`);
+          this._logger.error(
+            `Blocking ${stream} after ${lease.retry} retries.`
+          );
         return {
           lease,
           handled,
@@ -595,16 +597,19 @@ export class Act<
     const at = events.at(-1)!.id;
 
     lease.retry > 0 &&
-      logger.warn(`Retrying batch ${stream}@${events[0].id} (${lease.retry}).`);
+      this._logger.warn(
+        `Retrying batch ${stream}@${events[0].id} (${lease.retry}).`
+      );
 
     try {
       await batchHandler(events, stream);
       return { lease, handled: events.length, at };
     } catch (error) {
-      logger.error(error);
+      this._logger.error(error);
       const { options } = payloads[0];
       const block = lease.retry >= options.maxRetries && options.blockOnError;
-      block && logger.error(`Blocking ${stream} after ${lease.retry} retries.`);
+      block &&
+        this._logger.error(`Blocking ${stream} after ${lease.retry} retries.`);
       return {
         lease,
         handled: 0,
@@ -759,7 +764,7 @@ export class Act<
           this._needs_drain = false;
         return result;
       } catch (error) {
-        logger.error(error);
+        this._logger.error(error);
       } finally {
         this._drain_locked = false;
       }
@@ -1312,7 +1317,7 @@ export class Act<
         }
         if (lastDrain) this.emit("settled", lastDrain);
       })()
-        .catch((err) => logger.error(err))
+        .catch((err) => this._logger.error(err))
         .finally(() => {
           this._settling = false;
         });

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -11,6 +11,7 @@ import type {
   Actor,
   AsOf,
   BatchHandler,
+  BlockedLease,
   CloseResult,
   CloseTarget,
   Committed,
@@ -89,7 +90,7 @@ export class Act<
    */
   emit(event: "committed", args: Snapshot<TSchemaReg, TEvents>[]): boolean;
   emit(event: "acked", args: Lease[]): boolean;
-  emit(event: "blocked", args: Array<Lease & { error: string }>): boolean;
+  emit(event: "blocked", args: BlockedLease[]): boolean;
   emit(event: "settled", args: Drain<TEvents>): boolean;
   emit(event: "closed", args: CloseResult): boolean;
   emit(event: string, args: any): boolean {
@@ -108,10 +109,7 @@ export class Act<
     listener: (args: Snapshot<TSchemaReg, TEvents>[]) => void
   ): this;
   on(event: "acked", listener: (args: Lease[]) => void): this;
-  on(
-    event: "blocked",
-    listener: (args: Array<Lease & { error: string }>) => void
-  ): this;
+  on(event: "blocked", listener: (args: BlockedLease[]) => void): this;
   on(event: "settled", listener: (args: Drain<TEvents>) => void): this;
   on(event: "closed", listener: (args: CloseResult) => void): this;
   on(event: string, listener: (args: any) => void): this {
@@ -131,10 +129,7 @@ export class Act<
     listener: (args: Snapshot<TSchemaReg, TEvents>[]) => void
   ): this;
   off(event: "acked", listener: (args: Lease[]) => void): this;
-  off(
-    event: "blocked",
-    listener: (args: Array<Lease & { error: string }>) => void
-  ): this;
+  off(event: "blocked", listener: (args: BlockedLease[]) => void): this;
   off(event: "settled", listener: (args: Drain<TEvents>) => void): this;
   off(event: "closed", listener: (args: CloseResult) => void): this;
   off(event: string, listener: (args: any) => void): this {

--- a/libs/act/src/adapters/InMemoryStore.ts
+++ b/libs/act/src/adapters/InMemoryStore.ts
@@ -11,6 +11,7 @@
 import { SNAP_EVENT, TOMBSTONE_EVENT } from "../ports.js";
 import { ConcurrencyError } from "../types/errors.js";
 import type {
+  BlockedLease,
   Committed,
   EventMeta,
   Lease,
@@ -439,7 +440,7 @@ export class InMemoryStore implements Store {
    * @param leases - Leases to block, including lease holder and last error message.
    * @returns Blocked leases.
    */
-  async block(leases: Array<Lease & { error: string }>) {
+  async block(leases: BlockedLease[]) {
     await sleep();
     return leases
       .map((l) => this._streams.get(l.stream)?.block(l, l.error))

--- a/libs/act/src/internal/drain.ts
+++ b/libs/act/src/internal/drain.ts
@@ -18,7 +18,13 @@
  */
 
 import { store } from "../ports.js";
-import type { Committed, Fetch, Lease, Schemas } from "../types/index.js";
+import type {
+  BlockedLease,
+  Committed,
+  Fetch,
+  Lease,
+  Schemas,
+} from "../types/index.js";
 
 /** @internal */
 export interface DrainOps<TEvents extends Schemas> {
@@ -55,9 +61,8 @@ export async function fetch<TEvents extends Schemas>(
 
 export const ack = (leases: Lease[]): Promise<Lease[]> => store().ack(leases);
 
-export const block = (
-  leases: Array<Lease & { error: string }>
-): Promise<Array<Lease & { error: string }>> => store().block(leases);
+export const block = (leases: BlockedLease[]): Promise<BlockedLease[]> =>
+  store().block(leases);
 
 export const subscribe = (
   streams: Array<{ stream: string; source?: string }>

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -15,7 +15,11 @@
 import { patch } from "@rotorsoft/act-patch";
 import { randomUUID } from "crypto";
 import { cache, log, SNAP_EVENT, store, TOMBSTONE_EVENT } from "../ports.js";
-import { InvariantError, StreamClosedError } from "../types/errors.js";
+import {
+  ConcurrencyError,
+  InvariantError,
+  StreamClosedError,
+} from "../types/errors.js";
 import type {
   AsOf,
   Committed,
@@ -244,7 +248,7 @@ export async function action<
     );
   } catch (error) {
     // Invalidate cache on concurrency errors — cached state is stale
-    if ((error as { name?: string }).name === "ERR_CONCURRENCY") {
+    if (error instanceof ConcurrencyError) {
       await cache().invalidate(stream);
     }
     throw error;

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -29,8 +29,6 @@ import type {
 } from "../types/index.js";
 import { validate } from "../utils.js";
 
-const logger = log();
-
 /** @internal */
 export interface EsOps {
   snap: typeof snap;
@@ -71,7 +69,7 @@ export async function snap<TState extends Schema, TEvents extends Schemas>(
       version // IMPORTANT! - state events are committed right after the snapshot event
     );
   } catch (error) {
-    logger.error(error);
+    log().error(error);
   }
 }
 

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -266,14 +266,18 @@ export async function action<
   const last = snapshots.at(-1)!;
   const snapped = me.snap && me.snap(last);
 
-  // Update cache with post-commit state (reset patches if snapped)
-  void cache().set<TState>(stream, {
-    state: last.state,
-    version: last.event.version,
-    event_id: last.event.id,
-    patches: snapped ? 0 : last.patches,
-    snaps: snapped ? last.snaps + 1 : last.snaps,
-  });
+  // Update cache with post-commit state (reset patches if snapped).
+  // Fire-and-forget — log but don't fail the action on cache write errors
+  // (e.g., transient network failures in a custom Cache adapter).
+  cache()
+    .set<TState>(stream, {
+      state: last.state,
+      version: last.event.version,
+      event_id: last.event.id,
+      patches: snapped ? 0 : last.patches,
+      snaps: snapped ? last.snaps + 1 : last.snaps,
+    })
+    .catch((err) => log().error(err));
 
   // persist snap to store for cold start durability
   if (snapped) void snap(last);

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -105,12 +105,7 @@ export async function load<
   callback?: (snapshot: Snapshot<TState, TEvents>) => void,
   asOf?: AsOf
 ): Promise<Snapshot<TState, TEvents>> {
-  const timeTravel =
-    asOf &&
-    (asOf.before !== undefined ||
-      asOf.created_before !== undefined ||
-      asOf.created_after !== undefined ||
-      asOf.limit !== undefined);
+  const timeTravel = !!asOf && Object.values(asOf).some((v) => v !== undefined);
   const cached = timeTravel ? undefined : await cache().get<TState>(stream);
   let state = cached?.state ?? (me.init ? me.init() : ({} as TState));
   let patches = cached?.patches ?? 0;

--- a/libs/act/src/internal/index.ts
+++ b/libs/act/src/internal/index.ts
@@ -8,9 +8,14 @@
  * what lives here is implementation detail used by `Act`, the builders, and
  * the orchestrator's pipelines.
  *
+ * Only symbols actually consumed *outside* `internal/` are re-exported here.
+ * Modules within `internal/` import each other directly by file path, and
+ * tests that need bare ops (e.g., `action`, `load`) likewise import from
+ * the specific source file.
+ *
  * @internal
  */
-export * from "./drain.js";
-export * from "./event-sourcing.js";
-export * from "./merge.js";
-export * from "./tracing.js";
+export { type DrainOps } from "./drain.js";
+export { type EsOps } from "./event-sourcing.js";
+export { _this_, mergeProjection, registerState } from "./merge.js";
+export { buildDrain, buildEs } from "./tracing.js";

--- a/libs/act/src/internal/merge.ts
+++ b/libs/act/src/internal/merge.ts
@@ -71,93 +71,130 @@ export function registerState(
   actions: Record<string, any>,
   events: Record<string, any>
 ): void {
-  if (states.has(state.name)) {
-    // MERGE: same state name - combine events, actions, patches, handlers
-    const existing = states.get(state.name)!;
-    for (const name of Object.keys(state.actions)) {
-      // Same schema reference means the same partial re-registered via another slice
-      if (existing.actions[name] === state.actions[name]) continue;
-      if (actions[name]) throw new Error(`Duplicate action "${name}"`);
-    }
-    for (const name of Object.keys(state.events)) {
-      // Same schema reference means the same partial re-registered via another slice
-      if (existing.events[name] === state.events[name]) continue;
-      // Allow same-name state partials to redeclare the same event
-      // (e.g., a partial that only needs the event name for .on() reactions)
-      if (existing.events[name]) continue;
-      if (events[name]) throw new Error(`Duplicate event "${name}"`);
-    }
-    // Merge patches: only one custom (non-passthrough) patch per event allowed
-    const mergedPatch = { ...existing.patch };
-    for (const name of Object.keys(state.patch)) {
-      const existingP = existing.patch[name];
-      const incomingP = state.patch[name];
-      if (!existingP) {
-        mergedPatch[name] = incomingP;
-      } else {
-        const existingIsDefault = (existingP as any)._passthrough;
-        const incomingIsDefault = (incomingP as any)._passthrough;
-        if (
-          !existingIsDefault &&
-          !incomingIsDefault &&
-          existingP !== incomingP
-        ) {
-          throw new Error(
-            `Duplicate custom patch for event "${name}" in state "${state.name}"`
-          );
-        }
-        // Keep whichever is custom
-        if (existingIsDefault && !incomingIsDefault) {
-          mergedPatch[name] = incomingP;
-        }
-        // else: existing is custom or both are passthrough — keep existing
-      }
-    }
-    const merged = {
-      ...existing,
-      state: mergeSchemas(existing.state, state.state, state.name),
-      init: mergeInits(existing.init, state.init),
-      events: { ...existing.events, ...state.events },
-      actions: { ...existing.actions, ...state.actions },
-      patch: mergedPatch,
-      on: { ...existing.on, ...state.on },
-      given: { ...existing.given, ...state.given },
-      snap:
-        state.snap && existing.snap && state.snap !== existing.snap
-          ? (() => {
-              throw new Error(
-                `Duplicate snap strategy for state "${state.name}"`
-              );
-            })()
-          : state.snap || existing.snap,
-    };
-    states.set(state.name, merged);
-    // Update ALL action->state pointers to the merged object
-    for (const name of Object.keys(merged.actions)) {
-      actions[name] = merged;
-    }
-    for (const name of Object.keys(state.events)) {
-      if (events[name]) continue; // already registered, preserve reactions
-      events[name] = {
-        schema: state.events[name],
-        reactions: new Map(),
-      };
-    }
+  const existing = states.get(state.name);
+  if (existing) {
+    mergeIntoExisting(state, existing, states, actions, events);
   } else {
-    // NEW: register state for the first time
-    states.set(state.name, state);
-    for (const name of Object.keys(state.actions)) {
-      if (actions[name]) throw new Error(`Duplicate action "${name}"`);
-      actions[name] = state;
+    registerNewState(state, states, actions, events);
+  }
+}
+
+/**
+ * Registers a state for the first time. All action/event names must be unique
+ * across the registry; collisions throw.
+ */
+function registerNewState(
+  state: State<any, any, any>,
+  states: Map<string, State<any, any, any>>,
+  actions: Record<string, any>,
+  events: Record<string, any>
+): void {
+  states.set(state.name, state);
+  for (const name of Object.keys(state.actions)) {
+    if (actions[name]) throw new Error(`Duplicate action "${name}"`);
+    actions[name] = state;
+  }
+  for (const name of Object.keys(state.events)) {
+    if (events[name]) throw new Error(`Duplicate event "${name}"`);
+    events[name] = { schema: state.events[name], reactions: new Map() };
+  }
+}
+
+/**
+ * Merges an incoming partial state into an existing same-name state and
+ * updates the action/event registries. Splits into four phases:
+ *   1. validate no cross-state action/event collisions
+ *   2. merge per-event patches (one custom patch per event)
+ *   3. build the merged state and replace it in the states map
+ *   4. update action→state pointers and register new events
+ */
+function mergeIntoExisting(
+  state: State<any, any, any>,
+  existing: State<any, any, any>,
+  states: Map<string, State<any, any, any>>,
+  actions: Record<string, any>,
+  events: Record<string, any>
+): void {
+  // 1. Validate no cross-state collisions for actions/events
+  for (const name of Object.keys(state.actions)) {
+    // Same schema reference means the same partial re-registered via another slice
+    if (existing.actions[name] === state.actions[name]) continue;
+    if (actions[name]) throw new Error(`Duplicate action "${name}"`);
+  }
+  for (const name of Object.keys(state.events)) {
+    // Same schema reference means the same partial re-registered via another slice
+    if (existing.events[name] === state.events[name]) continue;
+    // Allow same-name state partials to redeclare the same event
+    // (e.g., a partial that only needs the event name for .on() reactions)
+    if (existing.events[name]) continue;
+    if (events[name]) throw new Error(`Duplicate event "${name}"`);
+  }
+
+  // 2. Merge patches with custom-vs-passthrough resolution
+  const mergedPatch = mergePatches(existing.patch, state.patch, state.name);
+
+  // 3. Build merged state
+  const merged = {
+    ...existing,
+    state: mergeSchemas(existing.state, state.state, state.name),
+    init: mergeInits(existing.init, state.init),
+    events: { ...existing.events, ...state.events },
+    actions: { ...existing.actions, ...state.actions },
+    patch: mergedPatch,
+    on: { ...existing.on, ...state.on },
+    given: { ...existing.given, ...state.given },
+    snap:
+      state.snap && existing.snap && state.snap !== existing.snap
+        ? (() => {
+            throw new Error(
+              `Duplicate snap strategy for state "${state.name}"`
+            );
+          })()
+        : state.snap || existing.snap,
+  };
+  states.set(state.name, merged);
+
+  // 4. Update action→state pointers; register events not yet seen
+  for (const name of Object.keys(merged.actions)) {
+    actions[name] = merged;
+  }
+  for (const name of Object.keys(state.events)) {
+    if (events[name]) continue; // already registered, preserve reactions
+    events[name] = { schema: state.events[name], reactions: new Map() };
+  }
+}
+
+/**
+ * Merges two patch maps. Only one custom (non-passthrough) patch per event is
+ * allowed; passthroughs always yield to custom reducers, and re-registering
+ * the same custom patch (same reference, e.g. across slices) is a no-op.
+ */
+function mergePatches(
+  existing: Record<string, any>,
+  incoming: Record<string, any>,
+  stateName: string
+): Record<string, any> {
+  const merged = { ...existing };
+  for (const name of Object.keys(incoming)) {
+    const existingP = existing[name];
+    const incomingP = incoming[name];
+    if (!existingP) {
+      merged[name] = incomingP;
+      continue;
     }
-    for (const name of Object.keys(state.events)) {
-      if (events[name]) throw new Error(`Duplicate event "${name}"`);
-      events[name] = {
-        schema: state.events[name],
-        reactions: new Map(),
-      };
+    const existingIsDefault = existingP._passthrough;
+    const incomingIsDefault = incomingP._passthrough;
+    if (!existingIsDefault && !incomingIsDefault && existingP !== incomingP) {
+      throw new Error(
+        `Duplicate custom patch for event "${name}" in state "${stateName}"`
+      );
+    }
+    // Keep whichever is custom; if both passthrough or existing custom, keep existing
+    if (existingIsDefault && !incomingIsDefault) {
+      merged[name] = incomingP;
     }
   }
+  return merged;
 }
 
 /**

--- a/libs/act/src/internal/merge.ts
+++ b/libs/act/src/internal/merge.ts
@@ -12,7 +12,7 @@ import type { Schema, State } from "../types/index.js";
  * Unwraps wrapper types (ZodOptional, ZodNullable, ZodDefault, ZodReadonly)
  * to find the base type name, e.g. `z.string().optional()` -> `"ZodString"`.
  */
-export function baseTypeName(zodType: ZodType): string {
+function baseTypeName(zodType: ZodType): string {
   let t: any = zodType;
   while (typeof t.unwrap === "function") {
     t = t.unwrap();
@@ -26,7 +26,7 @@ export function baseTypeName(zodType: ZodType): string {
  * error), then merges via `.extend()`. Falls back to keeping existing
  * schema if either is not a ZodObject.
  */
-export function mergeSchemas(
+function mergeSchemas(
   existing: ZodType,
   incoming: ZodType,
   stateName: string
@@ -54,7 +54,7 @@ export function mergeSchemas(
  * Merges two init functions by spreading both results together.
  * Each partial only provides its own defaults.
  */
-export function mergeInits<TState extends Schema>(
+function mergeInits<TState extends Schema>(
   existing: () => Readonly<TState>,
   incoming: () => Readonly<TState>
 ): () => Readonly<TState> {

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -4,13 +4,12 @@
  *
  * Centralized observability for the framework's internal pipelines.
  *
- * Trace decorators are higher-order functions that wrap a bare implementation
- * with `logger.trace(...)` calls at well-defined moments — entry points for
- * {@link "event-sourcing"} (`load`, `snap`, `action`) and exit points for the
- * {@link "drain"} pipeline (`claim`, `fetch`, `ack`, `block`,
- * `subscribe`). `action` carries both an entry log (🔵) and a post-commit
- * log (🔴) to preserve the diagnostic value of the historical mid-function
- * trace points.
+ * Trace decorators wrap a bare implementation with `logger.trace(...)` calls
+ * at well-defined moments — entry points for {@link "event-sourcing"} (`load`,
+ * `snap`, `action`) and exit points for the {@link "drain"} pipeline (`claim`,
+ * `fetch`, `ack`, `block`, `subscribe`). `action` carries both an entry log
+ * (🔵) and a post-commit log (🔴) to preserve the diagnostic value of the
+ * historical mid-function trace points.
  *
  * The two factories — {@link buildEs} and {@link buildDrain} — let the
  * orchestrator choose bare or traced variants once at `.build()` time based
@@ -18,55 +17,33 @@
  * imports tracing primitives.
  */
 
-import type { Lease, Logger, Schemas } from "../types/index.js";
+import type { Logger, Schemas } from "../types/index.js";
 import * as drain from "./drain.js";
 import { type DrainOps } from "./drain.js";
 import * as es from "./event-sourcing.js";
 import { type EsOps } from "./event-sourcing.js";
 
-// ---------------------------------------------------------------------------
-// Event-sourcing decorators
-// ---------------------------------------------------------------------------
+type AsyncFn = (...args: any[]) => Promise<any>;
 
-const withSnapTrace =
-  (logger: Logger, inner: typeof es.snap): typeof es.snap =>
-  async (snapshot) => {
-    logger.trace(
-      `🟠 snap ${snapshot.event!.stream}@${snapshot.event!.version}`
-    );
-    return inner(snapshot);
-  };
-
-const withLoadTrace =
-  (logger: Logger, inner: typeof es.load): typeof es.load =>
-  async (me, stream, callback, asOf) => {
-    logger.trace(`🟢 load ${stream}${asOf ? " (as-of)" : ""}`);
-    return inner(me, stream, callback, asOf);
-  };
-
-const withActionTrace =
-  (logger: Logger, inner: typeof es.action): typeof es.action =>
-  async (me, action, target, payload, reactingTo, skipValidation) => {
-    logger.trace(payload as object, `🔵 ${target.stream}.${action as string}`);
-    const snapshots = await inner(
-      me,
-      action,
-      target,
-      payload,
-      reactingTo,
-      skipValidation
-    );
-    const committed = snapshots.filter((s) => s.event);
-    if (committed.length) {
-      logger.trace(
-        committed.map((s) => s.event!.data),
-        `🔴 commit ${target.stream}.${committed
-          .map((s) => s.event!.name as string)
-          .join(", ")}`
-      );
-    }
-    return snapshots;
-  };
+/**
+ * Wraps an async function with optional `exit` and `entry` callbacks. Each
+ * callback fires at the corresponding phase; both receive the call args, and
+ * `exit` additionally receives the resolved result. Used to layer
+ * `logger.trace` calls onto bare ops without changing their signatures.
+ *
+ * @internal
+ */
+const traced = <F extends AsyncFn>(
+  inner: F,
+  exit?: (result: Awaited<ReturnType<F>>, ...args: Parameters<F>) => void,
+  entry?: (...args: Parameters<F>) => void
+): F =>
+  (async (...args: Parameters<F>) => {
+    entry?.(...args);
+    const result = (await inner(...args)) as Awaited<ReturnType<F>>;
+    exit?.(result, ...args);
+    return result;
+  }) as F;
 
 /**
  * Selects bare or traced event-sourcing handlers. Called once by the
@@ -79,100 +56,33 @@ export function buildEs(logger: Logger): EsOps {
     return { snap: es.snap, load: es.load, action: es.action };
   }
   return {
-    snap: withSnapTrace(logger, es.snap),
-    load: withLoadTrace(logger, es.load),
-    action: withActionTrace(logger, es.action),
+    snap: traced(es.snap, undefined, (snapshot) => {
+      logger.trace(
+        `🟠 snap ${snapshot.event!.stream}@${snapshot.event!.version}`
+      );
+    }),
+    load: traced(es.load, undefined, (_me, stream, _cb, asOf) => {
+      logger.trace(`🟢 load ${stream}${asOf ? " (as-of)" : ""}`);
+    }),
+    action: traced(
+      es.action,
+      (snapshots, _me, _action, target) => {
+        const committed = snapshots.filter((s) => s.event);
+        if (committed.length) {
+          logger.trace(
+            committed.map((s) => s.event!.data),
+            `🔴 commit ${target.stream}.${committed
+              .map((s) => s.event!.name)
+              .join(", ")}`
+          );
+        }
+      },
+      (_me, action, target, payload) => {
+        logger.trace(payload as object, `🔵 ${target.stream}.${action}`);
+      }
+    ),
   };
 }
-
-// ---------------------------------------------------------------------------
-// Drain-pipeline decorators
-// ---------------------------------------------------------------------------
-
-const withClaimTrace =
-  <T extends Schemas>(
-    logger: Logger,
-    inner: DrainOps<T>["claim"]
-  ): DrainOps<T>["claim"] =>
-  async (lagging, leading, by, millis) => {
-    const leased = await inner(lagging, leading, by, millis);
-    if (leased.length) {
-      const data = Object.fromEntries(
-        leased.map(({ stream, at, retry }) => [stream, { at, retry }])
-      );
-      logger.trace(data, ">> lease");
-    }
-    return leased;
-  };
-
-const withFetchTrace =
-  <T extends Schemas>(
-    logger: Logger,
-    inner: DrainOps<T>["fetch"]
-  ): DrainOps<T>["fetch"] =>
-  async (leased, eventLimit) => {
-    const fetched = await inner(leased, eventLimit);
-    const data = Object.fromEntries(
-      fetched.map(({ stream, source, events }) => {
-        const key = source ? `${stream}<-${source}` : stream;
-        const value = Object.fromEntries(
-          events.map(({ id, stream, name }) => [id, { [stream]: name }])
-        );
-        return [key, value];
-      })
-    );
-    logger.trace(data, ">> fetch");
-    return fetched;
-  };
-
-const withAckTrace =
-  <T extends Schemas>(
-    logger: Logger,
-    inner: DrainOps<T>["ack"]
-  ): DrainOps<T>["ack"] =>
-  async (leases) => {
-    const acked = await inner(leases);
-    if (acked.length) {
-      const data = Object.fromEntries(
-        acked.map(({ stream, at, retry }) => [stream, { at, retry }])
-      );
-      logger.trace(data, ">> ack");
-    }
-    return acked;
-  };
-
-const withBlockTrace =
-  <T extends Schemas>(
-    logger: Logger,
-    inner: DrainOps<T>["block"]
-  ): DrainOps<T>["block"] =>
-  async (leases: Array<Lease & { error: string }>) => {
-    const blocked = await inner(leases);
-    if (blocked.length) {
-      const data = Object.fromEntries(
-        blocked.map(({ stream, at, retry, error }) => [
-          stream,
-          { at, retry, error },
-        ])
-      );
-      logger.trace(data, ">> block");
-    }
-    return blocked;
-  };
-
-const withSubscribeTrace =
-  <T extends Schemas>(
-    logger: Logger,
-    inner: DrainOps<T>["subscribe"]
-  ): DrainOps<T>["subscribe"] =>
-  async (streams) => {
-    const result = await inner(streams);
-    if (result.subscribed) {
-      const data = streams.map(({ stream }) => stream).join(" ");
-      logger.trace(`>> correlate ${data}`);
-    }
-    return result;
-  };
 
 /**
  * Selects bare or traced drain-pipeline ops. Called once by the orchestrator
@@ -193,10 +103,50 @@ export function buildDrain<TEvents extends Schemas>(
     };
   }
   return {
-    claim: withClaimTrace<TEvents>(logger, drain.claim),
-    fetch: withFetchTrace<TEvents>(logger, drain.fetch),
-    ack: withAckTrace<TEvents>(logger, drain.ack),
-    block: withBlockTrace<TEvents>(logger, drain.block),
-    subscribe: withSubscribeTrace<TEvents>(logger, drain.subscribe),
+    claim: traced(drain.claim, (leased) => {
+      if (leased.length) {
+        const data = Object.fromEntries(
+          leased.map(({ stream, at, retry }) => [stream, { at, retry }])
+        );
+        logger.trace(data, ">> lease");
+      }
+    }),
+    fetch: traced(drain.fetch<TEvents>, (fetched) => {
+      const data = Object.fromEntries(
+        fetched.map(({ stream, source, events }) => {
+          const key = source ? `${stream}<-${source}` : stream;
+          const value = Object.fromEntries(
+            events.map(({ id, stream, name }) => [id, { [stream]: name }])
+          );
+          return [key, value];
+        })
+      );
+      logger.trace(data, ">> fetch");
+    }),
+    ack: traced(drain.ack, (acked) => {
+      if (acked.length) {
+        const data = Object.fromEntries(
+          acked.map(({ stream, at, retry }) => [stream, { at, retry }])
+        );
+        logger.trace(data, ">> ack");
+      }
+    }),
+    block: traced(drain.block, (blocked) => {
+      if (blocked.length) {
+        const data = Object.fromEntries(
+          blocked.map(({ stream, at, retry, error }) => [
+            stream,
+            { at, retry, error },
+          ])
+        );
+        logger.trace(data, ">> block");
+      }
+    }),
+    subscribe: traced(drain.subscribe, (result, streams) => {
+      if (result.subscribed) {
+        const data = streams.map(({ stream }) => stream).join(" ");
+        logger.trace(`>> correlate ${data}`);
+      }
+    }),
   };
 }

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -18,21 +18,18 @@
  * imports tracing primitives.
  */
 
-import { log } from "../ports.js";
-import type { Lease, Schemas } from "../types/index.js";
+import type { Lease, Logger, Schemas } from "../types/index.js";
 import * as drain from "./drain.js";
 import { type DrainOps } from "./drain.js";
 import * as es from "./event-sourcing.js";
 import { type EsOps } from "./event-sourcing.js";
-
-const logger = log();
 
 // ---------------------------------------------------------------------------
 // Event-sourcing decorators
 // ---------------------------------------------------------------------------
 
 const withSnapTrace =
-  (inner: typeof es.snap): typeof es.snap =>
+  (logger: Logger, inner: typeof es.snap): typeof es.snap =>
   async (snapshot) => {
     logger.trace(
       `🟠 snap ${snapshot.event!.stream}@${snapshot.event!.version}`
@@ -41,14 +38,14 @@ const withSnapTrace =
   };
 
 const withLoadTrace =
-  (inner: typeof es.load): typeof es.load =>
+  (logger: Logger, inner: typeof es.load): typeof es.load =>
   async (me, stream, callback, asOf) => {
     logger.trace(`🟢 load ${stream}${asOf ? " (as-of)" : ""}`);
     return inner(me, stream, callback, asOf);
   };
 
 const withActionTrace =
-  (inner: typeof es.action): typeof es.action =>
+  (logger: Logger, inner: typeof es.action): typeof es.action =>
   async (me, action, target, payload, reactingTo, skipValidation) => {
     logger.trace(payload as object, `🔵 ${target.stream}.${action as string}`);
     const snapshots = await inner(
@@ -77,14 +74,14 @@ const withActionTrace =
  *
  * @internal
  */
-export function buildEs(level: string): EsOps {
-  if (level !== "trace") {
+export function buildEs(logger: Logger): EsOps {
+  if (logger.level !== "trace") {
     return { snap: es.snap, load: es.load, action: es.action };
   }
   return {
-    snap: withSnapTrace(es.snap),
-    load: withLoadTrace(es.load),
-    action: withActionTrace(es.action),
+    snap: withSnapTrace(logger, es.snap),
+    load: withLoadTrace(logger, es.load),
+    action: withActionTrace(logger, es.action),
   };
 }
 
@@ -93,7 +90,10 @@ export function buildEs(level: string): EsOps {
 // ---------------------------------------------------------------------------
 
 const withClaimTrace =
-  <T extends Schemas>(inner: DrainOps<T>["claim"]): DrainOps<T>["claim"] =>
+  <T extends Schemas>(
+    logger: Logger,
+    inner: DrainOps<T>["claim"]
+  ): DrainOps<T>["claim"] =>
   async (lagging, leading, by, millis) => {
     const leased = await inner(lagging, leading, by, millis);
     if (leased.length) {
@@ -106,7 +106,10 @@ const withClaimTrace =
   };
 
 const withFetchTrace =
-  <T extends Schemas>(inner: DrainOps<T>["fetch"]): DrainOps<T>["fetch"] =>
+  <T extends Schemas>(
+    logger: Logger,
+    inner: DrainOps<T>["fetch"]
+  ): DrainOps<T>["fetch"] =>
   async (leased, eventLimit) => {
     const fetched = await inner(leased, eventLimit);
     const data = Object.fromEntries(
@@ -123,7 +126,10 @@ const withFetchTrace =
   };
 
 const withAckTrace =
-  <T extends Schemas>(inner: DrainOps<T>["ack"]): DrainOps<T>["ack"] =>
+  <T extends Schemas>(
+    logger: Logger,
+    inner: DrainOps<T>["ack"]
+  ): DrainOps<T>["ack"] =>
   async (leases) => {
     const acked = await inner(leases);
     if (acked.length) {
@@ -136,7 +142,10 @@ const withAckTrace =
   };
 
 const withBlockTrace =
-  <T extends Schemas>(inner: DrainOps<T>["block"]): DrainOps<T>["block"] =>
+  <T extends Schemas>(
+    logger: Logger,
+    inner: DrainOps<T>["block"]
+  ): DrainOps<T>["block"] =>
   async (leases: Array<Lease & { error: string }>) => {
     const blocked = await inner(leases);
     if (blocked.length) {
@@ -153,6 +162,7 @@ const withBlockTrace =
 
 const withSubscribeTrace =
   <T extends Schemas>(
+    logger: Logger,
     inner: DrainOps<T>["subscribe"]
   ): DrainOps<T>["subscribe"] =>
   async (streams) => {
@@ -171,9 +181,9 @@ const withSubscribeTrace =
  * @internal
  */
 export function buildDrain<TEvents extends Schemas>(
-  level: string
+  logger: Logger
 ): DrainOps<TEvents> {
-  if (level !== "trace") {
+  if (logger.level !== "trace") {
     return {
       claim: drain.claim,
       fetch: drain.fetch,
@@ -183,10 +193,10 @@ export function buildDrain<TEvents extends Schemas>(
     };
   }
   return {
-    claim: withClaimTrace<TEvents>(drain.claim),
-    fetch: withFetchTrace<TEvents>(drain.fetch),
-    ack: withAckTrace<TEvents>(drain.ack),
-    block: withBlockTrace<TEvents>(drain.block),
-    subscribe: withSubscribeTrace<TEvents>(drain.subscribe),
+    claim: withClaimTrace<TEvents>(logger, drain.claim),
+    fetch: withFetchTrace<TEvents>(logger, drain.fetch),
+    ack: withAckTrace<TEvents>(logger, drain.ack),
+    block: withBlockTrace<TEvents>(logger, drain.block),
+    subscribe: withSubscribeTrace<TEvents>(logger, drain.subscribe),
   };
 }

--- a/libs/act/src/state-builder.ts
+++ b/libs/act/src/state-builder.ts
@@ -10,6 +10,7 @@ import {
   ActionHandlers,
   GivenHandlers,
   Invariant,
+  PassthroughPatchHandler,
   PatchHandlers,
   Schema,
   Schemas,
@@ -467,8 +468,9 @@ export function state<TName extends string, TState extends Schema>(
           // Default passthrough patches: event data merges into state
           const defaultPatch = Object.fromEntries(
             Object.keys(events).map((k) => {
-              const fn = ({ data }: { data: any }) => data;
-              (fn as any)._passthrough = true;
+              const fn = Object.assign(({ data }: { data: any }) => data, {
+                _passthrough: true as const,
+              }) satisfies PassthroughPatchHandler;
               return [k, fn];
             })
           ) as unknown as PatchHandlers<TState, TEvents>;

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -301,6 +301,18 @@ export type PatchHandlers<TState extends Schema, TEvents extends Schemas> = {
 };
 
 /**
+ * Internal marker for the framework-default passthrough reducer
+ * (`({ data }) => data`). Custom user-supplied reducers never carry this
+ * flag. The builder merger uses it to resolve patch conflicts between
+ * partial states: a passthrough always yields to a custom reducer.
+ *
+ * @internal
+ */
+export type PassthroughPatchHandler = ((event: {
+  data: unknown;
+}) => unknown) & { readonly _passthrough: true };
+
+/**
  * Handles an action, producing one or more emitted events.
  * @template TState - State schema.
  * @template TEvents - Event schemas.

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -12,7 +12,7 @@ import type {
   Schema,
   Schemas,
 } from "./action.js";
-import type { Lease } from "./reaction.js";
+import type { BlockedLease, Lease } from "./reaction.js";
 
 /**
  * A function that disposes of a resource asynchronously.
@@ -402,9 +402,7 @@ export interface Store extends Disposable {
    *
    * @see {@link claim} for lease management
    */
-  block: (
-    leases: Array<Lease & { error: string }>
-  ) => Promise<Array<Lease & { error: string }>>;
+  block: (leases: BlockedLease[]) => Promise<BlockedLease[]>;
 
   /**
    * Resets watermarks for the given streams to -1, making them eligible

--- a/libs/act/src/types/reaction.ts
+++ b/libs/act/src/types/reaction.ts
@@ -268,6 +268,13 @@ export type Lease = {
 };
 
 /**
+ * A {@link Lease} augmented with the failure reason that pushed it past
+ * its retry budget. Yielded by {@link Drain.blocked}, emitted on the
+ * `"blocked"` lifecycle event, and accepted by {@link Store.block}.
+ */
+export type BlockedLease = Lease & { readonly error: string };
+
+/**
  * Options for draining events from the store.
  * @property streamLimit - Maximum number of streams to fetch.
  * @property eventLimit - Maximum number of events to fetch per stream.
@@ -290,7 +297,7 @@ export type Drain<TEvents extends Schemas> = {
   readonly fetched: Fetch<TEvents>;
   readonly leased: Lease[];
   readonly acked: Lease[];
-  readonly blocked: Array<Lease & { readonly error: string }>;
+  readonly blocked: BlockedLease[];
 };
 
 /**

--- a/libs/act/test/cache.bench.ts
+++ b/libs/act/test/cache.bench.ts
@@ -2,7 +2,7 @@
 import { bench, describe } from "vitest";
 import { z } from "zod";
 import { InMemoryStore } from "../src/adapters/InMemoryStore.js";
-import { action, load } from "../src/internal/index.js";
+import { action, load } from "../src/internal/event-sourcing.js";
 import { dispose, store } from "../src/ports.js";
 import { state } from "../src/state-builder.js";
 

--- a/libs/act/test/cache.spec.ts
+++ b/libs/act/test/cache.spec.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 import { InMemoryCache } from "../src/adapters/InMemoryCache.js";
 import { InMemoryStore } from "../src/adapters/InMemoryStore.js";
 import { action, load } from "../src/internal/event-sourcing.js";
-import { cache, dispose, store } from "../src/ports.js";
+import { cache, dispose, log, store } from "../src/ports.js";
 import { state } from "../src/state-builder.js";
+import type { Cache } from "../src/types/index.js";
 
 const Counter = state({ Counter: z.object({ count: z.number() }) })
   .init(() => ({ count: 0 }))
@@ -83,5 +84,41 @@ describe("cache integration", () => {
     const c = cache() as InMemoryCache;
     const entry = await c.get("c1");
     expect(entry).toBeUndefined();
+  });
+
+  it("cache.set rejection is logged but does not fail the action", async () => {
+    // Reset singletons so we can inject a failing cache for this test only
+    await dispose()();
+    store(new InMemoryStore());
+    await store().seed();
+
+    const setError = new Error("simulated cache write failure");
+    const failingCache: Cache = {
+      get: () => Promise.resolve(undefined),
+      set: () => Promise.reject(setError),
+      invalidate: () => Promise.resolve(),
+      clear: () => Promise.resolve(),
+      dispose: () => Promise.resolve(),
+    };
+    cache(failingCache);
+
+    const errorSpy = vi.spyOn(log(), "error").mockImplementation(() => {});
+
+    // Action should succeed despite cache.set rejecting
+    const snaps = await action(
+      Counter,
+      "increment",
+      target,
+      { count: 5 },
+      undefined,
+      true
+    );
+    expect(snaps[0].state.count).toBe(5);
+
+    // Flush the fire-and-forget .catch microtask
+    await new Promise((r) => setImmediate(r));
+
+    expect(errorSpy).toHaveBeenCalledWith(setError);
+    errorSpy.mockRestore();
   });
 });

--- a/libs/act/test/cache.spec.ts
+++ b/libs/act/test/cache.spec.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { InMemoryCache } from "../src/adapters/InMemoryCache.js";
 import { InMemoryStore } from "../src/adapters/InMemoryStore.js";
-import { action, load } from "../src/internal/index.js";
+import { action, load } from "../src/internal/event-sourcing.js";
 import { cache, dispose, store } from "../src/ports.js";
 import { state } from "../src/state-builder.js";
 

--- a/libs/act/test/event-sourcing.spec.ts
+++ b/libs/act/test/event-sourcing.spec.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { InMemoryStore } from "../src/adapters/InMemoryStore.js";
-import { action, load, snap } from "../src/internal/index.js";
+import { action, load, snap } from "../src/internal/event-sourcing.js";
 import { dispose, SNAP_EVENT, store } from "../src/ports.js";
 import { state } from "../src/state-builder.js";
 import { Snapshot } from "../src/types/action.js";
@@ -451,7 +451,7 @@ describe("event-sourcing", () => {
         log: () => fakeLogger,
       });
     });
-    const { snap } = await import("../src/internal/index.js");
+    const { snap } = await import("../src/internal/event-sourcing.js");
     await snap({
       event: {
         id: 1,

--- a/libs/act/test/tracing.spec.ts
+++ b/libs/act/test/tracing.spec.ts
@@ -6,7 +6,18 @@ import * as es from "../src/internal/event-sourcing.js";
 import { buildDrain, buildEs } from "../src/internal/tracing.js";
 import { cache, log, store } from "../src/ports.js";
 import { state } from "../src/state-builder.js";
+import type { Logger } from "../src/types/index.js";
 import { ZodEmpty } from "../src/types/schemas.js";
+
+// Returns a Logger that delegates to log() but reports the requested level.
+// Using a Proxy keeps dynamic dispatch so spies installed on log() still fire.
+const withLevel = (level: string): Logger =>
+  new Proxy(log(), {
+    get: (target, prop) =>
+      prop === "level"
+        ? level
+        : (target as unknown as Record<PropertyKey, unknown>)[prop],
+  });
 
 // State that emits one event per increment, and a no-op action that emits nothing
 const Counter = state({ Counter: z.object({ count: z.number() }) })
@@ -26,11 +37,7 @@ const target = (stream: string) => ({
   actor: { id: "u", name: "u" },
 });
 
-// Initialize singletons once for the whole file. We deliberately avoid
-// `dispose()()` between tests because tracing.ts captures `logger = log()`
-// at module-eval time; tearing the logger down would leave the captured
-// reference dangling and the spy installed below would be on a different
-// instance than the one the trace decorators actually call.
+// Initialize singletons once for the whole file.
 store(new InMemoryStore());
 cache(new InMemoryCache());
 
@@ -46,14 +53,14 @@ describe("tracing", () => {
 
   describe("buildEs", () => {
     it("returns bare ops for non-trace levels", () => {
-      const ops = buildEs("info");
+      const ops = buildEs(withLevel("info"));
       expect(ops.snap).toBe(es.snap);
       expect(ops.load).toBe(es.load);
       expect(ops.action).toBe(es.action);
     });
 
     it("returns wrapped ops for trace level", () => {
-      const ops = buildEs("trace");
+      const ops = buildEs(withLevel("trace"));
       expect(ops.snap).not.toBe(es.snap);
       expect(ops.load).not.toBe(es.load);
       expect(ops.action).not.toBe(es.action);
@@ -62,7 +69,7 @@ describe("tracing", () => {
 
   describe("buildDrain", () => {
     it("returns bare ops for non-trace levels", () => {
-      const ops = buildDrain("info");
+      const ops = buildDrain(withLevel("info"));
       expect(ops.claim).toBe(drain.claim);
       expect(ops.fetch).toBe(drain.fetch);
       expect(ops.ack).toBe(drain.ack);
@@ -71,7 +78,7 @@ describe("tracing", () => {
     });
 
     it("returns wrapped ops for trace level", () => {
-      const ops = buildDrain("trace");
+      const ops = buildDrain(withLevel("trace"));
       expect(ops.claim).not.toBe(drain.claim);
       expect(ops.fetch).not.toBe(drain.fetch);
       expect(ops.ack).not.toBe(drain.ack);
@@ -87,19 +94,19 @@ describe("tracing", () => {
     });
 
     it("withLoadTrace logs entry without asOf", async () => {
-      const { load } = buildEs("trace");
+      const { load } = buildEs(withLevel("trace"));
       await load(Counter, "s1");
       expect(traceSpy).toHaveBeenCalledWith("🟢 load s1");
     });
 
     it("withLoadTrace logs entry with asOf marker", async () => {
-      const { load } = buildEs("trace");
+      const { load } = buildEs(withLevel("trace"));
       await load(Counter, "s1", undefined, { before: 9999 });
       expect(traceSpy).toHaveBeenCalledWith("🟢 load s1 (as-of)");
     });
 
     it("withActionTrace logs entry and commit when events emitted", async () => {
-      const { action } = buildEs("trace");
+      const { action } = buildEs(withLevel("trace"));
       const snapshots = await action(Counter, "increment", target("s1"), {
         by: 5,
       });
@@ -111,7 +118,7 @@ describe("tracing", () => {
     });
 
     it("withActionTrace skips commit log when nothing emitted", async () => {
-      const { action } = buildEs("trace");
+      const { action } = buildEs(withLevel("trace"));
       await action(Counter, "noop", target("s2"), {});
       expect(traceSpy).toHaveBeenCalledWith({}, "🔵 s2.noop");
       const commitCalls = traceSpy.mock.calls.filter(
@@ -125,7 +132,7 @@ describe("tracing", () => {
       const [snapshot] = await es.action(Counter, "increment", target("s3"), {
         by: 1,
       });
-      const { snap } = buildEs("trace");
+      const { snap } = buildEs(withLevel("trace"));
       await snap(snapshot);
       expect(traceSpy).toHaveBeenCalledWith(
         `🟠 snap ${snapshot.event!.stream}@${snapshot.event!.version}`
@@ -140,7 +147,7 @@ describe("tracing", () => {
     });
 
     it("withClaimTrace skips log when no leases returned", async () => {
-      const { claim } = buildDrain("trace");
+      const { claim } = buildDrain(withLevel("trace"));
       const leased = await claim(1, 1, "by-x", 1000);
       expect(leased).toEqual([]);
       const leaseCalls = traceSpy.mock.calls.filter(
@@ -154,7 +161,7 @@ describe("tracing", () => {
       await es.action(Counter, "increment", target("claim-stream"), {
         by: 1,
       });
-      const { claim } = buildDrain("trace");
+      const { claim } = buildDrain(withLevel("trace"));
       const leased = await claim(2, 0, "claim-by", 60_000);
       expect(leased.length).toBeGreaterThan(0);
       expect(traceSpy).toHaveBeenCalledWith(expect.any(Object), ">> lease");
@@ -164,7 +171,7 @@ describe("tracing", () => {
       // Commit so we have events to "fetch"
       await es.action(Counter, "increment", target("fetch-stream"), { by: 2 });
 
-      const { fetch } = buildDrain("trace");
+      const { fetch } = buildDrain(withLevel("trace"));
       const fetched = await fetch(
         [
           {
@@ -190,7 +197,7 @@ describe("tracing", () => {
     });
 
     it("withAckTrace skips log on empty", async () => {
-      const { ack } = buildDrain("trace");
+      const { ack } = buildDrain(withLevel("trace"));
       const result = await ack([]);
       expect(result).toEqual([]);
       const ackCalls = traceSpy.mock.calls.filter(
@@ -202,7 +209,7 @@ describe("tracing", () => {
     it("withAckTrace logs on non-empty", async () => {
       await store().subscribe([{ stream: "ack-stream" }]);
       await es.action(Counter, "increment", target("ack-stream"), { by: 1 });
-      const { claim, ack } = buildDrain("trace");
+      const { claim, ack } = buildDrain(withLevel("trace"));
       const leased = await claim(2, 0, "ack-by", 60_000);
       expect(leased.length).toBeGreaterThan(0);
       const acked = await ack(leased);
@@ -211,7 +218,7 @@ describe("tracing", () => {
     });
 
     it("withBlockTrace skips log on empty", async () => {
-      const { block } = buildDrain("trace");
+      const { block } = buildDrain(withLevel("trace"));
       const result = await block([]);
       expect(result).toEqual([]);
       const blockCalls = traceSpy.mock.calls.filter(
@@ -225,7 +232,7 @@ describe("tracing", () => {
       await es.action(Counter, "increment", target("block-stream"), {
         by: 1,
       });
-      const { claim, block } = buildDrain("trace");
+      const { claim, block } = buildDrain(withLevel("trace"));
       const leased = await claim(2, 0, "block-by", 60_000);
       expect(leased.length).toBeGreaterThan(0);
       const blocked = await block(leased.map((l) => ({ ...l, error: "boom" })));
@@ -236,7 +243,7 @@ describe("tracing", () => {
     it("withSubscribeTrace skips log when nothing newly subscribed", async () => {
       // Pre-subscribe so the next subscribe is a no-op
       await store().subscribe([{ stream: "already-there" }]);
-      const { subscribe } = buildDrain("trace");
+      const { subscribe } = buildDrain(withLevel("trace"));
       const result = await subscribe([{ stream: "already-there" }]);
       expect(result.subscribed).toBe(0);
       const corrCalls = traceSpy.mock.calls.filter(
@@ -247,7 +254,7 @@ describe("tracing", () => {
     });
 
     it("withSubscribeTrace logs when subscribed > 0", async () => {
-      const { subscribe } = buildDrain("trace");
+      const { subscribe } = buildDrain(withLevel("trace"));
       const result = await subscribe([{ stream: "fresh-stream" }]);
       expect(result.subscribed).toBeGreaterThan(0);
       expect(traceSpy).toHaveBeenCalledWith(">> correlate fresh-stream");


### PR DESCRIPTION
## Summary

Cleanup pass over `libs/act/src/internal/` and adjacent surfaces. Three bug-class fixes, four refactors, two micro-opts. No behavior change at runtime; ~150 lines removed from `tracing.ts`, modest growth elsewhere from explicit naming/typing.

## Commits (smallest unit of review)

**Bugs / correctness**
- `72a5228a` — Inject logger instead of capturing at module load. Module-level `const logger = log()` forced eager port init, silently dropping user-injected loggers.
- `bb2d64b1` — Use `ConcurrencyError instanceof` instead of `error.name === "ERR_CONCURRENCY"`.
- `a3394ddd` — Catch `cache.set` errors instead of unhandled rejection (matters for custom Cache adapters).

**Refactor / dedupe**
- `619959fd` — Collapse 6 near-identical trace decorators in `tracing.ts` into a single `traced(inner, exit?, entry?)` helper. **Net −47 lines.**
- `263daebd` — Split 90-line `registerState` into `registerNewState` / `mergeIntoExisting` / `mergePatches` with explicit phase comments. Public signature unchanged so builder type chain is unaffected.
- `3feac839` — Type the `_passthrough` patch marker (typed alias + `satisfies` instead of `(fn as any)._passthrough = true`).

**Modularization**
- `455e0490` — Replace `export *` with explicit re-exports in `internal/index.ts`. Drop barrel exports for symbols only used inside `internal/`. Tests updated to import bare ops directly.
- `492d0103` — Extract `BlockedLease = Lease & { readonly error: string }` once; replace 10 inline sites across 7 files (Store interface, all three store impls, drain pipeline, Act lifecycle overloads, Drain result).

**Micro-opts**
- `cb7b169f` — Simplify time-travel predicate in `load()` to `Object.values(asOf).some(...)` so it auto-tracks if `AsOf` grows.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 884 tests pass (2 PG-connection failures pre-existing on master, unrelated)
- [x] `pnpm build` — all packages build

🤖 Generated with [Claude Code](https://claude.com/claude-code)