### PR TITLE
perf(act): root-folder optimizations + trace redesign + test-noise cleanup

### DIFF
--- a/libs/act-diagram/test/wolfdesk-broken.spec.ts
+++ b/libs/act-diagram/test/wolfdesk-broken.spec.ts
@@ -48,31 +48,6 @@ describe("wolfdesk broken import", () => {
       (s) => s.name === "TicketMessagingSlice"
     );
 
-    console.log(
-      "ops:",
-      ops?.name,
-      "states:",
-      ops?.states.length,
-      "error:",
-      ops?.error
-    );
-    console.log(
-      "creation:",
-      creation?.name,
-      "states:",
-      creation?.states.length,
-      "error:",
-      creation?.error
-    );
-    console.log(
-      "messaging:",
-      messaging?.name,
-      "states:",
-      messaging?.states.length,
-      "error:",
-      messaging?.error
-    );
-
     // All 3 slices visible
     expect(ops).toBeDefined();
     expect(creation).toBeDefined();
@@ -105,31 +80,6 @@ describe("wolfdesk broken import", () => {
     const creation = model.slices.find((s) => s.name === "TicketCreationSlice");
     const messaging = model.slices.find(
       (s) => s.name === "TicketMessagingSlice"
-    );
-
-    console.log(
-      "ops:",
-      ops?.name,
-      "states:",
-      ops?.states.length,
-      "error:",
-      ops?.error
-    );
-    console.log(
-      "creation:",
-      creation?.name,
-      "states:",
-      creation?.states.length,
-      "error:",
-      creation?.error
-    );
-    console.log(
-      "messaging:",
-      messaging?.name,
-      "states:",
-      messaging?.states.length,
-      "error:",
-      messaging?.error
     );
 
     // All 3 slices visible

--- a/libs/act-pino/test/pino-logger.spec.ts
+++ b/libs/act-pino/test/pino-logger.spec.ts
@@ -18,7 +18,7 @@ describe("PinoLogger", () => {
 
   it("creates with default options", () => {
     const logger = new PinoLogger({ pretty: false });
-    expect(logger.level).toBe("error"); // test env default
+    expect(logger.level).toBe("fatal"); // test env default
   });
 
   it("creates with custom level", () => {

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -182,8 +182,10 @@ export class Act<
     this._batch_handlers = batchHandlers;
     this._es = buildEs(this._logger);
     this._cd = buildDrain<TEvents>(this._logger);
-    // Classify resolvers and reactive events at build time
-    const statics: Array<{ stream: string; source?: string }> = [];
+    // Classify resolvers and reactive events at build time. Static targets
+    // are deduplicated by (target, source) — two reactions to different
+    // events that route to the same projection produce one subscription.
+    const statics = new Map<string, { stream: string; source?: string }>();
     for (const [name, register] of Object.entries(this.registry.events)) {
       if (register.reactions.size > 0) {
         this._reactive_events.add(name);
@@ -192,14 +194,13 @@ export class Act<
         if (typeof reaction.resolver === "function") {
           this._has_dynamic_resolvers = true;
         } else {
-          statics.push({
-            stream: reaction.resolver.target,
-            source: reaction.resolver.source,
-          });
+          const { target, source } = reaction.resolver;
+          const key = `${target}|${source ?? ""}`;
+          if (!statics.has(key)) statics.set(key, { stream: target, source });
         }
       }
     }
-    this._static_targets = statics;
+    this._static_targets = [...statics.values()];
 
     // Build the event-name → owning state index. Duplicate event names are
     // already rejected at registration time (merge.ts), so each entry is

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -167,6 +167,12 @@ export class Act<
   private readonly _event_to_state = new Map<string, State<any, any, any>>();
   /** Logger resolved at construction time (after user port configuration) */
   private readonly _logger: Logger = log();
+  /** Pre-bound IAct methods reused across drain cycles. Only `do` varies per
+   * payload (it captures the triggering event for reactingTo auto-inject). */
+  private readonly _bound_do = this.do.bind(this);
+  private readonly _bound_load = this.load.bind(this);
+  private readonly _bound_query = this.query.bind(this);
+  private readonly _bound_query_array = this.query_array.bind(this);
 
   constructor(
     public readonly registry: Registry<TSchemaReg, TEvents, TActions>,
@@ -536,14 +542,16 @@ export class Act<
       this._logger.warn(`Retrying ${stream}@${at} (${lease.retry}).`);
 
     // Scoped proxy: auto-injects reactingTo when do() is called without it,
-    // maintaining correlation chains by default (see #587).
-    // Bind stable methods once; only the do() closure changes per event.
-    const doAction = this.do.bind(this);
+    // maintaining correlation chains by default (see #587). The non-do
+    // methods are pre-bound on the Act instance and reused across all
+    // handle() calls; only the do() closure varies per payload because it
+    // captures the triggering event.
+    const doAction = this._bound_do;
     const scopedApp: IAct<TEvents, TActions, TActor> = {
       do: doAction,
-      load: this.load.bind(this),
-      query: this.query.bind(this),
-      query_array: this.query_array.bind(this),
+      load: this._bound_load,
+      query: this._bound_query,
+      query_array: this._bound_query_array,
     };
 
     for (const payload of payloads) {

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -708,7 +708,13 @@ export class Act<
         // Fetch events for each leased stream
         const fetched = await this._cd.fetch(leased, eventLimit);
 
-        const payloadsMap = new Map<string, ReactionPayload<TEvents>[]>();
+        // Build a single index keyed by stream — collapses two passes
+        // (payloadsMap build + per-lease fetched.find) into one Map lookup.
+        type FetchEntry = (typeof fetched)[number];
+        const fetchMap = new Map<
+          string,
+          { fetch: FetchEntry; payloads: ReactionPayload<TEvents>[] }
+        >();
 
         // compute fetch window max event id
         const fetch_window_at = fetched.reduce(
@@ -716,7 +722,8 @@ export class Act<
           0
         );
 
-        fetched.forEach(({ stream, events }) => {
+        for (const f of fetched) {
+          const { stream, events } = f;
           const payloads = events.flatMap((event) => {
             const register = this.registry.events[event.name];
             if (!register) return [];
@@ -730,15 +737,15 @@ export class Act<
               })
               .map((reaction) => ({ ...reaction, event }));
           });
-          payloadsMap.set(stream, payloads);
-        });
+          fetchMap.set(stream, { fetch: f, payloads });
+        }
 
         const handled = await Promise.all(
           leased.map((lease) => {
+            const entry = fetchMap.get(lease.stream);
             // fast-forward watermark using fetched events or window max
-            const streamFetch = fetched.find((f) => f.stream === lease.stream);
-            const at = streamFetch?.events.at(-1)?.id || fetch_window_at;
-            const payloads = payloadsMap.get(lease.stream)!;
+            const at = entry?.fetch.events.at(-1)?.id || fetch_window_at;
+            const payloads = entry?.payloads ?? [];
             const batchHandler = this._batch_handlers.get(lease.stream);
             if (batchHandler && payloads.length > 0) {
               return this.handleBatch({ ...lease, at }, payloads, batchHandler);

--- a/libs/act/src/config.ts
+++ b/libs/act/src/config.ts
@@ -70,7 +70,7 @@ const { NODE_ENV, LOG_LEVEL, LOG_SINGLE_LINE, SLEEP_MS } = process.env;
 const env = (NODE_ENV || "development") as Environment;
 const logLevel = (LOG_LEVEL ||
   (NODE_ENV === "test"
-    ? "error"
+    ? "fatal"
     : NODE_ENV === "production"
       ? "info"
       : "trace")) as LogLevel;

--- a/libs/act/src/config.ts
+++ b/libs/act/src/config.ts
@@ -79,6 +79,12 @@ const sleepMs = parseInt(NODE_ENV === "test" ? "0" : (SLEEP_MS ?? "100"), 10);
 
 const pkg = getPackage();
 
+// Lazily validated on first call. Cannot run extend() at module load
+// because of a utils.ts <-> config.ts cycle (utils imports config for
+// sleep()'s default). Inputs are frozen after import, so the cached
+// result is stable for the life of the process.
+let _validated: Config | undefined;
+
 /**
  * Gets the current Act Framework configuration.
  *
@@ -139,5 +145,11 @@ const pkg = getPackage();
  * @see {@link Package} for package.json metadata
  */
 export const config = (): Config => {
-  return extend({ ...pkg, env, logLevel, logSingleLine, sleepMs }, BaseSchema);
+  if (!_validated) {
+    _validated = extend(
+      { ...pkg, env, logLevel, logSingleLine, sleepMs },
+      BaseSchema
+    );
+  }
+  return _validated;
 };

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -35,13 +35,12 @@ type AsyncFn = (...args: any[]) => Promise<any>;
 
 const PRETTY = config().env !== "production";
 
-const C_BLUE = "\x1b[34m";
-const C_GREEN = "\x1b[32m";
-const C_YELLOW = "\x1b[33m";
-const C_CYAN = "\x1b[36m";
-const C_RED = "\x1b[31m";
-const C_GRAY = "\x1b[90m";
-const C_MAGENTA = "\x1b[35m";
+// 256-color codes for distinctive, theme-friendly hues
+const C_BLUE = "\x1b[38;5;39m"; // vivid sky blue (action)
+const C_ORANGE = "\x1b[38;5;208m"; // true orange (committed)
+const C_GREEN = "\x1b[38;5;42m"; // emerald (load)
+const C_MAGENTA = "\x1b[38;5;165m"; // bright magenta (snap)
+const C_DRAIN = "\x1b[38;5;244m"; // muted gray for all drain ops
 const C_RESET = "\x1b[0m";
 
 /**
@@ -55,11 +54,12 @@ const es_caption = (caption: string, color: string, body: string): string =>
 /**
  * Format a drain-pipeline caption. Drain logs keep a `>>` marker for easy
  * spotting in mixed log streams, plus a `caption` (past tense — every drain
- * trace fires on exit). Pretty mode colors the marker+caption block.
+ * trace fires on exit). All drain ops share one color (gray) so the pipeline
+ * reads as a single channel; the caption disambiguates the phase.
  */
-const drain_caption = (caption: string, color: string): string => {
+const drain_caption = (caption: string): string => {
   const tag = `>> ${caption}`;
-  return PRETTY ? `${color}${tag}${C_RESET}` : tag;
+  return PRETTY ? `${C_DRAIN}${tag}${C_RESET}` : tag;
 };
 
 /**
@@ -116,7 +116,7 @@ export function buildEs(logger: Logger): EsOps {
             committed.map((s) => s.event!.data),
             es_caption(
               "committed",
-              C_YELLOW,
+              C_ORANGE,
               `${target.stream}.${committed.map((s) => s.event!.name).join(", ")}`
             )
           );
@@ -156,7 +156,7 @@ export function buildDrain<TEvents extends Schemas>(
         const data = Object.fromEntries(
           leased.map(({ stream, at, retry }) => [stream, { at, retry }])
         );
-        logger.trace(data, drain_caption("claimed", C_CYAN));
+        logger.trace(data, drain_caption("claimed"));
       }
     }),
     fetch: traced(drain.fetch<TEvents>, (fetched) => {
@@ -169,14 +169,14 @@ export function buildDrain<TEvents extends Schemas>(
           return [key, value];
         })
       );
-      logger.trace(data, drain_caption("fetched", C_CYAN));
+      logger.trace(data, drain_caption("fetched"));
     }),
     ack: traced(drain.ack, (acked) => {
       if (acked.length) {
         const data = Object.fromEntries(
           acked.map(({ stream, at, retry }) => [stream, { at, retry }])
         );
-        logger.trace(data, drain_caption("acked", C_GREEN));
+        logger.trace(data, drain_caption("acked"));
       }
     }),
     block: traced(drain.block, (blocked) => {
@@ -187,13 +187,13 @@ export function buildDrain<TEvents extends Schemas>(
             { at, retry, error },
           ])
         );
-        logger.trace(data, drain_caption("blocked", C_RED));
+        logger.trace(data, drain_caption("blocked"));
       }
     }),
     subscribe: traced(drain.subscribe, (result, streams) => {
       if (result.subscribed) {
         const data = streams.map(({ stream }) => stream).join(" ");
-        logger.trace(`${drain_caption("correlated", C_GRAY)} ${data}`);
+        logger.trace(`${drain_caption("correlated")} ${data}`);
       }
     }),
   };

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -8,8 +8,15 @@
  * at well-defined moments — entry points for {@link "event-sourcing"} (`load`,
  * `snap`, `action`) and exit points for the {@link "drain"} pipeline (`claim`,
  * `fetch`, `ack`, `block`, `subscribe`). `action` carries both an entry log
- * (🔵) and a post-commit log (🔴) to preserve the diagnostic value of the
- * historical mid-function trace points.
+ * and a post-commit log to preserve the diagnostic value of the historical
+ * mid-function trace points.
+ *
+ * Output styles:
+ * - **Pretty mode** (`config().env !== "production"`) — event-sourcing logs
+ *   show only the colored target body (color carries the operation/phase),
+ *   drain logs keep a colored caption.
+ * - **Plain mode** (production / log aggregators) — every log gets a textual
+ *   prefix; event-sourcing uses `caption: body`, drain uses `caption body`.
  *
  * The two factories — {@link buildEs} and {@link buildDrain} — let the
  * orchestrator choose bare or traced variants once at `.build()` time based
@@ -17,6 +24,7 @@
  * imports tracing primitives.
  */
 
+import { config } from "../config.js";
 import type { Logger, Schemas } from "../types/index.js";
 import * as drain from "./drain.js";
 import { type DrainOps } from "./drain.js";
@@ -24,6 +32,35 @@ import * as es from "./event-sourcing.js";
 import { type EsOps } from "./event-sourcing.js";
 
 type AsyncFn = (...args: any[]) => Promise<any>;
+
+const PRETTY = config().env !== "production";
+
+const C_BLUE = "\x1b[34m";
+const C_GREEN = "\x1b[32m";
+const C_YELLOW = "\x1b[33m";
+const C_CYAN = "\x1b[36m";
+const C_RED = "\x1b[31m";
+const C_GRAY = "\x1b[90m";
+const C_MAGENTA = "\x1b[35m";
+const C_RESET = "\x1b[0m";
+
+/**
+ * Format an event-sourcing trace line. Pretty mode renders just the colored
+ * body (the color is the cue for which op/phase fired); plain mode prepends
+ * `caption: ` so log aggregators stay readable without ANSI.
+ */
+const es_caption = (caption: string, color: string, body: string): string =>
+  PRETTY ? `${color}${body}${C_RESET}` : `${caption}: ${body}`;
+
+/**
+ * Format a drain-pipeline caption. Drain logs keep a `>>` marker for easy
+ * spotting in mixed log streams, plus a `caption` (past tense — every drain
+ * trace fires on exit). Pretty mode colors the marker+caption block.
+ */
+const drain_caption = (caption: string, color: string): string => {
+  const tag = `>> ${caption}`;
+  return PRETTY ? `${color}${tag}${C_RESET}` : tag;
+};
 
 /**
  * Wraps an async function with optional `exit` and `entry` callbacks. Each
@@ -58,11 +95,17 @@ export function buildEs(logger: Logger): EsOps {
   return {
     snap: traced(es.snap, undefined, (snapshot) => {
       logger.trace(
-        `🟠 snap ${snapshot.event!.stream}@${snapshot.event!.version}`
+        es_caption(
+          "snap",
+          C_MAGENTA,
+          `${snapshot.event!.stream}@${snapshot.event!.version}`
+        )
       );
     }),
     load: traced(es.load, undefined, (_me, stream, _cb, asOf) => {
-      logger.trace(`🟢 load ${stream}${asOf ? " (as-of)" : ""}`);
+      logger.trace(
+        es_caption("load", C_GREEN, `${stream}${asOf ? " (as-of)" : ""}`)
+      );
     }),
     action: traced(
       es.action,
@@ -71,14 +114,19 @@ export function buildEs(logger: Logger): EsOps {
         if (committed.length) {
           logger.trace(
             committed.map((s) => s.event!.data),
-            `🔴 commit ${target.stream}.${committed
-              .map((s) => s.event!.name)
-              .join(", ")}`
+            es_caption(
+              "committed",
+              C_YELLOW,
+              `${target.stream}.${committed.map((s) => s.event!.name).join(", ")}`
+            )
           );
         }
       },
       (_me, action, target, payload) => {
-        logger.trace(payload as object, `🔵 ${target.stream}.${action}`);
+        logger.trace(
+          payload as object,
+          es_caption("action", C_BLUE, `${target.stream}.${action}`)
+        );
       }
     ),
   };
@@ -108,7 +156,7 @@ export function buildDrain<TEvents extends Schemas>(
         const data = Object.fromEntries(
           leased.map(({ stream, at, retry }) => [stream, { at, retry }])
         );
-        logger.trace(data, ">> lease");
+        logger.trace(data, drain_caption("claimed", C_CYAN));
       }
     }),
     fetch: traced(drain.fetch<TEvents>, (fetched) => {
@@ -121,14 +169,14 @@ export function buildDrain<TEvents extends Schemas>(
           return [key, value];
         })
       );
-      logger.trace(data, ">> fetch");
+      logger.trace(data, drain_caption("fetched", C_CYAN));
     }),
     ack: traced(drain.ack, (acked) => {
       if (acked.length) {
         const data = Object.fromEntries(
           acked.map(({ stream, at, retry }) => [stream, { at, retry }])
         );
-        logger.trace(data, ">> ack");
+        logger.trace(data, drain_caption("acked", C_GREEN));
       }
     }),
     block: traced(drain.block, (blocked) => {
@@ -139,13 +187,13 @@ export function buildDrain<TEvents extends Schemas>(
             { at, retry, error },
           ])
         );
-        logger.trace(data, ">> block");
+        logger.trace(data, drain_caption("blocked", C_RED));
       }
     }),
     subscribe: traced(drain.subscribe, (result, streams) => {
       if (result.subscribed) {
         const data = streams.map(({ stream }) => stream).join(" ");
-        logger.trace(`>> correlate ${data}`);
+        logger.trace(`${drain_caption("correlated", C_GRAY)} ${data}`);
       }
     }),
   };

--- a/libs/act/src/ports.ts
+++ b/libs/act/src/ports.ts
@@ -75,7 +75,10 @@ export function port<Port extends Disposable>(injector: Injector<Port>) {
     if (!adapters.has(injector.name)) {
       const injected = injector(adapter);
       adapters.set(injector.name, injected);
-      console.log(`[act] + ${injector.name}:${injected.constructor.name}`);
+      // log() is now in adapters (or this IS the log port we just registered),
+      // so the recursive call resolves immediately. Routing through the logger
+      // means level gating (e.g. silenced in tests at fatal) takes effect.
+      log().info(`[act] + ${injector.name}:${injected.constructor.name}`);
     }
     return adapters.get(injector.name) as Port;
   };
@@ -216,7 +219,7 @@ export async function disposeAndExit(code: ExitCode = "EXIT"): Promise<void> {
   }
   for (const adapter of [...adapters.values()].reverse()) {
     await adapter.dispose();
-    console.log(`[act] - ${adapter.constructor.name}`);
+    log().info(`[act] - ${adapter.constructor.name}`);
   }
   adapters.clear();
   config().env !== "test" && process.exit(code === "ERROR" ? 1 : 0);

--- a/libs/act/test/act.spec.ts
+++ b/libs/act/test/act.spec.ts
@@ -83,20 +83,17 @@ describe("act", () => {
 
     // first fully failed
     drained = await app.drain({ leaseMillis: 1 });
-    console.log("first try", drained);
     expect(drained.acked.length).toBe(0);
     expect(onDecremented).toHaveBeenCalledTimes(2);
 
     // second fully failed (first retry)
     drained = await app.drain({ leaseMillis: 1 });
-    console.log("second try", drained);
     expect(drained.acked.length).toBe(0);
     expect(drained.blocked.length).toBe(0);
     expect(onDecremented).toHaveBeenCalledTimes(3);
 
     // third fully failed (second retry) - should block
     drained = await app.drain({ leaseMillis: 1 });
-    console.log("third try", drained);
     expect(drained.acked.length).toBe(0);
     expect(drained.blocked.length).toBe(1);
     expect(onDecremented).toHaveBeenCalledTimes(4);

--- a/libs/act/test/config.spec.ts
+++ b/libs/act/test/config.spec.ts
@@ -33,7 +33,7 @@ describe("config", () => {
     const { config: loadConfig } = await import("../src/config.js");
     const config = loadConfig();
     expect(config.env).toBe("test");
-    expect(config.logLevel).toBe("error");
+    expect(config.logLevel).toBe("fatal");
     expect(config.sleepMs).toBe(0);
   });
 

--- a/libs/act/test/ports-injector.spec.ts
+++ b/libs/act/test/ports-injector.spec.ts
@@ -14,7 +14,7 @@ vi.mock("pino", () => ({
 vi.mock("../src/config.js", () => ({
   config: vi.fn().mockReturnValue({
     env: "development",
-    logLevel: "info",
+    logLevel: "fatal",
     logSingleLine: true,
   }),
 }));

--- a/libs/act/test/tracing.spec.ts
+++ b/libs/act/test/tracing.spec.ts
@@ -96,13 +96,15 @@ describe("tracing", () => {
     it("withLoadTrace logs entry without asOf", async () => {
       const { load } = buildEs(withLevel("trace"));
       await load(Counter, "s1");
-      expect(traceSpy).toHaveBeenCalledWith("🟢 load s1");
+      expect(traceSpy).toHaveBeenCalledWith(expect.stringContaining("s1"));
     });
 
     it("withLoadTrace logs entry with asOf marker", async () => {
       const { load } = buildEs(withLevel("trace"));
       await load(Counter, "s1", undefined, { before: 9999 });
-      expect(traceSpy).toHaveBeenCalledWith("🟢 load s1 (as-of)");
+      expect(traceSpy).toHaveBeenCalledWith(
+        expect.stringContaining("s1 (as-of)")
+      );
     });
 
     it("withActionTrace logs entry and commit when events emitted", async () => {
@@ -110,20 +112,31 @@ describe("tracing", () => {
       const snapshots = await action(Counter, "increment", target("s1"), {
         by: 5,
       });
-      expect(traceSpy).toHaveBeenCalledWith({ by: 5 }, "🔵 s1.increment");
+      // entry log: action payload + colored target body
+      expect(traceSpy).toHaveBeenCalledWith(
+        { by: 5 },
+        expect.stringContaining("s1.increment")
+      );
+      // exit log: committed event data + colored target.event body
       expect(traceSpy).toHaveBeenCalledWith(
         snapshots.map((s) => s.event?.data),
-        expect.stringContaining("🔴 commit s1.")
+        expect.stringContaining("s1.Incremented")
       );
     });
 
     it("withActionTrace skips commit log when nothing emitted", async () => {
       const { action } = buildEs(withLevel("trace"));
       await action(Counter, "noop", target("s2"), {});
-      expect(traceSpy).toHaveBeenCalledWith({}, "🔵 s2.noop");
+      expect(traceSpy).toHaveBeenCalledWith(
+        {},
+        expect.stringContaining("s2.noop")
+      );
+      // No "Incremented" / commit-style call should have fired
       const commitCalls = traceSpy.mock.calls.filter(
         (c: [unknown, unknown]) =>
-          typeof c[1] === "string" && c[1].startsWith("🔴 commit")
+          Array.isArray(c[0]) &&
+          typeof c[1] === "string" &&
+          c[1].includes("s2.")
       );
       expect(commitCalls).toHaveLength(0);
     });
@@ -135,7 +148,9 @@ describe("tracing", () => {
       const { snap } = buildEs(withLevel("trace"));
       await snap(snapshot);
       expect(traceSpy).toHaveBeenCalledWith(
-        `🟠 snap ${snapshot.event!.stream}@${snapshot.event!.version}`
+        expect.stringContaining(
+          `${snapshot.event!.stream}@${snapshot.event!.version}`
+        )
       );
     });
   });
@@ -146,14 +161,25 @@ describe("tracing", () => {
       traceSpy = vi.spyOn(log(), "trace").mockImplementation(() => {});
     });
 
+    // Helper: a trace call with caption substring `>> claimed` etc.
+    // Tests assert the caption substring; in pretty mode the caption is
+    // wrapped in ANSI color codes, but the substring still matches.
+    const calledWithCaption = (substr: string) =>
+      expect(traceSpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.stringContaining(substr)
+      );
+    const noCaptionCall = (substr: string) =>
+      traceSpy.mock.calls.filter(
+        (c: [unknown, unknown]) =>
+          typeof c[1] === "string" && c[1].includes(substr)
+      );
+
     it("withClaimTrace skips log when no leases returned", async () => {
       const { claim } = buildDrain(withLevel("trace"));
       const leased = await claim(1, 1, "by-x", 1000);
       expect(leased).toEqual([]);
-      const leaseCalls = traceSpy.mock.calls.filter(
-        (c: [unknown, unknown]) => c[1] === ">> lease"
-      );
-      expect(leaseCalls).toHaveLength(0);
+      expect(noCaptionCall(">> claimed")).toHaveLength(0);
     });
 
     it("withClaimTrace logs when leases returned", async () => {
@@ -164,7 +190,7 @@ describe("tracing", () => {
       const { claim } = buildDrain(withLevel("trace"));
       const leased = await claim(2, 0, "claim-by", 60_000);
       expect(leased.length).toBeGreaterThan(0);
-      expect(traceSpy).toHaveBeenCalledWith(expect.any(Object), ">> lease");
+      calledWithCaption(">> claimed");
     });
 
     it("withFetchTrace logs stream-only and stream<-source variants", async () => {
@@ -193,17 +219,14 @@ describe("tracing", () => {
         100
       );
       expect(fetched).toHaveLength(2);
-      expect(traceSpy).toHaveBeenCalledWith(expect.any(Object), ">> fetch");
+      calledWithCaption(">> fetched");
     });
 
     it("withAckTrace skips log on empty", async () => {
       const { ack } = buildDrain(withLevel("trace"));
       const result = await ack([]);
       expect(result).toEqual([]);
-      const ackCalls = traceSpy.mock.calls.filter(
-        (c: [unknown, unknown]) => c[1] === ">> ack"
-      );
-      expect(ackCalls).toHaveLength(0);
+      expect(noCaptionCall(">> acked")).toHaveLength(0);
     });
 
     it("withAckTrace logs on non-empty", async () => {
@@ -214,17 +237,14 @@ describe("tracing", () => {
       expect(leased.length).toBeGreaterThan(0);
       const acked = await ack(leased);
       expect(acked.length).toBeGreaterThan(0);
-      expect(traceSpy).toHaveBeenCalledWith(expect.any(Object), ">> ack");
+      calledWithCaption(">> acked");
     });
 
     it("withBlockTrace skips log on empty", async () => {
       const { block } = buildDrain(withLevel("trace"));
       const result = await block([]);
       expect(result).toEqual([]);
-      const blockCalls = traceSpy.mock.calls.filter(
-        (c: [unknown, unknown]) => c[1] === ">> block"
-      );
-      expect(blockCalls).toHaveLength(0);
+      expect(noCaptionCall(">> blocked")).toHaveLength(0);
     });
 
     it("withBlockTrace logs on non-empty", async () => {
@@ -237,7 +257,7 @@ describe("tracing", () => {
       expect(leased.length).toBeGreaterThan(0);
       const blocked = await block(leased.map((l) => ({ ...l, error: "boom" })));
       expect(blocked.length).toBeGreaterThan(0);
-      expect(traceSpy).toHaveBeenCalledWith(expect.any(Object), ">> block");
+      calledWithCaption(">> blocked");
     });
 
     it("withSubscribeTrace skips log when nothing newly subscribed", async () => {
@@ -248,7 +268,7 @@ describe("tracing", () => {
       expect(result.subscribed).toBe(0);
       const corrCalls = traceSpy.mock.calls.filter(
         (c: [unknown, unknown]) =>
-          typeof c[0] === "string" && c[0].startsWith(">> correlate")
+          typeof c[0] === "string" && c[0].includes(">> correlated")
       );
       expect(corrCalls).toHaveLength(0);
     });
@@ -257,7 +277,11 @@ describe("tracing", () => {
       const { subscribe } = buildDrain(withLevel("trace"));
       const result = await subscribe([{ stream: "fresh-stream" }]);
       expect(result.subscribed).toBeGreaterThan(0);
-      expect(traceSpy).toHaveBeenCalledWith(">> correlate fresh-stream");
+      // pretty mode wraps the >> correlated caption in ANSI codes; the
+      // stream name follows after the reset, so match each piece.
+      expect(traceSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/>> correlated.*fresh-stream/)
+      );
     });
   });
 });

--- a/packages/wolfdesk/src/ticket-projections.ts
+++ b/packages/wolfdesk/src/ticket-projections.ts
@@ -1,4 +1,4 @@
-import { projection } from "@rotorsoft/act";
+import { log, projection } from "@rotorsoft/act";
 import { eq, sql } from "drizzle-orm";
 import { db, tickets } from "./drizzle/index.js";
 import {
@@ -25,7 +25,7 @@ export const TicketProjection = projection("tickets")
           ...other,
         })
         .onConflictDoNothing()
-        .then(() => console.log(`${stream} => opened`));
+        .then(() => log().info(`${stream} => opened`));
     })
   .on({ TicketClosed })
     .do(async function closed({ stream, data }) {
@@ -33,7 +33,7 @@ export const TicketProjection = projection("tickets")
         .update(tickets)
         .set(data)
         .where(eq(tickets.id, stream))
-        .then(() => console.log(`${stream} => closed`));
+        .then(() => log().info(`${stream} => closed`));
     })
   .on({ TicketResolved })
     .do(async function resolved({ stream, data }) {
@@ -41,7 +41,7 @@ export const TicketProjection = projection("tickets")
         .update(tickets)
         .set(data)
         .where(eq(tickets.id, stream))
-        .then(() => console.log(`${stream} => resolved`));
+        .then(() => log().info(`${stream} => resolved`));
     })
   .on({ MessageAdded })
     .do(async function messageAdded({ stream }) {
@@ -49,7 +49,7 @@ export const TicketProjection = projection("tickets")
         .update(tickets)
         .set({ messages: sql`${tickets.messages} + 1` })
         .where(eq(tickets.id, stream))
-        .then(() => console.log(`${stream} => messageAdded`));
+        .then(() => log().info(`${stream} => messageAdded`));
     })
   .on({ TicketAssigned })
     .do(async function assigned({ stream, data }) {
@@ -62,7 +62,7 @@ export const TicketProjection = projection("tickets")
           ...other,
         })
         .where(eq(tickets.id, stream))
-        .then(() => console.log(`${stream} => assigned`));
+        .then(() => log().info(`${stream} => assigned`));
     })
   .on({ TicketEscalated })
     .do(async function escalated({ stream, data }) {
@@ -70,7 +70,7 @@ export const TicketProjection = projection("tickets")
         .update(tickets)
         .set({ escalationId: data.requestId })
         .where(eq(tickets.id, stream))
-        .then(() => console.log(`${stream} => escalated`));
+        .then(() => log().info(`${stream} => escalated`));
     })
   .on({ TicketReassigned })
     .do(async function reassigned({ stream, data }) {
@@ -83,6 +83,6 @@ export const TicketProjection = projection("tickets")
           ...other,
         })
         .where(eq(tickets.id, stream))
-        .then(() => console.log(`${stream} => reassigned`));
+        .then(() => log().info(`${stream} => reassigned`));
     })
   .build();

--- a/packages/wolfdesk/test/tickets.spec.ts
+++ b/packages/wolfdesk/test/tickets.spec.ts
@@ -70,7 +70,7 @@ describe("tickets", () => {
     expect(ticket?.escalateAfter).toBeDefined();
     expect(ticket?.reassignAfter).toBeDefined();
     // just to check projection while preparing test
-    console.table(ticket);
+    // console.table(ticket); // uncomment to inspect projection state
   });
 
   describe("automations", () => {
@@ -135,7 +135,7 @@ describe("tickets", () => {
       expect(drained.acked.length).toBeGreaterThan(0);
 
       let ticket = await findTicket(t.stream);
-      console.table(ticket);
+      // console.table(ticket); // uncomment to inspect projection state
       expect(ticket?.resolvedById).toBeDefined();
       expect(ticket?.closeAfter).toBe(now.getTime());
 


### PR DESCRIPTION
## Summary

Second slice of the root-folder review (after #638 bugs). Three themes:

### Performance
- **Drain `fetched` lookup is now O(1)** (`act.ts`). The per-lease `fetched.find(f => f.stream === lease.stream)` was O(L²) in the worst case (L leases × F fetched entries, typically equal). Index `fetched` into a `Map<stream, {fetch, payloads}>` once after `fetch()` returns; the same loop folds in the previously-separate `payloadsMap`.
- **Scoped IAct methods pre-bound on the Act instance**. `handle()` was rebinding `do/load/query/query_array` on every call — 4 `.bind()` per leased stream per drain. Move them to class fields. Only the `do` closure (which captures the triggering event for `reactingTo` auto-inject) is built per payload.
- **Static reaction targets deduplicated at build time**. Multiple reactions on different events that route to the same static target previously pushed N duplicate entries into `_static_targets`. Subscribe is idempotent so it was harmless, but cold-start did duplicate work. Key by `(target, source)` and keep first-seen.
- **`config()` memoizes its result**. It was running Zod parse on every call despite frozen inputs. Lazy-on-first-call (the `utils.ts ↔ config.ts` cycle prevents eager module-load validation).
- **Task #11 (`close()` max-version scan via `query_streams`) deferred to #639**. The existing N parallel `query()` calls are correctness-correct and the proposal in the original task description rests on a misread of `query_streams` (returns subscription positions, not stream-event positions). The right fix is a new `Store.query_heads(streams)` primitive — see issue #639 for the spec.

### Trace redesign
- Drop emoji prefixes (🔵🔴🟢🟠 `>>`).
- Pretty mode: event-sourcing traces render only the colored target body — color carries the operation/phase. Drain pipeline keeps a colored `>> caption` marker so the channel is easy to spot in mixed log streams.
- Plain mode: every line gets a textual prefix (`caption: body` for ES, `>> caption {data}` for drain) — no ANSI codes leak into JSON.
- Captions are past-tense on exits (`committed`, `claimed`, `fetched`, `acked`, `blocked`, `correlated`) and present-form on entries / single-phase ops (`action`, `load`, `snap`).
- 256-color codes (sky blue, true orange, emerald, magenta) instead of the muddy 16-color palette. Drain ops collapse onto one muted gray.

### Test-noise cleanup
- `chore(act)`: test-default `logLevel` from `"error"` to `"fatal"`. Tests that asserted on log output via `vi.spyOn(log(), "error"|"warn")` still work — the spy wraps noop and captures call history.
- Adapter registration `[act] +/-` lines route through `log().info` instead of raw `console.log`, so they respect log level (silent in tests).
- Stray developer-debug `console.log`s removed from `act.spec.ts` and `wolfdesk-broken.spec.ts`.
- `wolfdesk` projection `console.log` calls switched to `log().info` (matches the framework pattern + silent in tests, visible in `LOG_LEVEL=trace` dev runs).

## Verification
- `pnpm test`: all 895 tests pass; the 28 skipped are act-pg tests requiring a local Postgres instance.
- Lint clean.
- Manual check: `LOG_LEVEL=trace pnpm dev:calculator` renders the new colored captions correctly.

## Test plan
- [x] `pnpm -F @rotorsoft/act test` (full suite green)
- [x] Lint clean on every changed file
- [x] Verified colored trace output against a running calculator demo
- [ ] CI green (PG tests need the docker-compose up for full coverage)

## Notes for reviewer
- Issue #639 tracks the `query_heads` primitive proposal — that's the proper fix for `close()`'s max-version scan and several other places (inspector dashboards, stream-health monitoring, GDPR tooling). Out of scope here.
- Refactor work continues on `refactor/root-refactors`: collapse `handle`/`handleBatch` duplication, extract drain cycle, shared `mergeEventRegister`, builder reinstantiation cleanup, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)