### PR TITLE
docs: add READMEs for calculator, wolfdesk, server, client

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "simple-git-hooks",
     "dev:calculator": "pnpm -F calculator dev",
     "dev:wolfdesk": "pnpm -F wolfdesk dev",
-    "dev:trpc": "npx concurrently -n 'server,client' -c 'cyan,yellow' 'pnpm -F server dev' 'pnpm -F client dev'",
+    "dev:trpc": "npx concurrently -n 'server,client' -c 'cyan,yellow' 'CORS_ORIGIN=http://localhost:3000 pnpm -F server dev' 'pnpm -F client dev'",
     "dev:inspector": "pnpm -F @rotorsoft/act-inspector dev",
     "dev:diagram": "pnpm -F @rotorsoft/act-diagram dev",
     "scrub": "chmod +x ./scripts/scrub.sh && ./scripts/scrub.sh"

--- a/packages/calculator/README.md
+++ b/packages/calculator/README.md
@@ -1,0 +1,194 @@
+# @act/calculator
+
+A minimal Act example — a calculator state machine built around a single aggregate, plus standalone demos for projection rebuild and close-the-books.
+
+> Workspace package, not published. Run via `pnpm dev:calculator` from the monorepo root.
+
+## What it demonstrates
+
+- A focused state machine with custom event reducers
+- Multiple events emitted from a single action
+- Invariants that gate actions (e.g. `Clear` only works on a "dirty" calculator)
+- Snapshotting (`.snap((s) => s.patches > 12)`)
+- Reactions across streams — digit presses on calculators `A`/`B` aggregate into a shared `Board` projection state, and operator presses fan out to per-calculator result streams
+- Source-regex resolvers (`source: "^(A|B)$"`) and dynamic resolvers (`(e) => ({ source: e.stream, target: "Calculator" + e.stream })`)
+- Auto-correlation: reaction handlers call `app.do(...)` without an explicit `reactingTo` — the framework injects the triggering event automatically
+- A tRPC router exposing `PressKey` / `Clear` for the React client to consume
+
+## Quickstart
+
+```bash
+# From the monorepo root
+pnpm install
+
+# Run the calculator demo loop (random key presses across two streams)
+pnpm dev:calculator
+
+# Or the standalone demos:
+pnpm -F calculator dev:rebuild   # projection rebuild
+pnpm -F calculator dev:close     # close-the-books
+```
+
+The default demo (`pnpm dev:calculator` → `src/main.ts`) loops random `PressKey` actions across streams `A` and `B` until any digit on the `Board` aggregate has been pressed more than 3 times, then prints the final state and full event log.
+
+## Layout
+
+```
+packages/calculator/
+├── src/
+│   ├── calculator.ts      # Calculator state — events, patches, actions, invariants
+│   ├── main.ts            # Demo loop with reactions to a Board + per-stream result projection
+│   ├── rebuild-demo.ts    # Demonstrates app.reset() + drain for projection rebuild
+│   ├── close-demo.ts      # Demonstrates app.close() — archive, tombstone, restart
+│   ├── router.ts          # tRPC router exposing PressKey + Clear
+│   └── index.ts           # Re-exports calculator + router
+└── test/
+    └── invariants.spec.ts # Invariant + validation error coverage
+```
+
+## The Calculator state
+
+A single state with five events and two actions:
+
+| Event             | Reducer                                                  |
+|-------------------|----------------------------------------------------------|
+| `DigitPressed`    | Append the digit to `left` (or `right` if there's an op) |
+| `OperatorPressed` | If both operands present, compute and store result       |
+| `DotPressed`      | Append `.` if not already present in current operand     |
+| `EqualsPressed`   | Compute pending operation                                |
+| `Cleared`         | Reset to `{ result: 0 }`                                 |
+
+| Action     | Schema                       | Notes                                                   |
+|------------|------------------------------|---------------------------------------------------------|
+| `PressKey` | `{ key: digit \| op \| symbol }` | Routes to one of `DigitPressed` / `OperatorPressed` / `DotPressed` / `EqualsPressed` — can emit multiple events |
+| `Clear`    | empty                         | Guarded by `Must be dirty` invariant                    |
+
+Snapshot after every 12 patches:
+
+```ts
+.snap((s) => s.patches > 12)
+```
+
+## Reactions in `main.ts`
+
+Two inline reactions wire the single `Calculator` aggregate into wider workflows:
+
+```ts
+const app = act()
+  .withState(Calculator)
+  .withState(DigitBoard)
+  .withState(CalculatorResult)
+
+  .on("DigitPressed")
+  .do(async (event) => {
+    await app.do("CountDigit", { stream: "Board", actor }, { digit: event.data.digit });
+  })
+  .to({ source: `^(${streams.join("|")})$`, target: "Board" })
+
+  .on("OperatorPressed")
+  .do(async (event) => {
+    const calc = await app.load(Calculator, event.stream);
+    await app.do(
+      "ProjectResult",
+      { stream: "Calculator" + event.stream, actor },
+      { result: calc.state.result }
+    );
+  })
+  .to((e) => ({ source: e.stream, target: "Calculator" + e.stream }))
+  .build();
+```
+
+- The `DigitPressed` reaction uses a **static** target (`"Board"`) with a source regex — the framework subscribes the target stream once at boot.
+- The `OperatorPressed` reaction uses a **dynamic** target — Act re-correlates on each scan to discover new `Calculator{stream}` targets.
+- Neither `app.do(...)` call passes `reactingTo` explicitly — the triggering event is auto-injected so causation chains stay intact.
+
+## tRPC router (`src/router.ts`)
+
+Single shared `calculator` stream, used by `packages/server` and `packages/client`:
+
+```ts
+const target = { stream: "calculator", actor: { id: "1", name: "Calculator" } };
+
+export const calculatorRouter = t.router({
+  PressKey: t.procedure
+    .input(Calculator.actions.PressKey)
+    .mutation(({ input }) => app.do("PressKey", target, input)),
+  Clear: t.procedure.mutation(() => app.do("Clear", target, {})),
+});
+
+export type CalculatorRouter = typeof calculatorRouter;
+```
+
+`Calculator.actions.PressKey` is the original Zod schema, used directly as tRPC input validation — no duplication.
+
+## Standalone demos
+
+### Projection rebuild — `dev:rebuild`
+
+`src/rebuild-demo.ts` builds a `Counter` state with a `SumProjection`, emits five `Incremented` events, drains them, then resets the projection watermark and re-drains:
+
+```ts
+const resetCount = await app.reset(["sum-proj"]);
+await app.drain({ eventLimit: 100 });
+```
+
+`app.reset(["sum-proj"])` resets the watermark **and** arms the orchestrator's internal `_needs_drain` flag — calling `store().reset(...)` directly would not. The demo verifies the rebuilt sum matches the live state after each rebuild.
+
+### Close-the-books — `dev:close`
+
+`src/close-demo.ts` shows the full close lifecycle:
+
+1. Emit events across `counter-A`, `counter-B`, `counter-C`
+2. Close `counter-A` (archived) and `counter-B` (tombstoned, no archive callback)
+3. Verify writes to a tombstoned stream throw `StreamClosedError`
+4. Close `counter-C` with `restart: true` — emits a `__snapshot__` of the final state as the only remaining event
+5. Show idempotency: closing an already-tombstoned stream is a no-op
+
+```ts
+const result = await app.close([
+  {
+    stream: "counter-A",
+    archive: async () => {
+      const events = await app.query_array({
+        stream: "counter-A",
+        stream_exact: true,
+        with_snaps: true,
+      });
+      // ship to S3, etc.
+    },
+  },
+  { stream: "counter-B" },
+  { stream: "counter-C", restart: true, archive: async () => { /* ... */ } },
+]);
+```
+
+## Tests
+
+`test/invariants.spec.ts` covers:
+
+- Invariant violation (`Clear` on a clean calculator) → `InvariantError`
+- Schema violation (numeric key) → `ValidationError`
+- Custom emit-time error (`=` with no operator) → throws `"no operator"`
+- Missing target stream → throws `"Missing target stream"`
+
+Run with `pnpm test` from the root, or `pnpm -F calculator test` for this package only.
+
+## Switching to PostgreSQL
+
+`src/main.ts` ships configured for the default `InMemoryStore`. To run against PostgreSQL, uncomment the lines at the top of `main()`:
+
+```ts
+import { store } from "@rotorsoft/act";
+import { PostgresStore } from "@rotorsoft/act-pg";
+
+store(new PostgresStore({ schema: "act", table: "calculator", leaseMillis: 30_000 }));
+await store().drop();
+await store().seed();
+```
+
+## Related
+
+- [`@rotorsoft/act`](../../libs/act) — core framework
+- [`@act/server`](../server) — tRPC HTTP server that hosts `calculatorRouter`
+- [`@act/client`](../client) — React UI that calls `PressKey` / `Clear`
+- [`@act/wolfdesk`](../wolfdesk) — larger example with multiple slices and a SQLite read model

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,95 @@
+# client
+
+A minimal React + Vite + tRPC client for the calculator example. Demonstrates how to call an Act-backed tRPC router from a browser with full end-to-end type safety.
+
+> Workspace package, not published. Run via `pnpm dev:trpc` from the monorepo root (boots both server and client).
+
+## What it does
+
+- Renders a 4×5 calculator keypad
+- Calls `PressKey` / `Clear` mutations on the server-hosted `calculatorRouter`
+- Displays the latest snapshot returned from each mutation (`{ left, operator, right }`)
+- Reuses **types from the calculator package** (`Digits`, `Operators`, `CalculatorRouter`) — no duplicated schemas, no codegen
+
+## Quickstart
+
+```bash
+# From the monorepo root — runs server (4000) and client (3000) concurrently
+pnpm dev:trpc
+
+# Or just the client
+pnpm -F client dev
+```
+
+The Vite dev server listens on port `3000` (`vite.config.ts`). Open [http://localhost:3000](http://localhost:3000).
+
+The client expects the tRPC server at `http://localhost:4000` (hard-coded in `src/trpc.ts`). The root `dev:trpc` script sets the matching `CORS_ORIGIN` on the server automatically — when running the server standalone, set `CORS_ORIGIN=http://localhost:3000` yourself.
+
+## Layout
+
+```
+packages/client/
+├── index.html             # Vite entry HTML
+├── vite.config.ts         # port 3000, react plugin
+├── src/
+│   ├── main.tsx           # Mounts <App />
+│   ├── App.tsx            # Wraps Calculator in trpc.Provider + QueryClientProvider
+│   ├── Calculator.tsx     # Keypad UI + useMutation hooks
+│   ├── trpc.ts            # createTRPCReact<CalculatorRouter>() + httpLink
+│   ├── App.css, index.css # Styles
+│   └── assets/            # Static assets
+└── public/                # Public assets (favicon, etc.)
+```
+
+## How the type chain works
+
+1. **Calculator state** (`@act/calculator/src/calculator.ts`) defines actions and events using Zod schemas
+2. **Router** (`@act/calculator/src/router.ts`) wraps those Zod schemas as tRPC procedures and exports `CalculatorRouter`
+3. **Server** (`@act/server`) hosts that router on `http://localhost:4000`
+4. **Client** imports `CalculatorRouter` as a type and feeds it to `createTRPCReact<CalculatorRouter>()`:
+
+```ts
+// src/trpc.ts
+import type { CalculatorRouter } from "@act/calculator";
+import { createTRPCReact, httpLink } from "@trpc/react-query";
+
+export const trpc = createTRPCReact<CalculatorRouter>();
+export const queryClient = new QueryClient({});
+export const client = trpc.createClient({
+  links: [httpLink({ url: "http://localhost:4000" })],
+});
+```
+
+5. The component uses fully-typed mutation hooks:
+
+```tsx
+// src/Calculator.tsx
+import type { Digits, Operators } from "@act/calculator";
+
+const pressKey = trpc.PressKey.useMutation({
+  onSuccess: ([snap]) => {
+    setDisplay(`${snap.state.left ?? "0"} ${snap.state.operator ?? ""} ${snap.state.right ?? ""}`);
+  },
+});
+
+const clear = trpc.Clear.useMutation({
+  onSuccess: () => setDisplay("0"),
+});
+
+// inside the keypad map:
+pressKey.mutate({ key: key as Digits | Operators });
+```
+
+`snap.state` is typed by the Zod state schema all the way through — change the calculator's state shape in `@act/calculator` and TypeScript will flag mismatches in the client immediately, no codegen step.
+
+## Notes
+
+- All mutations target the single shared stream `calculator` (configured in the router). The UI shows the latest snapshot rather than tracking per-user streams.
+- React Query is wired with the default `QueryClient` — no caching strategy beyond the defaults.
+- Devtools are installed (`@tanstack/react-query-devtools`) but not mounted by default.
+
+## Related
+
+- [`@act/calculator`](../calculator) — defines the state machine, router, and exported types
+- [`@act/server`](../server) — tRPC HTTP server the client connects to
+- [tRPC + React Query docs](https://trpc.io/docs/client/react)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,84 @@
+# server
+
+A minimal tRPC HTTP server that hosts the calculator router from `@act/calculator`. Pairs with `@act/client` to demonstrate end-to-end Act → tRPC → React.
+
+> Workspace package, not published. Run via `pnpm dev:trpc` from the monorepo root (which boots both server and client).
+
+## What it does
+
+- Imports `calculatorRouter` from `@act/calculator` — Zod schemas from the Calculator state are reused as tRPC input validators
+- Wraps it with the standalone tRPC HTTP adapter
+- Adds CORS so the Vite client (different origin) can call it
+- Listens on port `4000`
+
+That's it — twelve lines of glue. The interesting code lives in [`@act/calculator`](../calculator).
+
+## Quickstart
+
+```bash
+# From the monorepo root — runs server (4000) and client (3000) concurrently
+pnpm dev:trpc
+
+# Or just the server
+pnpm -F server dev
+```
+
+`dev` runs `tsx watch src/server.ts`, so edits to the calculator package or the server itself reload automatically.
+
+## Source
+
+```ts
+// src/server.ts
+import { calculatorRouter } from "@act/calculator";
+import { createHTTPServer } from "@trpc/server/adapters/standalone";
+import cors from "cors";
+
+const server = createHTTPServer({
+  middleware: cors({
+    origin: process.env.CORS_ORIGIN || "http://localhost:5173",
+  }),
+  router: calculatorRouter,
+});
+server.listen(4000, () => {});
+```
+
+## Configuration
+
+| Env var       | Default                  | Purpose                          |
+|---------------|--------------------------|----------------------------------|
+| `CORS_ORIGIN` | `http://localhost:5173`  | Allowed origin for CORS requests |
+
+The root `pnpm dev:trpc` script sets `CORS_ORIGIN=http://localhost:3000` for you (matching the Vite client in `packages/client/vite.config.ts`). When running `pnpm -F server dev` standalone against a client on a different origin, set `CORS_ORIGIN` accordingly.
+
+## Procedures
+
+Inherited from `calculatorRouter`:
+
+| Procedure   | Type     | Input                          | Effect                              |
+|-------------|----------|--------------------------------|-------------------------------------|
+| `PressKey`  | mutation | `{ key: digit \| operator \| symbol }` | Dispatches `PressKey` to stream `calculator` |
+| `Clear`     | mutation | none                           | Dispatches `Clear` to stream `calculator`    |
+
+The router is exported as `CalculatorRouter` and consumed by `@act/client` to build a fully type-safe tRPC client — no schema duplication.
+
+## Switching to PostgreSQL
+
+The router (in `@act/calculator/src/router.ts`) builds its `act()` app with the default `InMemoryStore`. For a persistent server, inject a `PostgresStore` before importing the router, e.g. in a small bootstrap module:
+
+```ts
+import { store } from "@rotorsoft/act";
+import { PostgresStore } from "@rotorsoft/act-pg";
+
+store(new PostgresStore({ schema: "act", table: "calculator" }));
+
+// then…
+import { calculatorRouter } from "@act/calculator";
+```
+
+`store()` is a singleton accessor — set it once at startup and the router's app picks it up.
+
+## Related
+
+- [`@act/calculator`](../calculator) — defines `calculatorRouter` and the underlying state machine
+- [`@act/client`](../client) — React + tRPC client that calls `PressKey` / `Clear`
+- [tRPC standalone adapter docs](https://trpc.io/docs/server/adapters/standalone)

--- a/packages/wolfdesk/README.md
+++ b/packages/wolfdesk/README.md
@@ -1,0 +1,164 @@
+# @act/wolfdesk
+
+A larger Act example — a help-desk ticketing system adapted from *Learning Domain-Driven Design* (Vlad Khononov). Wolfdesk shows how to compose a single aggregate from multiple **partial states** and **slices** (vertical slice architecture), with a Drizzle/SQLite read model, periodic background jobs, and a PostgreSQL event store.
+
+> Workspace package, not published. Run via `pnpm dev:wolfdesk` from the monorepo root.
+
+## What it demonstrates
+
+- **One aggregate, three slices** — `Ticket` is built from three partial states (creation, messaging, operations), each owning its own actions, events, patches, and reactions
+- **Slice merging** — different slices register patches for shared events; conflicts are detected at build time
+- **Per-slice reactions**:
+  - `TicketCreationSlice` — on `TicketOpened`, auto-assigns an agent
+  - `TicketMessagingSlice` — on `MessageAdded`, calls `deliverMessage()` then dispatches `MarkMessageDelivered`
+  - `TicketOpsSlice` — on `TicketEscalationRequested`, dispatches `EscalateTicket`
+- **Standalone projection** — `TicketProjection` writes a denormalized read model into a Drizzle/SQLite `tickets` table
+- **Background jobs** — `AutoEscalate`, `AutoClose`, `AutoReassign` query the read model on intervals and dispatch corresponding actions
+- **Invariants shared across slices** — `mustBeOpen`, `mustBeUser`, `mustBeUserOrAgent`
+- **Correlation tracing** — the demo prints causation chains across reactions
+- **PostgreSQL event store** — uses `@rotorsoft/act-pg` for events, SQLite (libSQL via Drizzle) for the read model
+
+## Quickstart
+
+```bash
+# Boot Postgres for the event store (from the monorepo root, if a docker-compose.yml is provided)
+docker-compose up -d
+
+# Generate + run the SQLite migration for the read model and start the demo
+pnpm dev:wolfdesk
+```
+
+The `dev` script runs migrations first, then `tsx watch src/main.ts`. The demo:
+
+1. Resets the `act.wolfdesk` Postgres event store and the SQLite `tickets` table
+2. Starts the periodic jobs (escalate / close / reassign) and the correlation pump
+3. Opens a ticket, assigns an agent, adds two messages
+4. Prints the projection table after every drain (`app.on("acked", ...)`)
+5. Finally prints all events for the ticket grouped by correlation ID, indented by causation depth
+
+## Layout
+
+```
+packages/wolfdesk/
+├── src/
+│   ├── ticket.ts                # Re-exports the three slices, invariants, and projection
+│   ├── ticket-creation.ts       # TicketCreation partial + TicketCreationSlice (Open / Close / Resolve + auto-assign reaction)
+│   ├── ticket-messaging.ts      # TicketMessaging partial + TicketMessagingSlice (Add/Deliver/Ack + delivery reaction)
+│   ├── ticket-operations.ts     # TicketOperations partial + TicketOpsSlice (Assign / Escalate / Reassign + escalate reaction)
+│   ├── ticket-invariants.ts     # mustBeOpen, mustBeUser, mustBeUserOrAgent
+│   ├── ticket-projections.ts    # TicketProjection — Drizzle/SQLite read model updater
+│   ├── bootstrap.ts             # Composes act() with the three slices + the projection
+│   ├── jobs.ts                  # AutoEscalate / AutoClose / AutoReassign timers
+│   ├── errors.ts                # Domain errors
+│   ├── main.ts                  # Demo entrypoint
+│   ├── schemas/                 # Zod schemas (events, actions, partial state shapes)
+│   ├── services/                # External integrations (agent assignment, notifications)
+│   └── drizzle/                 # SQLite schema + migrations + db client
+├── drizzle.config.ts            # drizzle-kit config (sqlite, file:local.db)
+└── test/
+    ├── actions.ts               # Helpers for action dispatch in tests
+    ├── ticket.spec.ts           # Single-ticket happy paths
+    ├── tickets.spec.ts          # Multi-ticket scenarios + projection asserts + jobs
+    └── invariants.spec.ts       # Invariant + error coverage
+```
+
+## Vertical slice architecture
+
+A single `Ticket` aggregate is composed from three partial states that share a stream. Each slice owns its own actions, events, patches, and reactions:
+
+```ts
+// bootstrap.ts
+export const app = act()
+  .withSlice(TicketCreationSlice)   // TicketOpened, TicketClosed, TicketResolved
+  .withSlice(TicketMessagingSlice)  // MessageAdded, MessageDelivered, MessageRead
+  .withSlice(TicketOpsSlice)        // TicketAssigned, TicketEscalationRequested, TicketEscalated, TicketReassigned
+  .withProjection(TicketProjection) // Standalone — listens across all three slices
+  .build();
+```
+
+The framework merges the partials at build time. Each event is written by exactly one slice (the one that owns its custom patch) — re-declared events from sibling slices use the passthrough default and yield to the owning patch. Conflicting patches for the same event throw at build.
+
+### Per-slice reactions
+
+| Slice                 | Trigger                       | Reaction                                                |
+|-----------------------|-------------------------------|---------------------------------------------------------|
+| `TicketCreationSlice` | `TicketOpened`                | `assignAgent(...)` → `app.do("AssignTicket", ...)`      |
+| `TicketMessagingSlice`| `MessageAdded`                | `deliverMessage(...)` → `app.do("MarkMessageDelivered", ...)` |
+| `TicketOpsSlice`      | `TicketEscalationRequested`   | `app.do("EscalateTicket", ...)`                         |
+
+Each reaction dispatches a follow-up action on the same ticket stream. None pass `reactingTo` explicitly — the framework injects the triggering event automatically, so the projection (and the demo's correlation print-out) sees a clean causation chain.
+
+## Read model — `TicketProjection`
+
+A standalone projection (registered at the `act()` level, not embedded in any slice) keeps a denormalized `tickets` row up to date:
+
+```ts
+export const TicketProjection = projection("tickets")
+  .on({ TicketOpened }).do(async ({ stream, data }) => { /* insert */ })
+  .on({ MessageAdded }).do(async ({ stream }) => { /* messages += 1 */ })
+  .on({ TicketAssigned }).do(async ({ stream, data }) => { /* update */ })
+  .on({ TicketEscalated }).do(...)
+  .on({ TicketReassigned }).do(...)
+  .on({ TicketClosed }).do(...)
+  .on({ TicketResolved }).do(...)
+  .build();
+```
+
+The read model lives in SQLite (libSQL via Drizzle):
+
+| Column                 | Type    | Source event                              |
+|------------------------|---------|-------------------------------------------|
+| `id` (pk)              | text    | stream id                                 |
+| `product_id`, `support_category_id`, `priority`, `title`, `user_id` | text | `TicketOpened` |
+| `messages`             | int     | incremented on `MessageAdded`             |
+| `agent_id`             | text    | `TicketAssigned` / `TicketReassigned`     |
+| `escalation_id`        | text    | `TicketEscalated`                         |
+| `resolved_by_id`, `closed_by_id` | text | `TicketResolved` / `TicketClosed`     |
+| `reassign_after`, `escalate_after`, `close_after` | int (epoch ms) | written by assigns / opens |
+
+## Periodic jobs
+
+`src/jobs.ts` defines three timers that drive the ticket lifecycle from the read model:
+
+| Job              | Interval | Query                                                   | Action            |
+|------------------|----------|---------------------------------------------------------|-------------------|
+| `AutoEscalate`   | 10s      | `escalate_after < now()`                                | `EscalateTicket`  |
+| `AutoReassign`   | 10s      | `closed_by_id IS NULL AND reassign_after < now()`       | `ReassignTicket`  |
+| `AutoClose`      | 15s      | `close_after < now()`                                   | `CloseTicket`     |
+
+Each timer reads from the SQLite projection (cheap) and dispatches actions to the Postgres-backed aggregate.
+
+## Database setup
+
+### Event store — PostgreSQL
+
+`src/main.ts` configures `PostgresStore({ port: 5431, schema: "act", table: "wolfdesk" })`. Boot a Postgres on port 5431 (the project's `docker-compose.yml`, if present) before running the demo. The event store table is `act.wolfdesk`.
+
+### Read model — SQLite
+
+The `tickets` table lives in `packages/wolfdesk/local.db` (libSQL). Drizzle Kit manages migrations:
+
+```bash
+pnpm -F wolfdesk drizzle:migrate    # generate + apply migrations (also runs as part of `dev`)
+pnpm -F wolfdesk drizzle:push       # push schema directly without a migration
+pnpm -F wolfdesk drizzle:studio     # open Drizzle Studio against local.db
+```
+
+## Tests
+
+```bash
+pnpm -F wolfdesk test
+```
+
+- `ticket.spec.ts` — single ticket open/assign/message/close happy path
+- `tickets.spec.ts` — multi-ticket flows, projection assertions, and job-driven escalation/reassignment/close
+- `invariants.spec.ts` — invariant violations and domain errors
+
+Tests use the InMemoryStore for events and a freshly initialized SQLite file for the projection (`init_tickets_db()` in `beforeAll`).
+
+## Related
+
+- [`@rotorsoft/act`](../../libs/act) — core framework (slices, projections, invariants)
+- [`@rotorsoft/act-pg`](../../libs/act-pg) — PostgreSQL event store adapter
+- [`@act/calculator`](../calculator) — single-aggregate, simpler example
+- [Learning Domain-Driven Design](https://www.oreilly.com/library/view/learning-domain-driven-design/9781098100124/) — the Wolfdesk case study Vlad Khononov uses to teach DDD strategic and tactical patterns


### PR DESCRIPTION
## Summary

- Add comprehensive READMEs to the four example packages that were missing them: `calculator`, `wolfdesk`, `server`, `client`. Each covers what the package demonstrates, its layout, and how it connects to the rest of the framework.
- Fix `dev:trpc` in the root `package.json` to set `CORS_ORIGIN=http://localhost:3000`, matching the Vite client's port. Without this the server's default CORS origin (`5173`) blocks all requests from the client.

## Test plan

- [ ] `pnpm dev:trpc` starts both server and client, and the client at http://localhost:3000 can call `PressKey` / `Clear` without CORS errors
- [ ] `pnpm dev:calculator`, `pnpm -F calculator dev:rebuild`, and `pnpm -F calculator dev:close` all run as described in `packages/calculator/README.md`
- [ ] `pnpm dev:wolfdesk` flow matches the description in `packages/wolfdesk/README.md` (with Postgres on port 5431)
- [ ] All four READMEs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)