### PR TITLE
chore(act): jsdoc consistency pass

### DIFF
--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -167,12 +167,6 @@ export class Act<
     return this;
   }
 
-  /**
-   * Create a new Act orchestrator.
-   *
-   * @param registry The registry of state, event, and action schemas
-   * @param states Map of state names to their (potentially merged) state definitions
-   */
   /** Batch handlers for static-target projections (target → handler) */
   private readonly _batch_handlers: Map<string, BatchHandler<TEvents>>;
   /** Event-sourcing handlers, optionally wrapped with trace decorators */
@@ -198,6 +192,17 @@ export class Act<
   private readonly _handle: Handle<TEvents>;
   private readonly _handle_batch: HandleBatch<TEvents>;
 
+  /**
+   * Create a new Act orchestrator. Prefer the {@link act} builder over
+   * direct construction — `act()...build()` wires the registry, merges
+   * partial states, and collects batch handlers from registered slices
+   * and projections in one pass.
+   *
+   * @param registry  Schemas for every event and action across registered states
+   * @param _states   Merged map of state name → state definition
+   * @param batchHandlers Static-target projection batch handlers (target → handler)
+   * @param options   Tuning knobs — see {@link ActOptions}
+   */
   constructor(
     public readonly registry: Registry<TSchemaReg, TEvents, TActions>,
     private readonly _states: Map<string, State<any, any, any>> = new Map(),

--- a/libs/act/src/adapters/console-logger.ts
+++ b/libs/act/src/adapters/console-logger.ts
@@ -80,8 +80,10 @@ export class ConsoleLogger implements Logger {
     this.trace = threshold <= 10 ? write.bind(this, "trace", 10) : noop;
   }
 
+  /** No-op — `console.log` has no resources to release. */
   async dispose(): Promise<void> {}
 
+  /** @inheritDoc */
   child(bindings: Record<string, unknown>): Logger {
     return new ConsoleLogger({
       level: this.level,

--- a/libs/act/src/adapters/in-memory-cache.ts
+++ b/libs/act/src/adapters/in-memory-cache.ts
@@ -26,12 +26,14 @@ export class InMemoryCache implements Cache {
     this._entries = new LruMap(options?.maxSize ?? 1000);
   }
 
+  /** @inheritDoc */
   async get<TState extends Schema>(
     stream: string
   ): Promise<CacheEntry<TState> | undefined> {
     return this._entries.get(stream);
   }
 
+  /** @inheritDoc */
   async set<TState extends Schema>(
     stream: string,
     entry: CacheEntry<TState>
@@ -39,18 +41,22 @@ export class InMemoryCache implements Cache {
     this._entries.set(stream, entry);
   }
 
+  /** @inheritDoc */
   async invalidate(stream: string): Promise<void> {
     this._entries.delete(stream);
   }
 
+  /** @inheritDoc */
   async clear(): Promise<void> {
     this._entries.clear();
   }
 
+  /** @inheritDoc */
   async dispose(): Promise<void> {
     this._entries.clear();
   }
 
+  /** Current number of entries held by the LRU. */
   get size(): number {
     return this._entries.size;
   }

--- a/libs/act/src/types/errors.ts
+++ b/libs/act/src/types/errors.ts
@@ -241,6 +241,32 @@ export class InvariantError<
  *
  * @see {@link Store.commit} for version checking details
  */
+export class ConcurrencyError extends Error {
+  constructor(
+    /** The stream that had the concurrent modification */
+    public readonly stream: string,
+    /** The actual current version in the store */
+    public readonly lastVersion: number,
+    /** The events that were being committed */
+    public readonly events: Message<Schemas, keyof Schemas>[],
+    /** The version number that was expected */
+    public readonly expectedVersion: number
+  ) {
+    // Message lists stream + event names only. Payloads remain accessible
+    // via `error.events` for callers who need them — keeping them out of
+    // the message avoids MB-scale strings on contended writes and keeps
+    // potentially-sensitive data out of log streams.
+    super(
+      `Concurrency error committing "${events
+        .map((e) => `${stream}.${e.name}`)
+        .join(
+          ", "
+        )}". Expected version ${expectedVersion} but found version ${lastVersion}.`
+    );
+    this.name = Errors.ConcurrencyError;
+  }
+}
+
 /**
  * Thrown when attempting to write to a stream that has been closed
  * with a tombstone event.
@@ -271,31 +297,5 @@ export class StreamClosedError extends Error {
   ) {
     super(`Stream "${stream}" is closed (tombstoned)`);
     this.name = Errors.StreamClosedError;
-  }
-}
-
-export class ConcurrencyError extends Error {
-  constructor(
-    /** The stream that had the concurrent modification */
-    public readonly stream: string,
-    /** The actual current version in the store */
-    public readonly lastVersion: number,
-    /** The events that were being committed */
-    public readonly events: Message<Schemas, keyof Schemas>[],
-    /** The version number that was expected */
-    public readonly expectedVersion: number
-  ) {
-    // Message lists stream + event names only. Payloads remain accessible
-    // via `error.events` for callers who need them — keeping them out of
-    // the message avoids MB-scale strings on contended writes and keeps
-    // potentially-sensitive data out of log streams.
-    super(
-      `Concurrency error committing "${events
-        .map((e) => `${stream}.${e.name}`)
-        .join(
-          ", "
-        )}". Expected version ${expectedVersion} but found version ${lastVersion}.`
-    );
-    this.name = Errors.ConcurrencyError;
   }
 }

--- a/libs/act/src/types/registry.ts
+++ b/libs/act/src/types/registry.ts
@@ -10,7 +10,13 @@ import type { Reaction } from "./reaction.js";
  */
 
 /**
- * Reactions register
+ * Per-event registration: the event's schema plus every reaction
+ * registered against it. Keyed by reaction name within the inner map so
+ * a single event can fan out to multiple handlers (one per slice or
+ * top-level `act().on(...)` call).
+ *
+ * @template TEvents - Event schemas in the domain
+ * @template TKey    - Specific event name within `TEvents`
  */
 export type ReactionsRegister<
   TEvents extends Schemas,
@@ -29,8 +35,11 @@ export type EventRegister<TEvents extends Schemas> = {
 };
 
 /**
- * Maps action names to their schema definitions.
- * @template TSchemaReg - Schema register for actions.
+ * Type-level constraint: every key in the action map must point at a
+ * Zod schema. Used as a constraint on the registry's action half so
+ * downstream types can `infer` payloads safely.
+ *
+ * @template TSchemaReg - Schema register for actions
  */
 export type SchemaRegister<TSchemaReg> = {
   [TKey in keyof TSchemaReg]: Schema;


### PR DESCRIPTION
## Summary
JSDoc audit on the libs/act public surface caught two real bugs and a handful of fills.

### Real bugs (orphaned JSDoc blocks)
- **`types/errors.ts`** — `ConcurrencyError`'s JSDoc was stacked above `StreamClosedError`'s JSDoc, but the actual `ConcurrencyError` class was declared *after* `StreamClosedError`. TypeDoc/IDE happily attached the StreamClosedError JSDoc to itself and orphaned ConcurrencyError's, so the ConcurrencyError class ended up undocumented in the generated API ref. Reordered so each class is adjacent to its JSDoc.
- **`act.ts`** — the `Act` constructor JSDoc sat above six private field declarations (each with their own JSDoc), so it attached to the first private field instead of the constructor. Moved it down to be adjacent to the constructor and expanded it slightly to point callers at the `act()` builder.

### Fills
- **`adapters/in-memory-cache`** — `@inheritDoc` on `get`/`set`/`invalidate`/`clear`/`dispose` so TypeDoc picks up the `Cache` interface contract; brief one-liner on the `size` getter.
- **`adapters/console-logger`** — `@inheritDoc` on `child()`; explanatory one-liner on the no-op `dispose()`.
- **`types/registry`** — expanded the terse one-line JSDoc on `ReactionsRegister` and `SchemaRegister` with intent + template params.

### Verified clean
- `pnpm test` — 67 files, 995 tests passing
- `eslint` on the touched files — no errors
- `tsc --noEmit` on libs/act — clean

## Test plan
- [ ] Generate the typedoc output (`pnpm -F docs build:all` or `pnpm typedoc` in `libs/act`) and confirm `ConcurrencyError` and the `Act` constructor now show their JSDoc in the API reference