### PR TITLE
docs: contributor-facing architecture pages + libraries-table reorg

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Act is an event sourcing + CQRS + Actor Model framework for TypeScript. The core philosophy: any system distills into **Actions → {State} ← Reactions**. This monorepo contains the core framework libraries and example applications demonstrating various complexity levels.
+Act is an event sourcing + CQRS framework for TypeScript, built around DDD aggregates and reaction-driven workflows. The core philosophy: any system distills into **Actions → {State} ← Reactions**. This monorepo contains the core framework libraries and example applications demonstrating various complexity levels.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -10,40 +10,23 @@ The complexity of modern software design often arises from over-engineering abst
 
 ## Libraries
 
-### [@rotorsoft/act](https://github.com/rotorsoft/act-root/tree/master/libs/act)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act.svg)](https://www.npmjs.com/package/@rotorsoft/act)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act.svg)](https://www.npmjs.com/package/@rotorsoft/act)
+### Core
 
-### [@rotorsoft/act-pg](https://github.com/rotorsoft/act-root/tree/master/libs/act-pg)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg)
+| Package | Description |
+|---|---|
+| **[`@rotorsoft/act`](https://github.com/rotorsoft/act-root/tree/master/libs/act)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act.svg)](https://www.npmjs.com/package/@rotorsoft/act) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act.svg)](https://www.npmjs.com/package/@rotorsoft/act) | The framework. State, actions, reactions, slices, projections — Zod-typed end to end. |
+| **[`@rotorsoft/act-pg`](https://github.com/rotorsoft/act-root/tree/master/libs/act-pg)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg) | PostgreSQL store. Production-ready, atomic stream claiming, snapshots, connection pooling. |
+| **[`@rotorsoft/act-sqlite`](https://github.com/rotorsoft/act-root/tree/master/libs/act-sqlite)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite) | libSQL store for embedded or single-node deployments. |
+| **[`@rotorsoft/act-sse`](https://github.com/rotorsoft/act-root/tree/master/libs/act-sse)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-sse.svg)](https://www.npmjs.com/package/@rotorsoft/act-sse) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sse.svg)](https://www.npmjs.com/package/@rotorsoft/act-sse) | Server-Sent Events for incremental state broadcast — live UIs without polling. |
 
-### [@rotorsoft/act-sqlite](https://github.com/rotorsoft/act-root/tree/master/libs/act-sqlite)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
+### Supporting libraries & tools
 
-### [@rotorsoft/act-pino](https://github.com/rotorsoft/act-root/tree/master/libs/act-pino)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-pino.svg)](https://www.npmjs.com/package/@rotorsoft/act-pino)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pino.svg)](https://www.npmjs.com/package/@rotorsoft/act-pino)
-
-### [@rotorsoft/act-patch](https://github.com/rotorsoft/act-root/tree/master/libs/act-patch)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-patch.svg)](https://www.npmjs.com/package/@rotorsoft/act-patch)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-patch.svg)](https://www.npmjs.com/package/@rotorsoft/act-patch)
-
-### [@rotorsoft/act-sse](https://github.com/rotorsoft/act-root/tree/master/libs/act-sse)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-sse.svg)](https://www.npmjs.com/package/@rotorsoft/act-sse)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sse.svg)](https://www.npmjs.com/package/@rotorsoft/act-sse)
-
-### [@rotorsoft/act-diagram](https://github.com/rotorsoft/act-root/tree/master/libs/act-diagram)
-[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-diagram.svg)](https://www.npmjs.com/package/@rotorsoft/act-diagram)
-[![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-diagram.svg)](https://www.npmjs.com/package/@rotorsoft/act-diagram)
-
-## Tools
-
-### [@rotorsoft/act-inspector](https://github.com/rotorsoft/act-root/tree/master/packages/inspector)
-
-Event sourcing observatory — connect to any Act PostgreSQL store and inspect events in real time. Event log, SVG timeline, stream inspector, correlation explorer, and drain processing monitor with live polling.
-
+| Package | Description |
+|---|---|
+| **[`@rotorsoft/act-pino`](https://github.com/rotorsoft/act-root/tree/master/libs/act-pino)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-pino.svg)](https://www.npmjs.com/package/@rotorsoft/act-pino) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pino.svg)](https://www.npmjs.com/package/@rotorsoft/act-pino) | Pino-based logger adapter for production deployments that want pino's ecosystem. |
+| **[`@rotorsoft/act-patch`](https://github.com/rotorsoft/act-root/tree/master/libs/act-patch)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-patch.svg)](https://www.npmjs.com/package/@rotorsoft/act-patch) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-patch.svg)](https://www.npmjs.com/package/@rotorsoft/act-patch) | Immutable deep-merge patch utility used internally by reducers. |
+| **[`@rotorsoft/act-diagram`](https://github.com/rotorsoft/act-root/tree/master/libs/act-diagram)**<br>[![NPM Version](https://img.shields.io/npm/v/@rotorsoft/act-diagram.svg)](https://www.npmjs.com/package/@rotorsoft/act-diagram) [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-diagram.svg)](https://www.npmjs.com/package/@rotorsoft/act-diagram) | SVG diagram generator — visualize states, slices, and reactions from the registry. |
+| **[`@rotorsoft/act-inspector`](https://github.com/rotorsoft/act-root/tree/master/packages/inspector)** | Event sourcing observatory — connect to any Act PostgreSQL store and inspect events in real time. Event log, SVG timeline, stream inspector, correlation explorer, drain monitor with live polling. |
 
 ---
 
@@ -268,6 +251,7 @@ Any spec format works: event modeling diagrams, event storming boards, JSON conf
 
 - [API Reference](https://rotorsoft.github.io/act-root/docs/api/) — typedoc-generated, refreshed on every push to `master`
 - [Concepts & Guides](https://rotorsoft.github.io/act-root/docs/intro) — domain modeling, state management, error handling, real-time
+- [Architecture](./docs/architecture/) — contributor-facing pages on concurrency, cache/snapshots, correlation+drain, close-cycle, schema evolution, extension points
 - [Performance & Benchmarks](./libs/act/PERFORMANCE.md) — throughput numbers per store, CI regression guard, optimization history
 - [Philosophy](./docs/PHILOSOPHY.md) — Actor Model lineage, integration patterns, why this shape
 - [The Book](https://payhip.com/b/7ezLy) — Event Sourcing / CQRS / DDD applied end-to-end through a multiplayer Risk game

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Any system distills into three things:
 
 Act takes those three primitives seriously: Zod schemas as the source of truth, immutable events as the audit trail, and a built-in pipeline that turns reactions into observable workflows.
 
-→ For the why-this-shape rationale (Actor Model lineage, integration patterns, the emergent-complexity argument), see [docs/PHILOSOPHY.md](./docs/PHILOSOPHY.md).
+→ For the why-this-shape rationale (DDD / Event Sourcing / CQRS lineage, integration patterns, the emergent-complexity argument), see [docs/PHILOSOPHY.md](./docs/PHILOSOPHY.md).
 
 ## Design Decisions
 
@@ -253,7 +253,7 @@ Any spec format works: event modeling diagrams, event storming boards, JSON conf
 - [Concepts & Guides](https://rotorsoft.github.io/act-root/docs/intro) — domain modeling, state management, error handling, real-time
 - [Architecture](./docs/architecture/) — contributor-facing pages on concurrency, cache/snapshots, correlation+drain, close-cycle, schema evolution, extension points
 - [Performance & Benchmarks](./libs/act/PERFORMANCE.md) — throughput numbers per store, CI regression guard, optimization history
-- [Philosophy](./docs/PHILOSOPHY.md) — Actor Model lineage, integration patterns, why this shape
+- [Philosophy](./docs/PHILOSOPHY.md) — DDD / Event Sourcing / CQRS lineage, integration patterns, why this shape
 - [The Book](https://payhip.com/b/7ezLy) — Event Sourcing / CQRS / DDD applied end-to-end through a multiplayer Risk game
 - [Examples](#examples) — calculator, WolfDesk ticketing, tRPC integration
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -4,11 +4,15 @@ The why-this-shape rationale for `@rotorsoft/act`: where the framework's three p
 
 For day-to-day API and configuration, see the project [README](../README.md). For technical decisions and trade-offs, see the [Design Decisions](../README.md#design-decisions) section.
 
-## Timeless Ideas, Modern Context
+## Where this comes from
 
-In the earliest days of computing, the "Actor Model" offered a simple yet powerful mental framework: entities with their own state, processing messages asynchronously. Similarly, event-driven programming showed how reactions to changes could create more dynamic and decoupled systems. Could we take inspiration from the simplicity of the "Actor Model" while integrating modern concepts like "Event Sourcing" and "CQRS" to form the backbone of consistency and integration for the next generation of autonomous systems?
+Act draws from three traditions:
 
-At its core, any software system is a collection of "consistent states" interacting with one another. Each instance has its unique identity, clear boundaries serving as the authority over its data, and a well-defined lifecycle. Examples include a user profile, an order, or an inventory item. While we often call these "entities", "aggregates", or "domain objects", at their essence, they are all distinct islands of state.
+- **DDD aggregates** (Eric Evans, 2003) — the "consistent state with a boundary" idea. Each `state(...)` defines an aggregate: an entity with its own identity, the authority over its data, and a well-defined lifecycle. User profiles, orders, inventory items — distinct islands of state with clear edges.
+- **Event Sourcing** (Greg Young, mid-2000s) — events as the source of truth. State is derived by replaying an immutable event log; the log is the audit trail; replay is what makes time-travel and projection rebuild possible.
+- **CQRS** (also Young) — separate the write path (actions, invariants, commits) from the read path (loads, projections, queries). The framework's `action()` and `load()` are the two halves.
+
+Reactions sit on top of these as event-driven dispatch — close in shape to publish/subscribe, with the drain pipeline as the delivery mechanism.
 
 ## Actions and Reactions: The Lifeblood of a System
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,31 @@
+# Architecture
+
+Contributor-facing notes on how the framework's subsystems work together. The public README and JSDoc cover the user-facing surface; this directory covers the parts you only need when working *on* the framework.
+
+Each page targets one subsystem, focuses on the *why* behind the shape (not just the *what* — the source has that), and includes a small ASCII diagram where it helps.
+
+## Pages
+
+| Page | Topic |
+|---|---|
+| [`concurrency-model.md`](./concurrency-model.md) | Optimistic concurrency (`commit` + `expectedVersion`) vs stream leasing (`claim` + `FOR UPDATE SKIP LOCKED`); how they don't interact |
+| [`cache-and-snapshots.md`](./cache-and-snapshots.md) | Two checkpoint layers (in-memory cache + persisted snapshots), how `load()` reads both, time-travel bypass |
+| [`correlation-and-drain.md`](./correlation-and-drain.md) | Static vs dynamic resolvers; `_armed` skip-flag; dual-frontier drain; settle's debounced catch-up loop |
+| [`close-cycle.md`](./close-cycle.md) | Six phases of close-the-books; failure semantics at each phase; idempotency guarantees |
+| [`event-schema-evolution.md`](./event-schema-evolution.md) | Versioned event names; non-breaking-via-defaults vs breaking-via-new-name; why upcasting was rejected |
+| [`extension-points.md`](./extension-points.md) | `Store`, `Cache`, `Logger` contracts; invariants adapters must hold; concrete implementations in this repo |
+
+## Audience
+
+A new contributor onto the framework. After reading these six pages plus the relevant source modules, you should be able to:
+
+- Reason about concurrency without confusing optimistic concurrency and lease exclusivity
+- Trace a `load()` call through cache and snapshot layers and explain what each output field means
+- Walk a reaction from commit → correlate → drain → handler invocation
+- Predict what `app.close()` does at every failure point
+- Add a new event version without breaking existing readers
+- Implement a new `Store`/`Cache`/`Logger` adapter that the framework will trust
+
+## Where to look in source
+
+Every page links to the relevant source files at the bottom. The internal modules are under `libs/act/src/internal/`; the adapters are under `libs/act/src/adapters/` and the lib-specific packages (`libs/act-pg/`, `libs/act-sqlite/`, `libs/act-pino/`).

--- a/docs/architecture/cache-and-snapshots.md
+++ b/docs/architecture/cache-and-snapshots.md
@@ -1,0 +1,179 @@
+# Cache and snapshots
+
+Two distinct checkpoint mechanisms at different layers. Both exist to keep `load()` fast on long streams; they fail in different ways and recover from each other.
+
+## The two checkpoints
+
+| | **Cache** | **Snapshot** |
+|---|---|---|
+| **Where it lives** | In-memory port (`InMemoryCache` LRU by default; pluggable to Redis) | A `__snapshot__` event committed to the store |
+| **Lifetime** | Process lifetime; lost on restart, eviction | Persists in the event log forever |
+| **Created by** | `action()` after each commit; `load()` after each non-empty replay | `me.snap?.(snapshot)` callback after a commit |
+| **Read by** | Every `load()` (cache-first) | `load()` on cold start or cache miss |
+| **Granularity** | Latest checkpoint per stream | Multiple checkpoints per stream, anchored to specific event IDs |
+| **Invalidated by** | `ConcurrencyError`, manual `cache().invalidate()` | Never — events are immutable |
+
+## Why two layers
+
+A long stream needs to be replayed *somewhere*. The cheapest place is RAM (cache), but RAM is volatile. The next-cheapest is disk-via-DB (snapshot), but reading even one snapshot still costs a round trip. The framework uses both: cache catches the warm case for zero round-trips; snapshots catch the cold-start case to bound replay cost.
+
+## Read path — `load()`
+
+```
+                          load(state, stream, asOf?)
+                                  │
+              ┌───────────────────┴────────────────────┐
+              │                                         │
+        is asOf set?                              cache.get(stream)
+        (time-travel)                                  │
+              │                                ┌───── hit ──┐
+              ▼                                │            │
+        skip cache                       cached.state    cache miss
+        with_snaps:true                  cached.event_id     │
+        scan from asOf                       │            init state
+              │                              │            with_snaps:true
+              │                       query after        scan from start
+              │                       cached.event_id   (snap if any)
+              │                              │               │
+              ▼                              ▼               ▼
+        replay events ────────►  replay events ────► replay events
+              │                              │               │
+              └─────────────────────► snapshot ◄──────────────┘
+                                          │
+                              (write cache if replayed > 0
+                               and not time-travel)
+```
+
+Three distinct entry conditions, three different store-query shapes:
+
+- **Cache hit**: query `after: cached.event_id` (no `with_snaps`). Skip everything older — the cached state is correct as-of the cached event ID.
+- **Cache miss**: query from start with `with_snaps: true`. The query stream will surface any `__snapshot__` events; the reducer absorbs the snapshot's state and resets `patches` to 0.
+- **Time-travel** (`asOf` set): bypass cache entirely, query from start with snapshots, plus the `asOf` filter (`before`, `created_before`, `created_after`, `limit`). Time-travel reads must reflect history, not current cached state.
+
+After the loop, if any events were processed (`replayed > 0`) and we're not in time-travel mode, the cache is updated to the new checkpoint. This is what makes read-heavy paths warm — without it, repeated `load()`s on the same stream would all be misses.
+
+### Why no race protection on the cache write
+
+Two `load()`s on the same stream can race. If both write to cache, a slower load could overwrite a fresher entry with a stale checkpoint. Doesn't matter:
+
+```
+1. Cache has v=10 (from some earlier action)
+2. Slow load A starts; reads cache; queries past v=10 — finds nothing new
+3. Concurrent commit happens; action writes cache.set(v=11)
+4. Slow load A finishes (its view is v=10); writes cache.set(v=10)
+5. Cache now has v=10 (stale by one event)
+6. Next load B reads cache (v=10); queries after v=10 — finds the v=11 event
+7. Replays it; writes cache.set(v=11)
+8. Cache is correct.
+```
+
+Step 7 is the key: every load that processes events past the cached point updates the cache. Stale entries are self-correcting on the next access. No version-comparison needed at write time.
+
+## Snapshot creation
+
+Snapshots are created by user code via the `me.snap?` predicate at the end of every `action()`:
+
+```ts
+const last = snapshots.at(-1)!;
+const snapped = me.snap && me.snap(last);
+// ... cache.set with patches: snapped ? 0 : last.patches
+if (snapped) void snap(last);  // commits a __snapshot__ event, fire-and-forget
+```
+
+The user-supplied predicate decides *when* to snap. Common patterns:
+
+- **By patch count**: `.snap((s) => s.patches >= 50)` — every 50 events since last snap.
+- **By time elapsed**: keep timestamp on state, snap when `Date.now() - state.lastSnapAt > 60_000`.
+- **Never**: omit `.snap()`. Streams with bounded length (single-day TTL, capped by app logic) often don't need snapshots.
+
+The actual write is fire-and-forget — `void snap(last)` doesn't block the action's return. Snapshot failures log via `snap()`'s internal try/catch but don't propagate. The cache is the immediate source of truth; the snapshot is durability for cold start.
+
+## How the two interact on cold start
+
+A fresh process loading a long stream:
+
+```
+1. cache.get(stream) → undefined (process restart, cache empty)
+2. query store from start with with_snaps:true, returning:
+     v=0  (Created)
+     v=10 (__snapshot__, data = state at v=10)
+     v=11 (Updated)
+     ...
+     v=42 (Updated)
+3. As each event arrives in the reducer:
+     v=0:  apply Created reducer; patches=1
+     v=10: SNAP_EVENT detected; state = e.data; snaps++; patches=0
+     v=11: apply Updated reducer; patches=1
+     ...
+     v=42: apply Updated reducer; patches=32
+4. Return snapshot { state, version: 42, patches: 32, snaps: 1 }
+5. Cache updated to v=42 with patches=32, snaps=1
+6. Subsequent load() on this stream: cache hit, query after v=42, no replay
+```
+
+The snapshot at v=10 means we replayed 32 events instead of 42 (the snapshot data replaces the first 11 events worth of reducer work). Snap policy `>= 50` would have kept all 43 events as a single replay — fine for a 43-event stream, painful for a 5,000-event stream.
+
+## Time-travel reads
+
+`load()` accepts an optional `AsOf` parameter:
+
+```ts
+type AsOf = Pick<Query, "before" | "created_before" | "created_after" | "limit">;
+```
+
+When any field is set, the framework treats this as a historical read:
+
+- Cache is bypassed (cached state may include events past the cutoff)
+- Cache write at the end is skipped (don't pollute with a historical view)
+- Query uses `with_snaps: true` so any snapshot before the cutoff serves as a replay anchor
+- Snapshots *after* the cutoff are filtered out by the same `before` / `created_before` predicate
+
+The time-travel path is read-only by design — the framework's mutation API (`action()`) always operates on current state and never accepts `asOf`.
+
+## Observability — what the trace tells you
+
+The `load` trace breadcrumb surfaces what just happened:
+
+```
+load: orders-1 hit v=42 replayed=0 snaps=1 patches=32
+load: orders-1 (as-of before=5000) miss v=4 replayed=11 snaps=0 patches=11
+```
+
+- `hit/miss` — cache lookup outcome
+- `v=` — stream head version after this load
+- `replayed=` — events processed past the cache point. Zero after a warm cache hit; high on cold start
+- `snaps=` — total snapshots taken on this stream (cumulative across all loads)
+- `patches=` — events since last snap (snap-policy accumulator)
+
+A `cache: hit` with `patches=8` is *not* a contradiction. The cache had a checkpoint past 8 events of patches-since-snap. The cache hit means we didn't replay; the patches counter is what `snap()` policies key on for "should I take a snap soon."
+
+## Cache invalidation — narrow contract
+
+The cache is invalidated in only two places:
+
+1. **`ConcurrencyError`** in `action.commit`: the commit failed because the stream advanced past `expectedVersion`. The cached state could be stale.
+2. **`cache().invalidate(stream)`**: explicit caller request. Used by `app.close()` to drop tombstoned streams.
+
+Anything else — handler errors, validation errors, schema failures — leaves the cache untouched. The cache reflects committed state; if no commit happened, no invalidation needed.
+
+## Snapshot evolution — events first, snapshots second
+
+A subtle gotcha: when a state's reducer changes (new field, renamed field), older snapshots in the store contain old-shape state. The framework doesn't migrate snapshots.
+
+The supported pattern:
+
+1. Add the new field with a default in the reducer's output
+2. New events get the field; existing events still produce the old shape
+3. New snapshots reflect the new shape
+4. Old snapshots produce old-shape state on cold start; the next reducer call adds the new field
+
+This works because reducers are pure functions of state + event. As long as reducers handle missing fields gracefully (or `cache_hit` semantics align), schema evolution is safe. See `event-schema-evolution.md` for the full story on schema versioning.
+
+For a destructive reducer change (renamed field that you can't add as a new optional), the right move is to retire the stream via `app.close({ restart: true })` — that loads current state, commits a fresh `__snapshot__` reflecting the new shape, and tombstones older history.
+
+## Pointers
+
+- `libs/act/src/internal/event-sourcing.ts` — `load()`, `action()`, `snap()` — the only callers of `cache()` in the framework
+- `libs/act/src/adapters/in-memory-cache.ts` — default `Cache` implementation (LRU)
+- `libs/act/src/types/index.ts` — `Cache` interface, `CacheEntry` shape
+- `libs/act/test/property/cache-coherence.property.spec.ts` — invariants the implementation must hold

--- a/docs/architecture/cache-and-snapshots.md
+++ b/docs/architecture/cache-and-snapshots.md
@@ -20,28 +20,28 @@ A long stream needs to be replayed *somewhere*. The cheapest place is RAM (cache
 ## Read path — `load()`
 
 ```
-                          load(state, stream, asOf?)
-                                  │
-              ┌───────────────────┴────────────────────┐
-              │                                         │
-        is asOf set?                              cache.get(stream)
-        (time-travel)                                  │
-              │                                ┌───── hit ──┐
-              ▼                                │            │
-        skip cache                       cached.state    cache miss
-        with_snaps:true                  cached.event_id     │
-        scan from asOf                       │            init state
-              │                              │            with_snaps:true
-              │                       query after        scan from start
-              │                       cached.event_id   (snap if any)
-              │                              │               │
-              ▼                              ▼               ▼
-        replay events ────────►  replay events ────► replay events
-              │                              │               │
-              └─────────────────────► snapshot ◄──────────────┘
-                                          │
-                              (write cache if replayed > 0
-                               and not time-travel)
+                  load(state, stream, asOf?)
+                                │
+              ┌─────────────────┴─────────────────┐
+              │                                   │
+          asOf set?                        cache.get(stream)
+        (time-travel)                             │
+              │                       ┌───────────┴───────────┐
+              │                       │                       │
+              │                      hit                     miss
+              ▼                       ▼                       ▼
+          skip cache              cached.state            init state
+        with_snaps:true          cached.event_id         with_snaps:true
+        scan from asOf           query after             scan from start
+              │                  cached.event_id         (snap if any)
+              │                       │                       │
+              └───────────────────────┼───────────────────────┘
+                                      ▼
+                                replay events
+                                      │
+                                      ▼
+                        (write cache if replayed > 0
+                         and not time-travel)
 ```
 
 Three distinct entry conditions, three different store-query shapes:

--- a/docs/architecture/close-cycle.md
+++ b/docs/architecture/close-cycle.md
@@ -23,29 +23,29 @@ The operation has six phases, each gating the next. Failures at each phase have 
                       │
                       ▼
           ┌───────────────────────────┐
-          │ Phase 2: Partition by safety │ Skip any stream whose subscribed reactions are still
-          │   query_streams (read-only)  │ behind the head. Those go into `skipped`.
+          │ Phase 2: Safety partition │ Skip any stream whose subscribed reactions are still
+          │   query_streams           │ behind the head. Those go into `skipped`.
           └───────────┬───────────────┘
                       │
                       ▼
           ┌───────────────────────────┐
-          │ Phase 3: Guard with        │ Commit `__tombstone__` with expectedVersion. If the
-          │   tombstones (parallel)    │ stream advanced past our scan (concurrent writer),
-          │                            │ we get ConcurrencyError → that stream goes to skipped.
+          │ Phase 3: Guard with       │ Commit `__tombstone__` with expectedVersion. If the
+          │   tombstones (parallel)   │ stream advanced past our scan (concurrent writer),
+          │                           │ we get ConcurrencyError → that stream goes to skipped.
           └───────────┬───────────────┘
                       │
                       ▼
           ┌───────────────────────────┐
-          │ Phase 4: Load restart      │ For targets with `restart: true`, load the final state
-          │   seeds (parallel)         │ NOW, while the stream is guarded. The owning state is
-          │                            │ derived from the last event's name → registered state.
+          │ Phase 4: Load restart     │ For targets with `restart: true`, load the final state
+          │   seeds (parallel)        │ NOW, while the stream is guarded. The owning state is
+          │                           │ derived from the last event's name → registered state.
           └───────────┬───────────────┘
                       │
                       ▼
           ┌───────────────────────────┐
-          │ Phase 5: Run archive       │ User callback per stream. Sequential: callbacks may
-          │   callbacks (sequential)   │ share resources (S3 client, etc). A failure here
-          │                            │ propagates to the caller; streams remain guarded.
+          │ Phase 5: Run archive      │ User callback per stream. Sequential: callbacks may
+          │   callbacks (sequential)  │ share resources (S3 client, etc). A failure here
+          │                           │ propagates to the caller; streams remain guarded.
           └───────────┬───────────────┘
                       │
                       ▼

--- a/docs/architecture/close-cycle.md
+++ b/docs/architecture/close-cycle.md
@@ -1,0 +1,180 @@
+# Close cycle
+
+`app.close(targets)` archives, tombstones, and truncates streams from the operational store. The event-sourcing equivalent of "closing the books" in accounting: summarize the period, archive the detail, optionally restart with a fresh opening balance.
+
+The operation has six phases, each gating the next. Failures at each phase have well-defined recovery characteristics — the goal is that any partial-failure state is *safe* (no data loss, no inconsistent state, retryable).
+
+## Phase diagram
+
+```
+            close(targets)
+                  │
+                  ▼
+          ┌───────────────────────────┐
+          │ Phase 0: Correlate        │  Discover dynamic reaction targets so the safety check
+          │   correlate(limit:1000)   │  in Phase 2 can see them.
+          └───────────┬───────────────┘
+                      │
+                      ▼
+          ┌───────────────────────────┐
+          │ Phase 1: Scan stream heads│  For each target, find the latest non-tombstone event.
+          │   query backward, limit:1 │  Streams with no events are skipped here.
+          └───────────┬───────────────┘
+                      │
+                      ▼
+          ┌───────────────────────────┐
+          │ Phase 2: Partition by safety │ Skip any stream whose subscribed reactions are still
+          │   query_streams (read-only)  │ behind the head. Those go into `skipped`.
+          └───────────┬───────────────┘
+                      │
+                      ▼
+          ┌───────────────────────────┐
+          │ Phase 3: Guard with        │ Commit `__tombstone__` with expectedVersion. If the
+          │   tombstones (parallel)    │ stream advanced past our scan (concurrent writer),
+          │                            │ we get ConcurrencyError → that stream goes to skipped.
+          └───────────┬───────────────┘
+                      │
+                      ▼
+          ┌───────────────────────────┐
+          │ Phase 4: Load restart      │ For targets with `restart: true`, load the final state
+          │   seeds (parallel)         │ NOW, while the stream is guarded. The owning state is
+          │                            │ derived from the last event's name → registered state.
+          └───────────┬───────────────┘
+                      │
+                      ▼
+          ┌───────────────────────────┐
+          │ Phase 5: Run archive       │ User callback per stream. Sequential: callbacks may
+          │   callbacks (sequential)   │ share resources (S3 client, etc). A failure here
+          │                            │ propagates to the caller; streams remain guarded.
+          └───────────┬───────────────┘
+                      │
+                      ▼
+          ┌───────────────────────────┐
+          │ Phase 6: Truncate + seed  │ Atomic per-store transaction: delete every event for
+          │   (atomic per stream)     │ the stream, insert a single seed (`__snapshot__` for
+          │                           │ restart, `__tombstone__` for tombstone-only).
+          └───────────┬───────────────┘
+                      │
+                      ▼
+                 Cache update
+                      │
+                      ▼
+                 emit("closed", result)
+```
+
+## Phase-by-phase failure semantics
+
+The framework's invariant: **at every stable state during close, the stream is in a coherent, retryable shape.** No matter where you crash, re-running close on the same target produces the same final result (idempotent) or skips it cleanly (already done).
+
+### Phase 0 — Correlate
+
+If `app.close()` is called and dynamic-resolver streams haven't been correlated yet, the safety check in Phase 2 would miss them. So we explicitly correlate first with a generous limit.
+
+- **If correlate fails**: close() throws to caller. Nothing has been written. Idempotent retry.
+
+### Phase 1 — Scan stream heads
+
+For each target, query the store backward, filter out tombstones in the callback, take the first non-tombstone event. This gives us `(maxId, version, lastEventName)` per stream.
+
+The `with_snaps` flag is *not* set, so snapshot events are filtered server-side. The query returns the latest *domain* event.
+
+- **Stream has no domain events**: not included in the result map. Phase 2's `safe` list will exclude it. Result: stream untouched.
+- **Stream has only a tombstone**: same outcome as no domain events — the tombstone is filtered, no result entry, skipped.
+- **Query fails**: close() throws to caller. Streams are untouched.
+
+### Phase 2 — Partition by safety
+
+For apps with reactions, we can't tombstone a stream that still has pending reactions in flight — those reactions would never run after the truncate.
+
+Optimization: when `reactiveEvents.size === 0`, skip the safety probe entirely (every stream is safe). Most close operations on apps without reactions take this path.
+
+Otherwise, walk `query_streams` (read-only — no leasing, no state mutation). For each subscribed reader's position, mark any of our targets that still have unprocessed events behind that reader.
+
+- **Reader is behind**: target goes to `skipped`. Callable code can retry close after the reader catches up (e.g., after `await app.settle()`).
+- **Reader is at or past head**: target is `safe`.
+- **Probe fails**: close() throws. Nothing committed.
+
+### Phase 3 — Guard with tombstones
+
+For each safe stream, commit a `__tombstone__` event with `expectedVersion = lastVersion` from Phase 1. The tombstone serves two purposes:
+
+1. **Concurrency check**: if another writer committed between Phase 1's scan and now, our `expectedVersion` won't match and we get `ConcurrencyError`. That stream moves to `skipped`.
+2. **Block subsequent commits**: `action()` checks the head event before committing. If the head is `__tombstone__`, `action()` throws `StreamClosedError`. No new events can land on this stream from this point forward.
+
+All guards run in parallel (`Promise.all`). Each result is independently bucketed: `guarded` (tombstone landed) or `skipped` (concurrency error).
+
+- **Guard fails for some streams**: those go to `skipped`. The remaining guards continue.
+- **No streams guarded**: close returns early with `{ truncated: empty, skipped }`. Other phases don't run.
+
+After this phase, the framework's invariant is: **every stream in `guarded` has a tombstone at head and no concurrent writer can land an event on it.**
+
+### Phase 4 — Load restart seeds
+
+For each guarded stream where `target.restart === true`, load the final state.
+
+This phase runs *after* the guard, not before, by design. Loading state requires reading events. If we loaded before the guard, a concurrent commit could change the stream while we're reading; the seeded snapshot would be stale.
+
+After the guard, no concurrent writer can interfere. The load reflects the exact state at the moment the stream was guarded.
+
+The "owning state" for each stream is found via `eventToState.get(lastEventName)`. The build-classify pass at Act construction builds this map: event-name → state-definition that emits it. The duplicate-event guard in `merge.ts` ensures one event maps to at most one state.
+
+- **No state owns the last event** (deleted state, schema versioning gone wrong): we can't seed. The stream still gets tombstoned (no `restart: true` semantics), but a warning is logged. This is a degraded state — cold path.
+- **Load fails**: propagates to caller. Streams remain guarded but not truncated. Retryable.
+
+### Phase 5 — Run archive callbacks
+
+Sequential. Each `target.archive?` callback is awaited in turn.
+
+```ts
+for (const stream of guarded) {
+  const archiveFn = targetMap.get(stream)?.archive;
+  if (archiveFn) await archiveFn();
+}
+```
+
+Why sequential: archive callbacks frequently share connections (S3 client, etc). Parallel parallel writes can exhaust connection pools and produce nondeterministic failure modes. A user who *wants* parallelism can fan out in their own callback.
+
+- **Callback throws**: propagates. Subsequent callbacks don't run. Streams remain *guarded but not truncated*. The caller can retry close — Phase 1's scan will find the existing tombstone, Phase 3 will detect the stream is already at the tombstone version (no-op guard), Phase 4 will reload (idempotent), Phase 5 will run archive *again*. Archive callbacks must be idempotent, or the user must tolerate retries.
+- **Callback succeeds for some, fails for one**: same — subsequent streams don't truncate. Retryable.
+
+After this phase: archive completed (or partially completed); streams still tombstoned but not truncated. Safe state.
+
+### Phase 6 — Truncate + seed
+
+Atomic per-stream transaction. For each guarded stream:
+
+```sql
+BEGIN
+  DELETE FROM events WHERE stream = ?
+  DELETE FROM streams WHERE stream = ?
+  INSERT INTO events (...)  -- the seed: __snapshot__ if restart, __tombstone__ otherwise
+COMMIT
+```
+
+The seed is not optional. After truncate, the events table for this stream has exactly one row — either a snapshot (allowing future actions to start fresh from it) or a tombstone (closing the stream permanently).
+
+The result map contains `{ deleted: count, committed: seed_event }` per stream. The cache is then updated:
+
+- **Restart**: `cache.set(stream, { state: seed, version: 0, event_id: seed.id, patches: 0, snaps: 1 })`. Future loads serve the seed state from cache.
+- **Tombstone**: `cache.invalidate(stream)`. The cache is cleared; future loads will see only the tombstone and `action()` will throw `StreamClosedError`.
+
+- **Truncate fails for one stream**: that stream's pre-truncate state is preserved (transaction rolled back). Other streams continue. The failed stream is still safely guarded — retryable.
+
+## Idempotency
+
+Calling `close()` on an already-closed stream is a no-op:
+
+1. Phase 1 scans backward; the head is `__tombstone__` (because it's filtered, the scan returns no result for this stream)
+2. Phase 1's result map doesn't include this stream
+3. Phase 2's `safe` list doesn't include this stream
+4. Result: stream isn't in `truncated`, isn't in `skipped` from a concurrency error — it's just absent
+
+For a stream that's been *restarted* but not tombstoned (one `__snapshot__` event at v=0), close() will find that snapshot in Phase 1 (snapshots aren't filtered like tombstones are), proceed through guard, and tombstone it. The result is a truncate-and-tombstone of the restarted stream.
+
+## Pointers
+
+- `libs/act/src/internal/close-cycle.ts` — phase-by-phase orchestration, `runCloseCycle`
+- `libs/act/src/act.ts` — `Act.close()` — wires correlate + cycle + emit
+- `libs/act/src/types/errors.ts` — `StreamClosedError` thrown by `action()` on tombstoned streams
+- `libs/act/test/close.spec.ts` — happy-path and failure-mode coverage
+- `libs/act/test/property/close.property.spec.ts` — close idempotency under random workloads

--- a/docs/architecture/concurrency-model.md
+++ b/docs/architecture/concurrency-model.md
@@ -1,0 +1,152 @@
+# Concurrency model
+
+Two distinct concurrency primitives, used at different layers for different problems. Conflating them is the most common source of confusion when reading the framework's source.
+
+## The two primitives
+
+| | **Optimistic concurrency** | **Stream leasing** |
+|---|---|---|
+| **Where** | `Store.commit` (writes) | `Store.claim` (reads-for-reactions) |
+| **What it protects** | Stream version integrity | Reaction processing exclusivity |
+| **Mechanism** | `expectedVersion` parameter | `FOR UPDATE SKIP LOCKED` row lock |
+| **Caller's job on conflict** | Reload + retry the action | Nothing — the loser is silently skipped |
+| **Detected by** | `ConcurrencyError` thrown | Empty `claim()` return for that stream |
+
+Same store, same DB, but they don't interact. A stream can have a held reaction lease *and* successful commits at the same time — those are different rows in different operations.
+
+## Optimistic concurrency — the writer's safety net
+
+Action commits are append-only and version-checked. Each event in a stream has a `version` (0-indexed, monotonic per stream). A commit asserts "the current head version is X; append after that."
+
+```
+caller                  framework                   store
+  │  app.do(...)            │                          │
+  │ ─────────────────────► │                          │
+  │                         │  load() → snapshot.event │
+  │                         │  expectedVersion = ev?   │
+  │                         │  reduce → emit events    │
+  │                         │  store.commit(           │
+  │                         │    stream, msgs, meta,   │
+  │                         │    expectedVersion ──────────►   tx BEGIN
+  │                         │  )                       │      SELECT max(version)
+  │                         │                          │      if version != expectedVersion:
+  │                         │                          │          throw ConcurrencyError
+  │                         │                          │      INSERT events
+  │                         │                          │      tx COMMIT
+  │                         │  ◄──────────────────────────── return Committed[]
+  │  ◄─────────────────────  │
+```
+
+If two callers race on the same stream, only one wins. The loser sees `ConcurrencyError` with `expectedVersion` and `lastVersion` (the actual head). Standard pattern is to reload state and retry.
+
+### Two failure modes the framework handles
+
+**Predictable**: caller's `expectedVersion` doesn't match. Framework throws `ConcurrencyError` from the version check.
+
+**Subtle**: both transactions read the same max version, both pass the `expectedVersion` check, both try to INSERT at the same `(stream, version)` pair. The unique index catches the second INSERT — without explicit handling, this surfaces as an adapter-specific error (PG SQLSTATE `23505`), not `ConcurrencyError`. Callers retrying on the framework signal would silently lose the commit.
+
+**Resolution** (in `PostgresStore.commit`): catch the SQLSTATE `23505` from INSERT and re-throw as `ConcurrencyError`. After the catch, both failure modes look the same to the caller, and the retry path is consistent. Documented in `commit.error.spec.ts` and exercised by the `same-stream` scenario in the Postgres stress harness.
+
+### Reactions skip optimistic concurrency by design
+
+Inside `action()`, when `reactingTo` is provided (i.e., the action was triggered by a reaction handler), `expectedVersion` is *not* enforced:
+
+```ts
+// internal/event-sourcing.ts, action()
+reactingTo ? undefined : expected
+```
+
+The reasoning: reactions are inherently asynchronous catch-up. By the time a reaction processes event N, the stream has likely advanced past N. Forcing an `expectedVersion` check would convert ordinary catch-up into spurious retries. Stream leasing already serializes concurrent reactions on the same stream, so the version race doesn't matter.
+
+## Stream leasing — the reader's exclusivity primitive
+
+The drain pipeline polls for streams that have new events past their last-processed watermark, claims them via `FOR UPDATE SKIP LOCKED`, processes their events, then acks (releases the lease and advances the watermark) or blocks (marks the stream failed after exceeding retry budget).
+
+```
+worker A                  store                     worker B
+  │  claim(by="A")             │                          │
+  │ ─────────────────────────► │                          │
+  │                            │  tx BEGIN                │
+  │                            │  SELECT * FROM streams   │
+  │                            │   WHERE leased_until<NOW │
+  │                            │   FOR UPDATE             │
+  │                            │   SKIP LOCKED            │
+  │                            │  UPDATE leased_by='A'    │
+  │                            │  tx COMMIT               │
+  │  ◄────────────────────────  │                          │
+  │  [streams 1, 3, 5]         │                          │
+  │                            │   ◄──────────────────────  claim(by="B")
+  │                            │  tx BEGIN                │
+  │                            │  SELECT ... SKIP LOCKED  │
+  │                            │  → returns 2, 4 (1,3,5   │
+  │                            │   locked by A; skipped)  │
+  │                            │  ────────────────────────►
+  │                            │                          │  [streams 2, 4]
+  │  process events for 1,3,5  │                          │  process events for 2,4
+  │  ack(by="A")               │                          │  ack(by="B")
+  │ ─────────────────────────► │  ◄──────────────────────  │
+```
+
+`SKIP LOCKED` is the key: workers never block each other waiting for a lock. If a stream is held by another worker, the polling worker just gets the next available stream. Zero contention, no thundering herd. The trade-off is no fairness guarantees — a worker can repeatedly pick up the "easier" streams and leave the leased ones to time out — but in practice this is desirable (active workers stay active).
+
+### Lease lifecycle
+
+```
+                   ┌───────────────────────┐
+                   │ leased_by=NULL        │
+                   │ at=last_acked_position │  ← steady state
+                   └─────────┬─────────────┘
+                              │  claim()
+                              ▼
+                   ┌───────────────────────┐
+                   │ leased_by='worker-X'  │
+                   │ leased_until=NOW+lease│
+                   └─────────┬─────────────┘
+                              │
+              ┌──────── ack() ┼ block() ─────┐
+              │               │              │
+              ▼               ▼              ▼
+        leased_by=NULL  leased_by=NULL  blocked=true
+        at=new position at=last position retry_count++
+        retry_count=0   retry_count++
+                              │
+                              │ (if retry_count > maxRetries
+                              │  AND blockOnError)
+                              ▼
+                       set blocked=true
+                       (no further claims)
+```
+
+Three "exits" from a leased state:
+
+- **`ack`** — handler succeeded; advance the watermark to the last processed event ID, clear the lease, reset retry count.
+- **`block`** — handler failed past the retry budget; set `blocked=true`. The stream stays out of `claim()` results until something explicitly unblocks it (e.g., `app.reset()`).
+- **Timeout** — worker died or hung; `leased_until` passes; the next `claim()` from any worker can acquire the stream. Retry count is *not* incremented — the timed-out worker may have processed the events successfully but failed to ack.
+
+### Why a stream stays in `claim()` after a partial handler failure
+
+If a reaction handler throws, the framework `block`s the lease *only if* `retry_count > maxRetries && blockOnError`. Otherwise it just releases without advancing the watermark. The next `claim()` cycle picks the stream up again — same events, fresh handler invocation, retry count incremented. Bounded retries with backoff are configured per-reaction via `ReactionOptions`.
+
+## How the two interact
+
+A common confusion: "If I commit while another worker holds a lease, does my commit fail?"
+
+**No.** Stream leasing locks the row in the `streams` table (which tracks reaction watermarks). Commits write to the `events` table and check the `(stream, version)` index. Different rows, different locks. A commit and a reaction lease can be active on the same stream concurrently.
+
+Real interaction surfaces in the close-the-books flow (`close-cycle.md`), where the close operation must coordinate both: tombstone the stream (write a guard event via `commit`), then verify no leases are held (lease lifecycle).
+
+## Observability
+
+Both primitives surface in the trace breadcrumb stream:
+
+- Optimistic concurrency: `ConcurrencyError` thrown to caller; the framework logs nothing extra (caller decides what to log)
+- Lease lifecycle: `>> claimed`, `>> acked`, `>> blocked` traces from `internal/drain-cycle.ts` decorators
+
+For a stuck stream, query `store.query_streams` directly — it returns the per-stream `at`, `retry`, `blocked`, and `leased_by/leased_until` without taking a lease. The act-inspector tool is built on this primitive.
+
+## Pointers
+
+- `libs/act/src/internal/event-sourcing.ts` — `action()` and the `expectedVersion` check
+- `libs/act-pg/src/PostgresStore.ts` — `commit()` (with the `PG_UNIQUE_VIOLATION` translation), `claim()` (with `FOR UPDATE SKIP LOCKED`)
+- `libs/act/src/internal/drain-cycle.ts` — `runDrainCycle` orchestration and `DrainController` lifecycle
+- `libs/act-pg/test/stress/` — multi-process exercise of both primitives under contention

--- a/docs/architecture/concurrency-model.md
+++ b/docs/architecture/concurrency-model.md
@@ -21,7 +21,7 @@ Action commits are append-only and version-checked. Each event in a stream has a
 ```
 caller                  framework                   store
   │  app.do(...)            │                          │
-  │ ─────────────────────► │                          │
+  │ ──────────────────────► │                          │
   │                         │  load() → snapshot.event │
   │                         │  expectedVersion = ev?   │
   │                         │  reduce → emit events    │
@@ -34,7 +34,7 @@ caller                  framework                   store
   │                         │                          │      INSERT events
   │                         │                          │      tx COMMIT
   │                         │  ◄──────────────────────────── return Committed[]
-  │  ◄─────────────────────  │
+  │  ◄───────────────────── │
 ```
 
 If two callers race on the same stream, only one wins. The loser sees `ConcurrencyError` with `expectedVersion` and `lastVersion` (the actual head). Standard pattern is to reload state and retry.
@@ -73,7 +73,7 @@ worker A                  store                     worker B
   │                            │   SKIP LOCKED            │
   │                            │  UPDATE leased_by='A'    │
   │                            │  tx COMMIT               │
-  │  ◄────────────────────────  │                          │
+  │  ◄──────────────────────── │                          │
   │  [streams 1, 3, 5]         │                          │
   │                            │   ◄──────────────────────  claim(by="B")
   │                            │  tx BEGIN                │
@@ -84,7 +84,7 @@ worker A                  store                     worker B
   │                            │                          │  [streams 2, 4]
   │  process events for 1,3,5  │                          │  process events for 2,4
   │  ack(by="A")               │                          │  ack(by="B")
-  │ ─────────────────────────► │  ◄──────────────────────  │
+  │ ─────────────────────────► │  ◄────────────────────── │
 ```
 
 `SKIP LOCKED` is the key: workers never block each other waiting for a lock. If a stream is held by another worker, the polling worker just gets the next available stream. Zero contention, no thundering herd. The trade-off is no fairness guarantees — a worker can repeatedly pick up the "easier" streams and leave the leased ones to time out — but in practice this is desirable (active workers stay active).
@@ -94,14 +94,14 @@ worker A                  store                     worker B
 ```
                    ┌───────────────────────┐
                    │ leased_by=NULL        │
-                   │ at=last_acked_position │  ← steady state
-                   └─────────┬─────────────┘
+                   │ at=last_acked_pos     │  ← steady state
+                   └──────────┬────────────┘
                               │  claim()
                               ▼
                    ┌───────────────────────┐
                    │ leased_by='worker-X'  │
                    │ leased_until=NOW+lease│
-                   └─────────┬─────────────┘
+                   └──────────┬────────────┘
                               │
               ┌──────── ack() ┼ block() ─────┐
               │               │              │

--- a/docs/architecture/correlation-and-drain.md
+++ b/docs/architecture/correlation-and-drain.md
@@ -1,0 +1,192 @@
+# Correlation and drain
+
+How reactions actually fire. Two cooperating subsystems with a shared goal: deliver every reactive event to its handler, exactly once, eventually. Different concerns:
+
+- **Correlation** — discovery. Given an event, *which streams* should react to it?
+- **Drain** — delivery. Given streams that need processing, *fetch and run* their reactions.
+
+Both run lazily: nothing happens until a caller invokes `correlate()`, `drain()`, `settle()`, or one of the polling timers. The framework never spins up background workers without being told to.
+
+## The shape of a reaction
+
+A reaction is registered against an event name with a *resolver* and a handler:
+
+```ts
+.on("OrderPlaced")
+  .do(async (event, stream, app) => { /* handler */ })
+  .to((event) => ({ target: `order-${event.orderId}` }))   // dynamic resolver
+  // or .to("inventory")                                   // static resolver
+```
+
+The resolver answers "for this event, which target stream processes the reaction?" Two kinds:
+
+- **Static**: a constant target (string). Known at build time. Subscribed once during `correlate.init()`. Doesn't need event-by-event scanning.
+- **Dynamic**: a function `(event) => ({ target, source? })`. Target depends on event content. Discovered lazily by `correlate()`.
+
+Build-time classification (`internal/build-classify.ts`) walks the registry, partitions resolvers by kind, and stashes:
+
+- `staticTargets[]` — subscribed once at init
+- `hasDynamicResolvers: boolean` — short-circuit flag for `correlate()`
+- `reactiveEvents: Set<string>` — events with at least one reaction; drives the drain skip-flag in `do()` and `reset()`
+
+If `hasDynamicResolvers` is false, `correlate()` becomes effectively a no-op past init — no event scan needed.
+
+## Correlation — discovering dynamic targets
+
+`correlate(query)` scans events past the correlation checkpoint, evaluates each registered dynamic resolver, and registers any new (target, source) pairs as subscribed streams via `store.subscribe`.
+
+```
+                    correlate({ after, limit })
+                              │
+                  has dynamic resolvers?
+                       no ──┬── yes
+                            │     │
+                            ▼     ▼
+                  return as-is  query events past checkpoint
+                                        │
+                                        ▼
+                              for each event:
+                                for each registered dynamic resolver:
+                                  resolved = resolver(event)
+                                  if resolved.target not yet subscribed:
+                                    add to "to subscribe" map
+                                        │
+                                        ▼
+                              subscribe(map.entries())
+                                        │
+                                        ▼
+                              advance checkpoint to last scanned event id
+                                        │
+                                        ▼
+                              add new targets to subscribed-streams LRU
+```
+
+The checkpoint advances only after `subscribe` succeeds. If `subscribe` throws, the checkpoint stays where it was and the next correlate retries from the same point.
+
+### The subscribed-streams LRU
+
+`CorrelateCycle` holds an `LruSet<string>` cap (default 1000, configurable via `ActOptions.maxSubscribedStreams`). Apps that mint millions of dynamic targets — e.g., one stream per user activity — would otherwise grow this set unbounded.
+
+Eviction cost: a redundant `store.subscribe` call when an evicted-but-still-active stream's event is correlated again. `subscribe` is idempotent at the store level (`INSERT … ON CONFLICT DO NOTHING`), so this is harmless. The LRU is a memory bound, not a correctness mechanism.
+
+## Drain — claim, fetch, dispatch
+
+`drain()` runs one cycle of the pipeline:
+
+```
+                              drain({ streamLimit, eventLimit, leaseMillis })
+                                        │
+                              armed? (do() / reset() flagged work)
+                                  no ──┬── yes
+                                       │
+                                  return empty result
+                                       │
+                                       ▼
+                              concurrent drain in flight?
+                                  yes ─┬── no
+                                       │
+                                  return empty result
+                                       │
+                                       ▼
+                              compute lagging/leading split via ratio
+                                       │
+                                       ▼
+                              ops.claim(lagging, leading, by, leaseMillis)
+                                       │
+                                  ┌────┴───────┐
+                                  ▼            ▼
+                              empty?       leases
+                                │            │
+                          disarm; return     │
+                                             ▼
+                              ops.fetch(leases, eventLimit)
+                                             │
+                                             ▼
+                              for each leased stream:
+                                build payloads (filter events to ones
+                                whose registered reaction targets us)
+                                             │
+                                             ▼
+                              dispatch via handle / handleBatch
+                                             │
+                                             ▼
+                              ops.ack(successes), ops.block(retries-exhausted)
+                                             │
+                                             ▼
+                              update lag/lead ratio per pressure
+                                             │
+                                             ▼
+                              emit "acked" / "blocked" lifecycle events
+                                             │
+                                             ▼
+                              disarm if no acks / blocks / errors this cycle
+```
+
+### The dual-frontier split
+
+`claim()` takes two budgets: `lagging` (streams with low watermarks) and `leading` (streams with high watermarks). The split is adaptive — `DrainController._ratio` starts at 0.5 and adjusts each cycle based on which frontier produced more events:
+
+```ts
+// internal/drain-ratio.ts (paraphrased)
+ratio = (laggingHandled - leadingHandled) / total
+clamped to [0.2, 0.8]
+```
+
+If lagging streams produced more work this cycle, the next cycle leans toward lagging (fast-forward streams that have fallen behind). If leading streams produced more, lean toward leading (keep up with active streams). The clamp prevents starvation in either direction.
+
+### The `_armed` skip flag
+
+A naive drain would query the store on every call. For apps where most actions don't have reactions, that's wasted I/O. The framework keeps an `_armed` boolean on `DrainController`:
+
+- `do()` sets `_armed = true` if any committed event is in `reactiveEvents`
+- `reset()` sets `_armed = true` if there are any reactive events
+- `correlate.init()` sets `_armed = true` on cold start (might have historical reactive events to process)
+- `drain()` clears `_armed` when a cycle settles with no acks, no blocks, no errors
+
+When `_armed` is false, `drain()` returns immediately without issuing `claim`. Three round trips saved per call (`claim`, `query`, `ack`). Cold start: armed by `correlate.init()` so historical events are picked up on first drain.
+
+## Settle — the catch-up loop
+
+`settle()` is the production-friendly entry point. It debounces multiple rapid calls into one cycle, then runs `correlate → drain` in a loop until a pass produces no progress:
+
+```
+                    settle(options) ── debounce timer ── timer fires
+                                                              │
+                                                              ▼
+                                                  reentrancy guard
+                                                              │
+                                                              ▼
+                                                  await correlate.init()
+                                                              │
+                                                              ▼
+                                                  loop until no progress:
+                                                    correlate({ after: checkpoint })
+                                                    drain(options)
+                                                    progress = subscribed > 0 ||
+                                                               acked.length > 0 ||
+                                                               blocked.length > 0
+                                                              │
+                                                              ▼
+                                                  emit "settled" with last drain
+```
+
+"Until no progress" handles paginated catch-up. After `app.reset(...)`, a settled stream might have thousands of events. One drain cycle's `streamLimit × eventLimit` won't catch up; subsequent cycles will. `settle()` doesn't return until the work is done — the caller gets the `"settled"` event when there's nothing left.
+
+The debounce is `ActOptions.settleDebounceMs ?? 10` by default. Coalesces commits in the same tick (typical pattern: tRPC mutation chain calling `app.do` many times) into one settle pass.
+
+## Why drain is one-cycle, settle is the loop
+
+`drain()` is one round-trip: claim, fetch, dispatch, ack/block, return. Predictable. Useful for tests and synchronous catch-up scripts where the caller wants control over each cycle.
+
+`settle()` wraps drain in a debounced async loop with progress detection. Useful for production: fire and forget; the framework figures out when "done" means done. Listeners on `"settled"` get notified once per coalesced burst.
+
+Mixing them is fine — `settle()` doesn't acquire any global lock, just a per-controller reentrancy guard. Multiple settle calls on different Act instances proceed independently.
+
+## Pointers
+
+- `libs/act/src/internal/correlate-cycle.ts` — `CorrelateCycle` class, init, scan, polling
+- `libs/act/src/internal/drain-cycle.ts` — `runDrainCycle` (pure cycle), `DrainController` (stateful driver)
+- `libs/act/src/internal/drain-ratio.ts` — adaptive lag/lead ratio
+- `libs/act/src/internal/settle.ts` — `SettleLoop` debounce + progress loop
+- `libs/act/src/internal/build-classify.ts` — registry classification at construction
+- `libs/act/src/internal/reactions.ts` — `buildHandle` / `buildHandleBatch` — what runs inside a drain cycle for each leased stream

--- a/docs/architecture/event-schema-evolution.md
+++ b/docs/architecture/event-schema-evolution.md
@@ -1,0 +1,139 @@
+# Event schema evolution
+
+Events on disk are immutable. State shapes change over time. Reconciling those two facts is what schema evolution is.
+
+The framework's stance: **versioned event names**, not upcasting. Old event versions stay in the registry; reducers handle each version explicitly. Type information is preserved end-to-end.
+
+## What the alternatives look like (and why they were rejected)
+
+### Upcasting
+
+The traditional event-sourcing approach. Define a single `OrderPlaced` event; when a new field is added, write an "upcaster" that transforms old payloads into the new shape at read time:
+
+```ts
+// Pseudocode for an upcasting framework
+function upcast(rawEvent) {
+  if (rawEvent.version === 1) {
+    return { ...rawEvent, priority: "medium" };  // default for v1 events
+  }
+  return rawEvent;
+}
+```
+
+Upcasting buys *runtime* compatibility but at the cost of *type* compatibility. The reducer signature has to be `(event: OrderPlaced) => State` — there's no way to express "this branch handles upcasted-from-v1, this branch handles native-v2." Upcasters typically take and return `unknown` or `any`, erasing the very thing Zod schemas exist to provide.
+
+The bigger problem is that upcasting hides versioning behavior from the reader. A reducer looking at `event.priority` doesn't know that priority might have come from a default supplied by an upcaster. Bugs in upcasters are silently absorbed into "current state."
+
+### Migration scripts
+
+Run a one-time script that rewrites old events into the new shape. Direct, but breaks the immutability invariant. Audit logs no longer reflect what actually happened — they reflect what the most recent migration *says* happened. The first time something subtle goes wrong, this hurts.
+
+The framework's event log is the source of truth. Rewriting it is not on the table.
+
+## How versioned event names work
+
+Add a new event name with a version suffix; keep the old one in the registry; both have explicit reducers:
+
+```ts
+.emits({
+  // v1: original schema (kept forever — historical events match this name)
+  TicketOpened: z.object({
+    title: z.string(),
+    type: z.string(),
+  }),
+
+  // v2: breaking change — renamed `type` to `category`, added `priority`
+  TicketOpened_v2: z.object({
+    title: z.string(),
+    priority: z.enum(["low", "medium", "high"]),
+    category: z.string(),
+  }),
+})
+.patch({
+  // Reducer for v1 events — maps old shape to current state shape
+  TicketOpened: ({ data }, state) => ({
+    ...state,
+    title: data.title,
+    category: data.type,           // map old field
+    priority: "medium",            // default for v1
+  }),
+
+  // Reducer for v2 events — direct
+  TicketOpened_v2: ({ data }, state) => ({
+    ...state,
+    title: data.title,
+    priority: data.priority,
+    category: data.category,
+  }),
+})
+// New actions emit v2
+.on({ openTicket: z.object({ ... }) })
+  .emit((action) => ["TicketOpened_v2", { ... }])
+```
+
+### What this guarantees
+
+- **Type safety end-to-end**: Zod's `z.infer` produces narrow types per event name. Reducer functions, query filters, projection handlers — all see the right shape per event.
+- **Audit fidelity**: events on disk are exactly what was committed. No transformation at read time.
+- **Schema discoverability**: looking at `me.events` shows every version that has ever existed. Adding a new version is a deliberate, visible act.
+- **Reducer locality**: the migration logic for v1 lives in the v1 reducer. Future readers of the code see "this is how an old event becomes current state."
+
+### What this costs
+
+- **Registry grows over time**: old event names stick around. For a stream that's been live for years through several breaking changes, the registry might have `OrderPlaced`, `OrderPlaced_v2`, `OrderPlaced_v3`. That's the cost of immutable history.
+- **Multiple reducers per concept**: each version needs its own reducer. Often the v1 reducer's job is "translate to v2 shape, then apply v2 logic"; sometimes that's tempting to factor as `me.patch.OrderPlaced_v1 = compose(translateV1ToV2, me.patch.OrderPlaced_v2)`. The framework allows that; it doesn't enforce it.
+
+## Non-breaking changes need no version bump
+
+Adding an optional field with a sensible default is not a breaking change:
+
+```ts
+.emits({
+  // Was: title only. Now: title + optional priority with a default.
+  TicketOpened: z.object({
+    title: z.string(),
+    priority: z.enum(["low", "medium", "high"]).default("medium"),
+  }),
+})
+.patch({
+  TicketOpened: ({ data }, state) => ({
+    ...state,
+    title: data.title,
+    priority: data.priority ?? "medium",  // handles old events that have no priority
+  }),
+})
+```
+
+Zod's `.default()` does the lift on parse. New events go in with a value (defaulted at validation time if not supplied). Old events on disk don't have the field; the reducer's `?? "medium"` fills it on replay.
+
+This works for: adding optional fields, adding fields with defaults, broadening enum members, broadening string types. It does *not* work for: renames, removals, narrowing constraints, type changes (string → number). Those need a version bump.
+
+## Cross-cutting: cache and snapshots
+
+Schema evolution interacts with the cache and snapshot layers:
+
+- **Cache** lives in process memory and reflects post-reducer state. After a reducer change, restarting the process empties the cache; all loads cold-reload. No migration needed.
+- **Snapshots** are events too. A `__snapshot__` event committed under v1 of the state shape contains v1-shape state. After a v2 schema change, the framework doesn't migrate the snapshot — it loads the snapshot's data as the seed state, then applies subsequent reducer-versioned events on top.
+- **Stale snapshots**: if v1's state shape was `{ title, type }` and v2's is `{ title, category, priority }`, a v1 snapshot's data lacks `category` and `priority`. The reducer in `load()` reads the snapshot raw — `state = e.data as TState`. After this, every subsequent reducer call will work normally on the v1-shaped state plus newer events.
+
+In practice this means: snapshots are forward-compatible as long as your reducers handle the missing fields. If a v1 snapshot's missing fields would corrupt the v2 reducer, the right move is `app.close({ restart: true })` — load current state via the latest reducers, commit a fresh `__snapshot__` reflecting the current shape, tombstone the historical events.
+
+See `cache-and-snapshots.md` for more on the snapshot lifecycle.
+
+## What to do when
+
+| Change | Approach |
+|---|---|
+| Add an optional field with a default | Update the schema with `.default(...)`; reducer handles missing |
+| Add a required field | Add as optional with default first; backfill if needed; later make required |
+| Rename a field | New version with the new field; v1 reducer maps old field to new state shape |
+| Change a field's type | New version (string→number is a breaking change in Zod); v1 reducer parses/converts |
+| Remove a field | New version that omits the field; v1 reducer ignores it |
+| Combine two events into one | New combined event name; v1 reducers stay (history doesn't change); going forward emit only v2 |
+| Split one event into many | New event names; v1 reducer maps old event to compound state changes; going forward emit the new ones |
+
+## Pointers
+
+- `libs/act/src/types/action.ts` — `EventRegister`, `PatchHandlers` — type-level shape that drives this
+- `libs/act/src/internal/event-sourcing.ts` — `load()` — reads `me.patch[e.name]`; missing reducer logs a warning rather than silently corrupting state
+- `libs/act/src/internal/merge.ts` — duplicate-event-name guard at slice composition time (one canonical reducer per event)

--- a/docs/architecture/extension-points.md
+++ b/docs/architecture/extension-points.md
@@ -1,0 +1,165 @@
+# Extension points
+
+Three pluggable contracts: `Store`, `Cache`, `Logger`. Each is exposed as a singleton port. A new adapter implements the contract; calling the port with the adapter installs it (first call wins).
+
+This page covers each contract, its invariants, and the concrete adapters in this repo. Anyone writing a new adapter should be able to read this page plus the contract source and build something correct.
+
+## The port pattern
+
+Every infrastructure dependency in the framework is reached via a port — a singleton getter that lazily initializes a default the first time it's called:
+
+```ts
+import { store, cache, log, dispose } from "@rotorsoft/act";
+
+// Defaults install on first call
+store();   // → InMemoryStore
+cache();   // → InMemoryCache
+log();     // → ConsoleLogger
+
+// Or inject before first read
+import { PostgresStore } from "@rotorsoft/act-pg";
+store(new PostgresStore({ /* ... */ }));   // sets the singleton
+const s = store();                          // returns the PostgresStore
+```
+
+First call wins by design. Once an adapter is registered, subsequent calls with a different argument are ignored. This forces app initialization to be deterministic and prevents mid-run swaps that would corrupt state.
+
+The `dispose()` port collects cleanup callbacks. Adapters' `dispose()` methods are wired into this so they release resources (DB pools, file handles) on shutdown. Order: registered disposers run in reverse, then port adapters in reverse registration order.
+
+## Store contract
+
+The `Store` interface in `libs/act/src/types/index.ts`. The framework needs the store to do **eight** things:
+
+```ts
+interface Store extends Disposable {
+  seed(): Promise<void>;
+  drop(): Promise<void>;
+  commit(stream, msgs, meta, expectedVersion?): Promise<Committed[]>;
+  query(callback, filter?): Promise<number>;
+  claim(lagging, leading, by, millis): Promise<Lease[]>;
+  subscribe(streams): Promise<{ subscribed; watermark }>;
+  ack(leases): Promise<Lease[]>;
+  block(leases): Promise<BlockedLease[]>;
+  reset(streams): Promise<number>;
+  truncate(targets): Promise<Map<stream, { deleted; committed }>>;
+  query_streams(callback, query?): Promise<QueryStreamsResult>;
+}
+```
+
+### Invariants an adapter must hold
+
+- **Per-stream version monotonicity**: every event for a given stream has a `version` that's strictly greater than the previous event's `version` for that stream, starting at 0.
+- **Optimistic concurrency**: when `expectedVersion` is provided, `commit` MUST throw `ConcurrencyError` if the stream's current head version doesn't match. This includes catching adapter-specific unique-constraint violations and re-throwing as `ConcurrencyError`. Callers cannot retry correctly on adapter-specific errors.
+- **Atomic commits**: a multi-event commit is all-or-nothing. Either all events land or none do.
+- **Atomic truncate**: `truncate` deletes all events for a stream and inserts the seed event in a single transaction. Partial states are not observable.
+- **Lease exclusivity**: a successful `claim` returns leases that no concurrent `claim()` can return again until released by `ack`/`block`/timeout.
+- **Tombstone semantics**: a tombstone event is a regular event with `name === TOMBSTONE_EVENT`. Adapters don't need to know what it means — the framework's `action()` reads the head event to decide. Adapters just need to return tombstones in queries like any other event.
+
+### Concrete adapters
+
+| Adapter | Where | Use case |
+|---|---|---|
+| `InMemoryStore` | `libs/act/src/adapters/in-memory-store.ts` | Tests, single-process dev |
+| `PostgresStore` | `libs/act-pg/src/PostgresStore.ts` | Production multi-process |
+| `SqliteStore` | `libs/act-sqlite/src/SqliteStore.ts` | Embedded, single-node |
+
+### What the framework does NOT promise the adapter
+
+- Connection pooling — the adapter implements it (PG: `pg.Pool`; SQLite: libSQL's built-in)
+- Transactions — the adapter wraps multi-step operations as needed
+- Schema migration — adapters define their own DDL in `seed()`; users run it explicitly
+- Auth/connection strings — adapter constructor takes a config; framework doesn't inspect
+
+## Cache contract
+
+```ts
+interface Cache extends Disposable {
+  get<TState>(stream): Promise<CacheEntry<TState> | undefined>;
+  set<TState>(stream, entry): Promise<void>;
+  invalidate(stream): Promise<void>;
+  clear(): Promise<void>;
+}
+
+interface CacheEntry<TState> {
+  readonly state: TState;
+  readonly version: number;
+  readonly event_id: number;
+  readonly patches: number;
+  readonly snaps: number;
+}
+```
+
+### Invariants
+
+- **`get` is a hint, not a contract**: the cache may return undefined at any time (eviction, network failure for a Redis-backed adapter, cold start). The framework treats `undefined` the same as a logical miss and falls back to store replay.
+- **`set` is best-effort**: failures are logged but don't propagate. The cache is an optimization, not source of truth.
+- **`invalidate` should be reliable**: when called after `ConcurrencyError`, the framework relies on the entry being gone. A failed `invalidate` followed by a `get` returning the old entry would surface stale state. Adapters should treat this as a critical path.
+- **Async by design**: the interface is async even for in-memory implementations. Don't optimize away the async — Redis/external caches need it.
+
+### Concrete adapters
+
+| Adapter | Where | Use case |
+|---|---|---|
+| `InMemoryCache` | `libs/act/src/adapters/in-memory-cache.ts` | Single-process; LRU, default `maxSize: 1000` |
+
+For distributed deployments, a Redis-backed adapter is the natural extension. Not provided in this repo because Redis-vs-Memcached-vs-other choice is app-specific.
+
+## Logger contract
+
+```ts
+interface Logger extends Disposable {
+  level: string;
+  fatal(msgOrObj, msg?: string): void;
+  error(msgOrObj, msg?: string): void;
+  warn(msgOrObj, msg?: string): void;
+  info(msgOrObj, msg?: string): void;
+  debug(msgOrObj, msg?: string): void;
+  trace(msgOrObj, msg?: string): void;
+  child(bindings): Logger;
+}
+```
+
+### Invariants
+
+- **No-throw**: log calls must never throw. A misbehaving logger crashing the framework is the classic operability footgun.
+- **Level gating**: levels above `level` should be no-ops. The `tracing` module checks `logger.level === "trace"` to decide whether to instrument event-sourcing and drain ops with breadcrumb logs. Lying about the level disables tracing silently.
+- **`child(bindings)` returns a logger that forwards to the same sink with merged bindings**. Used by `Act.create_correlations` and similar to add a per-instance binding (e.g., `correlationId`).
+
+### Concrete adapters
+
+| Adapter | Where | Use case |
+|---|---|---|
+| `ConsoleLogger` | `libs/act/src/adapters/console-logger.ts` | Default. JSON in production, colorized human-readable in dev. Zero deps. |
+| `PinoLogger` | `libs/act-pino/src/index.ts` | Production deployments using pino's transport ecosystem. |
+
+## Wiring it together — a minimal app
+
+```ts
+import { act, store, cache, log, dispose } from "@rotorsoft/act";
+import { PostgresStore } from "@rotorsoft/act-pg";
+import { InMemoryCache } from "@rotorsoft/act";  // re-exported from main
+import { PinoLogger } from "@rotorsoft/act-pino";
+
+// 1. Wire ports BEFORE constructing Act
+log(new PinoLogger({ level: "info" }));
+store(new PostgresStore({ host: "...", database: "...", schema: "events", table: "events" }));
+cache(new InMemoryCache({ maxSize: 5000 }));
+
+// 2. Build the Act instance
+const app = act()
+  .withState(...)
+  .build();
+
+// 3. Run as normal
+await app.do("...", target, payload);
+```
+
+If any port is left to default, the framework wires the in-memory implementation for that port. Useful for tests; deliberate for production.
+
+## Pointers
+
+- `libs/act/src/ports.ts` — `port()` factory and the three default ports
+- `libs/act/src/types/ports.ts` — `Store`, `Cache`, `Logger`, `Disposable` contracts
+- `libs/act/src/adapters/` — default in-memory implementations of all three
+- `libs/act-pg/src/PostgresStore.ts`, `libs/act-sqlite/src/SqliteStore.ts`, `libs/act-pino/src/index.ts` — production adapters
+- `libs/act-pg/test/stress/` — multi-process stress harness exercising the Store contract under contention; useful as a worked example of which invariants the framework actually depends on

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,7 @@ title: Act Framework
 
 # Act Framework
 
-Act is a modern event sourcing + CQRS + Actor Model framework for TypeScript. The core philosophy: any system distills into **Actions → \{State\} ← Reactions**.
+Act is a modern event sourcing + CQRS framework for TypeScript, with first-class support for DDD aggregates and reaction-driven workflows. The core philosophy: any system distills into **Actions → \{State\} ← Reactions**.
 
 ## Purpose & Philosophy
 

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -4,7 +4,7 @@
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act.svg)](https://www.npmjs.com/package/@rotorsoft/act)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[Act](../../README.md) core library - Event Sourcing + CQRS + Actor Model framework for TypeScript.
+[Act](../../README.md) core library — Event Sourcing + CQRS framework for TypeScript, built around DDD aggregates and reaction-driven workflows.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

PR-D1 from the architectural plan. Two pieces of documentation work bundled because they touch overlapping ground (root README + new docs section under it):

1. **`docs/architecture/` — six new contributor-facing pages**
2. **Root README — Libraries section reorganized into two tables**

## Architecture pages

For new contributors who need to reason about the framework's load-bearing subsystems without reading every internal module first. Each page focuses on the *why* behind the shape (the source has the *what*), includes a small ASCII diagram where it helps, and links into the relevant source files at the bottom.

| Page | Topic |
|---|---|
| [`concurrency-model.md`](https://github.com/Rotorsoft/act-root/blob/docs/architecture-pages/docs/architecture/concurrency-model.md) | Optimistic concurrency (`commit` + `expectedVersion`) vs stream leasing (`claim` + `FOR UPDATE SKIP LOCKED`) — two distinct primitives at different layers, why they don't interact, and the SELECT-then-INSERT race that #650 exposed and fixed |
| [`cache-and-snapshots.md`](https://github.com/Rotorsoft/act-root/blob/docs/architecture-pages/docs/architecture/cache-and-snapshots.md) | Two checkpoint layers; how `load()` reads both; time-travel bypass; why cache-write-on-read (#649) is safe without race protection |
| [`correlation-and-drain.md`](https://github.com/Rotorsoft/act-root/blob/docs/architecture-pages/docs/architecture/correlation-and-drain.md) | Static vs dynamic resolvers; \`_armed\` skip-flag; dual-frontier drain ratio; settle's debounced correlate→drain catch-up loop |
| [`close-cycle.md`](https://github.com/Rotorsoft/act-root/blob/docs/architecture-pages/docs/architecture/close-cycle.md) | Six phases with phase diagram; failure semantics at each phase ("at every stable state during close, the stream is in a coherent retryable shape"); idempotency guarantees |
| [`event-schema-evolution.md`](https://github.com/Rotorsoft/act-root/blob/docs/architecture-pages/docs/architecture/event-schema-evolution.md) | Versioned event names; why upcasting was rejected; how schema evolution interacts with snapshots |
| [`extension-points.md`](https://github.com/Rotorsoft/act-root/blob/docs/architecture-pages/docs/architecture/extension-points.md) | Store/Cache/Logger contracts; invariants adapters must hold; the three defaults in this repo |

The `docs/architecture/README.md` is the index. Audience and "after reading this you should be able to..." are stated explicitly there.

## Libraries section reorg

Previously: 7 libraries listed sequentially with H3 headings + badges, plus a separate "Tools" section for the inspector.

Now: two two-column tables.

- **Core**: `@rotorsoft/act`, `@rotorsoft/act-pg`, `@rotorsoft/act-sqlite`, `@rotorsoft/act-sse`. The framework + the stores most users will pick + the real-time module that most production deployments use.
- **Supporting libraries & tools**: `@rotorsoft/act-pino`, `@rotorsoft/act-patch`, `@rotorsoft/act-diagram`, `@rotorsoft/act-inspector`. Optional adapters and tooling.

Each row has the package badge column on the left and a short purpose-and-shape description on the right. Removes the previous separate Tools section now that the inspector lives in the supporting table.

## Documentation index updated

The Documentation section gains a bullet pointing at `docs/architecture/` so the new pages are discoverable from the README.

## Test plan

- [x] All existing tests still pass — this PR is documentation-only, no source changes
- [x] Markdown renders as expected (verified locally)
- [x] No broken cross-links between architecture pages
- [ ] CI green on push

## What's NOT in this PR

- **Concept guides under `docs/docs/concepts/`** — those are user-facing (state management, error handling, etc.) and already exist on the docs site. The new architecture pages are *contributor-facing*; different audience.
- **JSDoc consistency pass** — that's PR-G1+G2, queued for after the current saga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)