### PR TITLE
fix(act): populate cache on load() so read-heavy paths are warm

### DIFF
--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -195,6 +195,24 @@ export async function load<
     }
   );
 
+  // Populate the cache when this load actually processed events. Without
+  // this, read-heavy paths (UI loops calling load() many times between
+  // commits) miss the cache forever — only action() would ever warm it.
+  // No race-protection re-check needed: the cache is a state checkpoint
+  // at (version, event_id), and any subsequent load queries past
+  // event_id, picks up missed events, and replays — so an "older" cache
+  // write from a concurrent slower load is self-correcting on next access.
+  // Time-travel loads bypass cache entirely and skip this too.
+  if (replayed > 0 && !timeTravel && event) {
+    await cache().set(stream, {
+      state,
+      version,
+      event_id: event.id,
+      patches,
+      snaps,
+    });
+  }
+
   return { event, state, version, patches, snaps, cache_hit, replayed };
 }
 

--- a/libs/act/test/property/cache-coherence.property.spec.ts
+++ b/libs/act/test/property/cache-coherence.property.spec.ts
@@ -100,6 +100,25 @@ describe("property: cache/store coherence", () => {
     expect(after.state).toEqual(before.state); // store is unchanged
   });
 
+  test.prop([fc.array(incArb, { minLength: 1, maxLength: 15 })], {
+    numRuns: 50,
+  })(
+    "load() populates the cache — subsequent read on same stream is a hit",
+    async (ops) => {
+      const { stream, by } = ops[0];
+      await action(Counter, "inc", target(stream), { by });
+      // Clear cache so the first load is a miss; that miss should warm
+      // the cache so the second load is a hit.
+      await cache().clear();
+      const first = await load(Counter, stream);
+      expect(first.cache_hit).toBe(false);
+      const second = await load(Counter, stream);
+      expect(second.cache_hit).toBe(true);
+      expect(second.state).toEqual(first.state);
+      expect(second.version).toBe(first.version);
+    }
+  );
+
   test.prop([fc.array(incArb, { minLength: 0, maxLength: 25 })], {
     numRuns: 50,
   })("version equals the head event's version", async (ops) => {


### PR DESCRIPTION
## Summary

Reported in the field: every `load()` showed `cache: miss` in the trace, even for back-to-back loads of the same stream. Reproducer from a real user app:

\`\`\`
[server] 17:27:23.976 TRACE book-2026 miss v=6 replayed=7 snaps=0 patches=7
[server] 17:27:23.984 TRACE settings miss v=0 replayed=1 snaps=0 patches=1
[server] 17:27:23.990 TRACE book-2026 miss v=6 replayed=7 snaps=0 patches=7   ← same stream, 14ms later
\`\`\`

## Root cause

`load()` read the cache (\`cache().get(stream)\`) but never wrote to it. Only \`action()\` warmed the cache after a successful commit. For read-heavy paths — UI loops calling \`load()\` many times between commits — the cache was permanently cold. The recently-shipped \`cache_hit\` field on \`Snapshot\` was almost always \`false\` outside of action chains, which is misleading and not what users expect.

## Fix

At the end of \`load()\`, when events were actually processed (\`replayed > 0\`), write a fresh cache checkpoint:

\`\`\`ts
if (replayed > 0 && !timeTravel && event) {
  await cache().set(stream, { state, version, event_id: event.id, patches, snaps });
}
\`\`\`

No race-protection re-check needed. Events are immutable, and the cache holds a \`(state, version, event_id)\` checkpoint. If a slower load races with \`action()\` and writes an "older" entry, the next load reads that entry, queries past its \`event_id\`, picks up missed events, and refreshes — self-correcting on next access.

Time-travel loads (\`asOf\`) still bypass the cache. Loads that processed zero events past the cached \`event_id\` skip the write (no new info to absorb).

## Test

One property test added to \`cache-coherence.property.spec.ts\`:

\`\`\`
load() populates the cache — subsequent read on same stream is a hit
\`\`\`

## Verification

- [x] 972 tests pass (was 971)
- [x] 100% coverage maintained on every metric
- [x] Existing cache-coherence properties still hold (\`load()\` returns same state as fresh-load post-clear; \`ConcurrencyError\` invalidates cache)
- [ ] CI green on push

## What this changes for users

- After a cold \`load()\`, the cache is warmed for that stream — subsequent loads are hits.
- The trace breadcrumb \`cache: hit/miss\` now reflects what users intuitively expect.
- For read-heavy apps (UIs calling \`load\` repeatedly between commits), this is the difference between every-load-misses and almost-every-load-hits.

## What this does NOT change

- \`action()\` cache writes (unchanged — still write-through after commit)
- Cache invalidation on \`ConcurrencyError\` (unchanged)
- Cache adapter contracts (\`Cache.set/get/invalidate/clear\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)