### PR TITLE
fix(builders): split .emit() overloads + zod as peer dep

### DIFF
--- a/libs/act-diagram/package.json
+++ b/libs/act-diagram/package.json
@@ -41,12 +41,12 @@
   },
   "dependencies": {
     "lucide-react": "^0.577.0",
-    "sucrase": "^3.35.1",
-    "zod": "^4.4.3"
+    "sucrase": "^3.35.1"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.92.0",

--- a/libs/act-pg/package.json
+++ b/libs/act-pg/package.json
@@ -37,11 +37,11 @@
     "stress": "tsx test/stress/runner.ts"
   },
   "dependencies": {
-    "pg": "^8.20.0",
-    "zod": "^4.4.3"
+    "pg": "^8.20.0"
   },
   "peerDependencies": {
-    "@rotorsoft/act": ">=0.31.1"
+    "@rotorsoft/act": ">=0.31.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/pg": "^8.20.0"

--- a/libs/act-sqlite/package.json
+++ b/libs/act-sqlite/package.json
@@ -36,10 +36,10 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "dependencies": {
-    "@libsql/client": "^0.17.3",
-    "zod": "^4.4.3"
+    "@libsql/client": "^0.17.3"
   },
   "peerDependencies": {
-    "@rotorsoft/act": ">=0.31.1"
+    "@rotorsoft/act": ">=0.31.1",
+    "zod": "^4.4.3"
   }
 }

--- a/libs/act/package.json
+++ b/libs/act/package.json
@@ -44,7 +44,9 @@
     "bench:realistic": "NODE_ENV=test LOG_LEVEL=fatal tsx scripts/realistic-bench.ts > realistic-result.json"
   },
   "dependencies": {
-    "@rotorsoft/act-patch": "workspace:^",
+    "@rotorsoft/act-patch": "workspace:^"
+  },
+  "peerDependencies": {
     "zod": "^4.4.3"
   }
 }

--- a/libs/act/src/builders/state-builder.ts
+++ b/libs/act/src/builders/state-builder.ts
@@ -227,29 +227,48 @@ export type ActionBuilder<
        * .emit("TicketAssigned")
        * ```
        */
-      emit: (
-        handler:
-          | ActionHandler<TState, TEvents, { [P in TKey]: TNewActions }, TKey>
-          | (keyof TEvents & string)
-      ) => ActionBuilder<
-        TState,
-        TEvents,
-        TActions & { [P in TKey]: TNewActions },
-        TName
-      >;
+      emit: {
+        /** Custom handler — receives `(action, snapshot)` and returns one
+         *  or more `[EventName, data]` tuples (or `undefined`). */
+        (
+          handler: ActionHandler<
+            TState,
+            TEvents,
+            { [P in TKey]: TNewActions },
+            TKey
+          >
+        ): ActionBuilder<
+          TState,
+          TEvents,
+          TActions & { [P in TKey]: TNewActions },
+          TName
+        >;
+        /** Passthrough — the action payload becomes the event data
+         *  directly. Must reference an event declared in `.emits()`. */
+        (
+          eventName: keyof TEvents & string
+        ): ActionBuilder<
+          TState,
+          TEvents,
+          TActions & { [P in TKey]: TNewActions },
+          TName
+        >;
+      };
     };
     /**
-     * Defines the action handler that emits events.
+     * Defines the action handler that emits events. Same two overloads as
+     * the post-`.given()` form above:
      *
-     * The handler receives the action payload and current state snapshot,
-     * and must return one or more events to emit. Return a single event as
-     * `["EventName", data]` or multiple events as an array of event tuples.
+     * - **Function** — receives `(action, snapshot)` and returns one or
+     *   more `[EventName, data]` tuples (or `undefined`).
+     * - **String** — passthrough: the action payload becomes the event
+     *   data directly. Must reference an event declared in `.emits()`.
      *
-     * Pass a string event name for passthrough: the action payload becomes
-     * the event data directly.
-     *
-     * @param handler - Function that returns events to emit, or event name string for passthrough
-     * @returns The ActionBuilder for chaining more actions
+     * The two overloads are kept separate (rather than merged into a
+     * `handler | string` union) so that TS contextual typing of the
+     * function alternative isn't degraded by considering the string
+     * branch — under the union form `TState` could collapse to its
+     * `Schema` constraint inside the callback.
      *
      * @example Passthrough (action payload = event data)
      * ```typescript
@@ -269,16 +288,29 @@ export type ActionBuilder<
      * ])
      * ```
      */
-    emit: (
-      handler:
-        | ActionHandler<TState, TEvents, { [P in TKey]: TNewActions }, TKey>
-        | (keyof TEvents & string)
-    ) => ActionBuilder<
-      TState,
-      TEvents,
-      TActions & { [P in TKey]: TNewActions },
-      TName
-    >;
+    emit: {
+      (
+        handler: ActionHandler<
+          TState,
+          TEvents,
+          { [P in TKey]: TNewActions },
+          TKey
+        >
+      ): ActionBuilder<
+        TState,
+        TEvents,
+        TActions & { [P in TKey]: TNewActions },
+        TName
+      >;
+      (
+        eventName: keyof TEvents & string
+      ): ActionBuilder<
+        TState,
+        TEvents,
+        TActions & { [P in TKey]: TNewActions },
+        TName
+      >;
+    };
   };
   /**
    * Defines a snapshotting strategy to optimize state reconstruction.

--- a/libs/act/test/builder-type-explosion.spec.ts
+++ b/libs/act/test/builder-type-explosion.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Type-narrowing regressions for the state and projection builders.
+ *
+ * Companion to the `.emit()` overload split: the prior `handler | string`
+ * union signature confused contextual typing on the function alternative,
+ * letting `TState` collapse to its `Schema` constraint inside the callback
+ * (so destructured snapshot fields lost their types). Splitting `.emit()`
+ * into two overloads — function and string — lets TS pick the matching
+ * branch eagerly and keeps callback parameter narrowing sharp.
+ *
+ * The runtime expectations are minor; the value of the file is that it
+ * MUST type-check and that the `@ts-expect-error` directives stay USED
+ * (proving narrowing is real and didn't collapse to `any`).
+ */
+import { delta } from "@rotorsoft/act-patch";
+import { z } from "zod";
+import { projection, state } from "../src/index.js";
+import type { Invariant } from "../src/types/index.js";
+
+// Realistic-shaped Zod schemas: a TS enum fed through `z.enum(...)` plus
+// ~10 fields with mixed required / optional / default modifiers. Smaller
+// schemas don't reproduce the inference degradation even with the same
+// chain shape, so the regression repro keeps the surface honest.
+enum InvoiceSchedule {
+  Weekly = "weekly",
+  Biweekly = "biweekly",
+  Semimonthly = "semimonthly",
+  Monthly = "monthly",
+}
+
+const ClientFields = z.object({
+  name: z.string().min(1),
+  address: z.string().min(1),
+  email: z.string().optional(),
+  contactName: z.string().optional(),
+  hourlyRate: z.number().positive(),
+  paymentTermsDays: z.number().int().default(30),
+  invoiceSchedule: z
+    .enum(InvoiceSchedule)
+    .optional()
+    .default(InvoiceSchedule.Monthly),
+  commuteMiles: z.number().optional(),
+  paymentInstructions: z.string().optional(),
+});
+
+const ClientFieldsPatch = z.object({
+  name: z.string().min(1).optional(),
+  address: z.string().min(1).optional(),
+  email: z.string().optional(),
+  contactName: z.string().optional(),
+  hourlyRate: z.number().positive().optional(),
+  paymentTermsDays: z.number().int().optional(),
+  invoiceSchedule: z.enum(InvoiceSchedule).optional(),
+  commuteMiles: z.number().optional(),
+  paymentInstructions: z.string().optional(),
+});
+
+const RegisterClient = ClientFields;
+const UpdateClient = ClientFieldsPatch;
+const ClientRegistered = ClientFields;
+const ClientUpdated = ClientFieldsPatch;
+
+const ClientState = z.object({
+  slug: z.string(),
+  name: z.string(),
+  address: z.string(),
+  email: z.string().optional(),
+  contactName: z.string().optional(),
+  hourlyRate: z.number(),
+  paymentTermsDays: z.number().int(),
+  invoiceSchedule: z.enum(InvoiceSchedule),
+  active: z.boolean(),
+  commuteMiles: z.number().optional(),
+  paymentInstructions: z.string().optional(),
+});
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+describe("builder type narrowing regressions", () => {
+  // ── Function-style .emit() preserves snapshot narrowing ────────────────
+  // Under the prior `handler | string` union signature, TS could collapse
+  // `snapshot.state` to `Readonly<Schema>` inside the callback, losing all
+  // field types. With the overloads split, the function alternative is
+  // picked eagerly and `s.field` stays narrowed.
+  it(".emit((data, snap) => …) keeps snapshot.state narrowed", () => {
+    const Client = state({ Client: ClientState })
+      .init(() => ({
+        slug: "",
+        name: "",
+        address: "",
+        hourlyRate: 0,
+        paymentTermsDays: 30,
+        invoiceSchedule: InvoiceSchedule.Monthly,
+        active: true,
+      }))
+      .emits({ ClientRegistered, ClientUpdated })
+      .on({ RegisterClient })
+      .emit("ClientRegistered")
+      .on({ UpdateClient })
+      .emit((data, { state: s }) => {
+        const { active: _a, slug: _s, ...current } = s;
+        // Narrowing proof: `current.name` must remain `string`, not `any`.
+        const _name: string = current.name;
+        const target = { ...current, ...data };
+        const patch = delta(current, target);
+        const evt: Partial<typeof current> = {};
+        for (const [k, v] of Object.entries(patch)) {
+          if (v !== null) (evt as Record<string, unknown>)[k] = v;
+        }
+        return ["ClientUpdated", evt];
+      })
+      .build();
+
+    expect(Client.on.RegisterClient).toBeDefined();
+    expect(Client.on.UpdateClient).toBeDefined();
+  });
+
+  // ── Strong narrowing of snapshot.state — sample assertion fails ─────────
+  // If `snapshot.state` ever widens to `any`/`Schema`, both the negative
+  // assertion and the positive one will quietly succeed. Pair them so a
+  // regression is caught either way.
+  it(".emit() callback narrows snapshot.state to TState (not Schema)", () => {
+    state({ Counter: z.object({ count: z.number(), label: z.string() }) })
+      .init(() => ({ count: 0, label: "" }))
+      .emits({ Bumped: z.object({ by: z.number() }) })
+      .on({ bump: z.object({ by: z.number() }) })
+      .emit((action, snap) => {
+        const _count: number = snap.state.count;
+        // @ts-expect-error label is string, not number
+        const _bad: number = snap.state.label;
+        return ["Bumped", { by: action.by + _count }];
+      })
+      .build();
+    expect(true).toBe(true);
+  });
+
+  // ── String-form .emit("EventName") keeps autocomplete + rejection ──────
+  it('.emit("EventName") rejects unknown event names', () => {
+    state({ Counter: z.object({ count: z.number() }) })
+      .init(() => ({ count: 0 }))
+      .emits({ Incremented: z.object({ by: z.number() }) })
+      .on({ inc: z.object({ by: z.number() }) })
+      // @ts-expect-error 'NotAnEvent' isn't in .emits()
+      .emit("NotAnEvent")
+      .build();
+    expect(true).toBe(true);
+  });
+
+  // ── Partial-state Invariant<{slug: string}> still accepted ─────────────
+  // A common pattern: write an invariant against a tiny subset of state
+  // (one field) and pass it where the full state is expected. This is
+  // contravariantly safe and must continue to type-check.
+  it(".given([Invariant<Subset>]) accepts narrower-than-state invariants", () => {
+    const slugMustBeUnused: Invariant<{ slug: string }> = {
+      description: "A client with this slug is already registered",
+      valid: (s) => s.slug === "",
+    };
+
+    const Client = state({ Client: ClientState })
+      .init(() => ({
+        slug: "",
+        name: "",
+        address: "",
+        hourlyRate: 0,
+        paymentTermsDays: 30,
+        invoiceSchedule: InvoiceSchedule.Monthly,
+        active: true,
+      }))
+      .emits({ ClientRegistered, ClientUpdated })
+      .patch({
+        ClientRegistered: ({ data }) => ({
+          ...data,
+          slug: slugify(data.name),
+          active: true,
+        }),
+        ClientUpdated: ({ data }) => ({ ...data }),
+      })
+      .on({ RegisterClient })
+      .given([slugMustBeUnused])
+      .emit("ClientRegistered")
+      .build();
+
+    expect(Client.given?.RegisterClient).toBeDefined();
+  });
+
+  // ── Projection chain over realistic schemas type-checks cleanly ────────
+  // Multi-`.on().do()` over fat schemas was the canonical TS2589 trigger
+  // when coupled with cross-version zod compares. Even with peer-deps
+  // ensuring a single zod, this remains useful as a smoke test.
+  it("projection: chained .on().do() over fat schemas type-checks", () => {
+    const ClientsView = projection("clients_view")
+      .on({ ClientRegistered })
+      .do(async function registered({ stream, data }) {
+        const _id: string = stream;
+        const _name: string = data.name;
+      })
+      .on({ ClientUpdated })
+      .do(async function updated({ stream, data }) {
+        const _id: string = stream;
+        // ClientUpdated.name is optional — narrowing must reflect that.
+        const _maybeName: string | undefined = data.name;
+      })
+      .build();
+
+    expect(ClientsView._tag).toBe("Projection");
+    expect(ClientsView.events.ClientRegistered).toBeDefined();
+    expect(ClientsView.events.ClientUpdated).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two related improvements that close the path that took `tsc` to OOM in real-world consumer projects.

### 1. `.emit(handler | string)` split into two overloads

Under the union signature, TS retried both alternatives during contextual typing of the function arg, and `TState` could collapse to its `Schema` constraint inside the callback (so `snap.state.foo` lost its type and downstream values widened to `Partial<{[x:string]: any}>`). Splitting `.emit()` into a function overload and a string overload lets TS pick the matching branch eagerly — callback parameter narrowing stays sharp.

### 2. `zod` moved from `dependencies` to `peerDependencies`

In `@rotorsoft/act` and `@rotorsoft/act-sqlite`. Conceptually this is the right model: act doesn't use zod runtime values, it accepts schemas the consumer constructs with their own zod, so the consumer's resolved version should be reused.

Practically this also closes a class of TS explosions: when a consumer ended up with two zod minor versions in `node_modules` (older transitive dep alongside a newer direct one), `tsc` would structurally compare zod types across packages — walking `ToJSONSchemaParams`, `JSONSchema`, `$ZodTypes`, and friends — and OOM in extreme cases. With zod as peer, pnpm/npm dedupe to a single copy and the cross-package compare can't happen.

## Repro context

Discovered while debugging a consumer project (konsult) where `pnpm typecheck` OOM'd in ~25s at 8GB heap. Root cause was `node_modules/zod -> .pnpm/zod@4.4.2/...` (locked from `^4.3.6`) alongside `@rotorsoft/act`'s nested `zod@4.4.3`. With this fix, that consumer aligns its zod to the peer range (`^4.4.3`) at install time and `pnpm typecheck` completes in **3.7s**.

## Consumer impact

`pnpm install` will now warn (or error, depending on `auto-install-peers` / `strict-peer-dependencies` settings) if a consumer's resolved zod doesn't satisfy `^4.4.3`. Consumers can either:
- Bump their direct zod dep to match the peer range, OR
- Use `pnpm.overrides` to dedupe zod across the workspace

Either path produces a single deduped zod and a clean type-check.

## Regression coverage

Adds `libs/act/test/builder-type-explosion.spec.ts` exercising the contextual-typing improvement with realistically-sized schemas: function-style `.emit()` returning a tuple after destructuring snapshot state, partial-state `Invariant<{slug: string}>` accepted contravariantly, multi-`.on().do()` projection over fat schemas. The `@ts-expect-error` directives (e.g. `_bad: number = snap.state.label` where label is string) fire only if narrowing collapses, catching any future regression of the inference improvement.

## Test plan

- [x] `pnpm typecheck` clean across the monorepo
- [x] All 408 vitest specs pass in `libs/act`
- [x] `pnpm build` clean
- [x] Verified against external consumer (konsult): `pnpm typecheck` 25s OOM → 3.7s clean once zod is aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)