### PR TITLE
chore: tighten biome rules and apply autofixes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -55,14 +55,14 @@
         "noExplicitAny": "off",
         "noUnsafeDeclarationMerging": "off",
         "noAssignInExpressions": "off",
-        "noImplicitAnyLet": "off",
-        "noConfusingVoidType": "off"
+        "noConfusingVoidType": "off",
+        "noConsole": "error"
       },
       "style": {
         "noNonNullAssertion": "off",
-        "useImportType": "off",
         "useTemplate": "off",
-        "noParameterAssign": "off"
+        "useImportType": "error",
+        "noParameterAssign": "error"
       },
       "correctness": {
         "noUnusedVariables": {
@@ -71,6 +71,9 @@
             "ignoreRestSiblings": true
           }
         }
+      },
+      "performance": {
+        "noAccumulatingSpread": "warn"
       }
     }
   },
@@ -83,6 +86,24 @@
     }
   },
   "overrides": [
+    {
+      "includes": [
+        "**/__tests__/**",
+        "**/test/**",
+        "**/scripts/**",
+        "**/*.bench.ts",
+        "packages/**",
+        "performance/**",
+        "libs/act-diagram/src/server/**"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
     {
       "includes": ["libs/act/src/**/*.ts", "!libs/act/src/internal/**"],
       "linter": {

--- a/libs/act-diagram/src/client/lib/build-model.ts
+++ b/libs/act-diagram/src/client/lib/build-model.ts
@@ -84,7 +84,7 @@ function fixupReactions(
   if (!src) return;
   const doRe =
     /\.on\(\s*["'`](\w+)["'`]\s*\)\s*\.do\(\s*(?:async\s+)?(?:function\s+(\w+)|(?:\w+\.)?(\w+))?/g;
-  let dm;
+  let dm: RegExpExecArray | null;
   while ((dm = doRe.exec(src)) !== null) {
     const eventName = dm[1];
     const handlerName = dm[2] || dm[3];

--- a/libs/act-diagram/src/client/lib/evaluate.ts
+++ b/libs/act-diagram/src/client/lib/evaluate.ts
@@ -163,7 +163,7 @@ function execute(
       // Pre-scan: capture slice variable names before eval
       const sliceNamesInAct: string[] = [];
       const wsRe = /\.withSlice\(\s*(?:\w+\.)*(\w+)\s*\)/g;
-      let wsm;
+      let wsm: RegExpExecArray | null;
       const codeOnly = stripNonCode(js);
       while ((wsm = wsRe.exec(codeOnly)) !== null) {
         if (!sliceNamesInAct.includes(wsm[1])) sliceNamesInAct.push(wsm[1]);

--- a/libs/act-diagram/src/client/lib/sort.ts
+++ b/libs/act-diagram/src/client/lib/sort.ts
@@ -20,7 +20,7 @@ export function topoSort(tsFiles: FileTab[]): FileTab[] {
     deps.set(key, fileDeps);
 
     const fromRe = /from\s+["']([^"']+)["']/g;
-    let m;
+    let m: RegExpExecArray | null;
     while ((m = fromRe.exec(f.content)) !== null) {
       const imp = m[1];
       const resolved = resolve(imp, key, byKey);

--- a/libs/act-pg/test/app.ts
+++ b/libs/act-pg/test/app.ts
@@ -1,4 +1,10 @@
-import { act, ReactionHandler, sleep, state, ZodEmpty } from "@rotorsoft/act";
+import {
+  act,
+  type ReactionHandler,
+  sleep,
+  state,
+  ZodEmpty,
+} from "@rotorsoft/act";
 import z from "zod";
 
 const counter = state({ Counter: z.object({ count: z.number() }) })

--- a/libs/act-pg/test/commit.error.spec.ts
+++ b/libs/act-pg/test/commit.error.spec.ts
@@ -1,5 +1,10 @@
-import { Committed, ConcurrencyError, dispose, Schemas } from "@rotorsoft/act";
-import { Pool, QueryResult } from "pg";
+import {
+  type Committed,
+  ConcurrencyError,
+  dispose,
+  type Schemas,
+} from "@rotorsoft/act";
+import { Pool, type QueryResult } from "pg";
 import { PostgresStore } from "../src/index.js";
 
 const query = (

--- a/libs/act-pg/test/store.spec.ts
+++ b/libs/act-pg/test/store.spec.ts
@@ -1,8 +1,8 @@
 import {
-  Committed,
+  type Committed,
   ConcurrencyError,
   dispose,
-  Schemas,
+  type Schemas,
   SNAP_EVENT,
   sleep,
   store,

--- a/libs/act-pg/test/stress/worker.ts
+++ b/libs/act-pg/test/stress/worker.ts
@@ -19,7 +19,7 @@
  * @internal
  */
 
-import { ConcurrencyError, dispose, Schemas, store } from "@rotorsoft/act";
+import { ConcurrencyError, dispose, type Schemas, store } from "@rotorsoft/act";
 import { PostgresStore } from "../../src/index.js";
 
 const PG_CONFIG = {

--- a/libs/act-sqlite/test/app.ts
+++ b/libs/act-sqlite/test/app.ts
@@ -1,4 +1,10 @@
-import { act, ReactionHandler, sleep, state, ZodEmpty } from "@rotorsoft/act";
+import {
+  act,
+  type ReactionHandler,
+  sleep,
+  state,
+  ZodEmpty,
+} from "@rotorsoft/act";
 import z from "zod";
 
 const counter = state({ Counter: z.object({ count: z.number() }) })

--- a/libs/act-sqlite/test/store.spec.ts
+++ b/libs/act-sqlite/test/store.spec.ts
@@ -1,8 +1,8 @@
 import {
-  Committed,
+  type Committed,
   ConcurrencyError,
   dispose,
-  Schemas,
+  type Schemas,
   SNAP_EVENT,
   sleep,
   store,

--- a/libs/act/src/config.ts
+++ b/libs/act/src/config.ts
@@ -10,9 +10,9 @@ import * as fs from "node:fs";
 import { z } from "zod";
 import { log } from "./ports.js";
 import {
-  Environment,
+  type Environment,
   Environments,
-  LogLevel,
+  type LogLevel,
   LogLevels,
 } from "./types/index.js";
 import { extend } from "./utils.js";

--- a/libs/act/src/internal/correlate-cycle.ts
+++ b/libs/act/src/internal/correlate-cycle.ts
@@ -15,7 +15,7 @@
  */
 
 import { LruSet } from "../lru-map.js";
-import { store } from "../ports.js";
+import { log, store } from "../ports.js";
 import type {
   Query,
   ReactionPayload,
@@ -159,8 +159,8 @@ export class CorrelateCycle<
 
   /**
    * Start a periodic correlation worker. Returns false if one is already
-   * running. Errors from `correlate()` are sent to `console.error` (matches
-   * pre-extraction behavior; the timer keeps running on failure).
+   * running. Errors from `correlate()` are routed through `log()` so they
+   * land in the configured logger (the timer keeps running on failure).
    */
   startPolling(
     query: Query = {},
@@ -176,7 +176,7 @@ export class CorrelateCycle<
           .then((result) => {
             if (callback && result.subscribed) callback(result.subscribed);
           })
-          .catch(console.error),
+          .catch((err) => log().error(err)),
       frequency
     );
     return true;

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -251,7 +251,7 @@ export async function action<
   const { stream, expectedVersion, actor } = target;
   if (!stream) throw new Error("Missing target stream");
 
-  payload = skipValidation
+  const validated = skipValidation
     ? payload
     : validate(action as string, payload, me.actions[action]);
 
@@ -266,7 +266,7 @@ export async function action<
       if (!valid(snapshot.state, actor))
         throw new InvariantError(
           action,
-          payload,
+          validated,
           target,
           snapshot,
           description
@@ -274,7 +274,7 @@ export async function action<
     });
   }
 
-  const result = me.on[action](payload, snapshot, target);
+  const result = me.on[action](validated, snapshot, target);
   if (!result) return [snapshot];
 
   // An empty array means no events were emitted

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -28,10 +28,10 @@
 
 import { config } from "../config.js";
 import type { AsOf, Logger, Schemas } from "../types/index.js";
+import type { DrainOps } from "./drain.js";
 import * as drain from "./drain.js";
-import { type DrainOps } from "./drain.js";
+import type { EsOps } from "./event-sourcing.js";
 import * as es from "./event-sourcing.js";
-import { type EsOps } from "./event-sourcing.js";
 
 type AsyncFn = (...args: any[]) => Promise<any>;
 

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -1,7 +1,7 @@
 import type { Patch } from "@rotorsoft/act-patch";
-import { ZodType, z } from "zod";
+import type { ZodType, z } from "zod";
 import type { TruncateResult } from "./ports.js";
-import {
+import type {
   ActorSchema,
   CausationEventSchema,
   CommittedMetaSchema,

--- a/libs/act/src/types/registry.ts
+++ b/libs/act/src/types/registry.ts
@@ -1,4 +1,4 @@
-import { ZodType, z } from "zod";
+import type { ZodType, z } from "zod";
 import type { CommittedMeta, Schema, Schemas, State } from "./action.js";
 import type { Reaction } from "./reaction.js";
 

--- a/libs/act/src/types/schemas.ts
+++ b/libs/act/src/types/schemas.ts
@@ -1,4 +1,4 @@
-import { ZodObject, ZodRawShape, z } from "zod";
+import { type ZodObject, type ZodRawShape, z } from "zod";
 
 /**
  * @packageDocumentation

--- a/libs/act/test/act.spec.ts
+++ b/libs/act/test/act.spec.ts
@@ -113,10 +113,10 @@ describe("act", () => {
     await app.do("add", { stream: "s2", actor }, {});
     await app.correlate();
     // Drain until nothing left (InMemoryStore may need multiple passes)
-    let d;
-    do {
+    let d = await app.drain();
+    while (d.acked.length || d.blocked.length) {
       d = await app.drain();
-    } while (d.acked.length || d.blocked.length);
+    }
 
     // Now _needs_drain is false. Non-reactive event should NOT set it.
     await app.do("ignore2", { stream: "s2", actor }, {});
@@ -574,10 +574,10 @@ describe("act", () => {
   it("should clear _needs_drain when drain processes events with no results", async () => {
     await app.do("increment", { stream: "clear-flag", actor }, {});
     await app.correlate();
-    let d;
-    do {
+    let d = await app.drain();
+    while (d.acked.length || d.blocked.length) {
       d = await app.drain();
-    } while (d.acked.length || d.blocked.length);
+    }
     expect((app as any)._drain.armed).toBe(false);
   });
 

--- a/libs/act/test/cache.spec.ts
+++ b/libs/act/test/cache.spec.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { InMemoryCache } from "../src/adapters/in-memory-cache.js";
+import type { InMemoryCache } from "../src/adapters/in-memory-cache.js";
 import { InMemoryStore } from "../src/adapters/in-memory-store.js";
 import { state } from "../src/builders/state-builder.js";
 import { action, load } from "../src/internal/event-sourcing.js";

--- a/libs/act/test/calculator.spec.ts
+++ b/libs/act/test/calculator.spec.ts
@@ -1,4 +1,11 @@
-import { Actor, act, Committed, dispose, sleep, store } from "@rotorsoft/act";
+import {
+  type Actor,
+  act,
+  type Committed,
+  dispose,
+  sleep,
+  store,
+} from "@rotorsoft/act";
 import { Calculator } from "./calculator.js";
 
 describe("calculator lifecycle", () => {

--- a/libs/act/test/close.spec.ts
+++ b/libs/act/test/close.spec.ts
@@ -36,10 +36,10 @@ describe("close", () => {
 
   async function drainAll() {
     await app.correlate();
-    let d;
-    do {
+    let d = await app.drain();
+    while (d.acked.length) {
       d = await app.drain();
-    } while (d.acked.length);
+    }
   }
 
   beforeEach(async () => {

--- a/libs/act/test/digit-board.ts
+++ b/libs/act/test/digit-board.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
-  Actor,
+  type Actor,
   act,
   config,
   InvariantError,

--- a/libs/act/test/event-sourcing.spec.ts
+++ b/libs/act/test/event-sourcing.spec.ts
@@ -3,7 +3,7 @@ import { InMemoryStore } from "../src/adapters/in-memory-store.js";
 import { state } from "../src/builders/state-builder.js";
 import { action, load, snap } from "../src/internal/event-sourcing.js";
 import { dispose, SNAP_EVENT, store } from "../src/ports.js";
-import { Snapshot } from "../src/types/action.js";
+import type { Snapshot } from "../src/types/action.js";
 import { InvariantError } from "../src/types/errors.js";
 import { ZodEmpty } from "../src/types/schemas.js";
 

--- a/packages/calculator/src/main.ts
+++ b/packages/calculator/src/main.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
-  Actor,
+  type Actor,
   act,
   config,
   InvariantError,

--- a/packages/calculator/src/router.ts
+++ b/packages/calculator/src/router.ts
@@ -1,4 +1,4 @@
-import { act, Target } from "@rotorsoft/act";
+import { act, type Target } from "@rotorsoft/act";
 import { initTRPC } from "@trpc/server";
 import { Calculator } from "./calculator.js";
 

--- a/packages/calculator/test/invariants.spec.ts
+++ b/packages/calculator/test/invariants.spec.ts
@@ -1,5 +1,5 @@
 import {
-  Actor,
+  type Actor,
   act,
   dispose,
   InvariantError,

--- a/packages/client/src/trpc.ts
+++ b/packages/client/src/trpc.ts
@@ -1,4 +1,4 @@
-import { type CalculatorRouter } from "@act/calculator";
+import type { CalculatorRouter } from "@act/calculator";
 import { QueryClient } from "@tanstack/react-query";
 import {
   type CreateTRPCReact,

--- a/packages/inspector/src/client/trpc.ts
+++ b/packages/inspector/src/client/trpc.ts
@@ -4,7 +4,7 @@ import {
   createTRPCReact,
   httpLink,
 } from "@trpc/react-query";
-import { type InspectorRouter } from "../server/router.js";
+import type { InspectorRouter } from "../server/router.js";
 
 export const trpc: CreateTRPCReact<InspectorRouter, unknown> =
   createTRPCReact<InspectorRouter>();

--- a/packages/wolfdesk/src/drizzle/schema.ts
+++ b/packages/wolfdesk/src/drizzle/schema.ts
@@ -1,5 +1,5 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { Priority } from "../schemas/index.js";
+import type { Priority } from "../schemas/index.js";
 
 export const tickets = sqliteTable("tickets", {
   id: text("id").primaryKey(),

--- a/packages/wolfdesk/src/jobs.ts
+++ b/packages/wolfdesk/src/jobs.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { Actor } from "@rotorsoft/act";
+import type { Actor } from "@rotorsoft/act";
 import { and, isNull, lt } from "drizzle-orm";
 import { app } from "./bootstrap.js";
 import { db, tickets } from "./drizzle/index.js";

--- a/packages/wolfdesk/src/main.ts
+++ b/packages/wolfdesk/src/main.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { Actor, Committed, Schemas, sleep, store } from "@rotorsoft/act";
+import {
+  type Actor,
+  type Committed,
+  type Schemas,
+  sleep,
+  store,
+} from "@rotorsoft/act";
 import { PostgresStore } from "@rotorsoft/act-pg";
 import { Chance } from "chance";
 import { app } from "./bootstrap.js";

--- a/packages/wolfdesk/src/services/agent.ts
+++ b/packages/wolfdesk/src/services/agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { Priority } from "../schemas/index.js";
+import type { Priority } from "../schemas/index.js";
 
 export type AvailableAgent = {
   agentId: string;

--- a/packages/wolfdesk/src/services/notification.ts
+++ b/packages/wolfdesk/src/services/notification.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import { Message } from "../schemas/index.js";
+import type { z } from "zod";
+import type { Message } from "../schemas/index.js";
 
 export const deliverMessage = (
   message: z.infer<typeof Message>

--- a/packages/wolfdesk/src/ticket-invariants.ts
+++ b/packages/wolfdesk/src/ticket-invariants.ts
@@ -1,4 +1,4 @@
-import { type Invariant } from "@rotorsoft/act";
+import type { Invariant } from "@rotorsoft/act";
 
 export const mustBeOpen: Invariant<{
   productId: string;

--- a/packages/wolfdesk/test/actions.ts
+++ b/packages/wolfdesk/test/actions.ts
@@ -1,4 +1,4 @@
-import { type Target } from "@rotorsoft/act";
+import type { Target } from "@rotorsoft/act";
 import { Chance } from "chance";
 import { app } from "../src/bootstrap.js";
 import { Priority } from "../src/schemas/index.js";

--- a/performance/act-performance/src/index.ts
+++ b/performance/act-performance/src/index.ts
@@ -11,7 +11,7 @@ import { create as memProjector } from "./mem-projector";
 import { create as pgProjector } from "./pg-projector";
 import { updateStats } from "./stats";
 import { Todo } from "./todo";
-import { LoadTestOptions } from "./types";
+import type { LoadTestOptions } from "./types";
 
 // maps a todo-UUID stream to a bucket of N+1 streams
 function target(stream: string, N: number) {

--- a/performance/act-performance/src/mem-projector.ts
+++ b/performance/act-performance/src/mem-projector.ts
@@ -3,7 +3,7 @@
  * Updated by event handlers.
  */
 import { type CommittedOf, sleep, store } from "@rotorsoft/act";
-import { Events, TodoState } from "./todo";
+import type { Events, TodoState } from "./todo";
 
 export function create() {
   const todos = new Map<string, TodoState>();

--- a/performance/act-performance/src/pg-projector.ts
+++ b/performance/act-performance/src/pg-projector.ts
@@ -4,7 +4,7 @@
  */
 import { type CommittedOf, sleep } from "@rotorsoft/act";
 import { Pool } from "pg";
-import { Events } from "./todo";
+import type { Events } from "./todo";
 
 export function create(connectionString?: string) {
   const pool = new Pool({

--- a/performance/act-performance/src/server.ts
+++ b/performance/act-performance/src/server.ts
@@ -3,7 +3,7 @@ import { act, type Committed, type Schemas, store } from "@rotorsoft/act";
 import { PostgresStore } from "@rotorsoft/act-pg";
 import express from "express";
 import { create as pgProjector } from "./pg-projector.js";
-import { ConvergenceState, updateStats } from "./stats.js";
+import { type ConvergenceState, updateStats } from "./stats.js";
 import { Todo } from "./todo.js";
 
 const PORT = Number(process.env.PORT) || 3000;

--- a/performance/act-performance/src/stats.ts
+++ b/performance/act-performance/src/stats.ts
@@ -1,4 +1,4 @@
-import { Drain, Schemas } from "@rotorsoft/act";
+import type { Drain, Schemas } from "@rotorsoft/act";
 import Table from "cli-table3";
 
 export interface ConvergenceState {

--- a/performance/act-performance/src/types.ts
+++ b/performance/act-performance/src/types.ts
@@ -1,5 +1,5 @@
-import { CommittedOf } from "@rotorsoft/act";
-import { Events, TodoState } from "./todo";
+import type { CommittedOf } from "@rotorsoft/act";
+import type { Events, TodoState } from "./todo";
 
 export type LoadTestOptions = {
   maxEvents: number;


### PR DESCRIPTION
## Summary
- Tighten Biome's lint config for a typed, immutable, published framework: enable `useImportType`, `noParameterAssign`, `noConsole`, `noImplicitAnyLet`, and `noAccumulatingSpread` (warn).
- Add a path-scoped override that keeps `noConsole` off where console output is appropriate: tests, scripts, benches, example apps under `packages/**`, perf code under `performance/**`, and CLI/server bootstraps under `libs/act-diagram/src/server/**`.
- Apply Biome's safe autofixes (mostly `useImportType` rewrites across 34 files) and a handful of manual fixes for the remaining violations.

## Notable manual fixes
- `libs/act/src/internal/correlate-cycle.ts` — `startPolling` no longer routes polling errors to `console.error`; it now calls `log().error(err)` so failures land in the configured logger.
- `libs/act/src/internal/event-sourcing.ts` — stop reassigning the `payload` parameter; introduce a local `validated` const and use it through the function.
- `libs/act-diagram/src/client/lib/{build-model,evaluate,sort}.ts` and three test files — annotate `let` declarations so `noImplicitAnyLet` passes without behavioral change.

## Test plan
- [x] `pnpm exec biome check` — clean (0 errors)
- [x] `pnpm typecheck` — passes
- [x] `pnpm exec vitest run libs/act libs/act-sqlite` — 943 passed (PG tests need a live DB; not run locally)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)