### PR TITLE
ci(speedup): build once + coverage in summary + skip unchanged-lib releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,31 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm test
 
+      # Render the v8 coverage summary as a markdown table in the PR/run
+      # summary. `json-summary` reporter is enabled in vite.config.ts.
+      - name: Coverage summary
+        if: always()
+        run: |
+          node -e '
+            const fs = require("fs");
+            const f = "coverage/coverage-summary.json";
+            if (!fs.existsSync(f)) { console.log("No coverage summary found"); process.exit(0); }
+            const t = JSON.parse(fs.readFileSync(f, "utf8")).total;
+            const row = (label, m) => `| ${label} | ${m.pct.toFixed(2)}% | ${m.covered}/${m.total} |`;
+            const md = [
+              "## Coverage",
+              "",
+              "| Metric | % | Covered / Total |",
+              "|---|---:|---:|",
+              row("Statements", t.statements),
+              row("Branches",   t.branches),
+              row("Functions",  t.functions),
+              row("Lines",      t.lines),
+              "",
+            ].join("\n");
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n");
+          '
+
       # Perf regression guard. Compares a fresh bench run against the
       # checked-in baseline; fails if any scenario's p50 exceeds 1.5× baseline.
       # To refresh: `pnpm -F @rotorsoft/act bench:update` in a PR labeled
@@ -59,14 +84,52 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  cd:
+      # Hand the built libs off to the CD matrix so each release job
+      # doesn't have to rebuild the dependency tree from scratch.
+      # `pnpm typecheck` runs `pnpm build` internally, so the dist files
+      # already exist at this point.
+      - if: github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: act-libs-dist
+          path: libs/*/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  # Detect which libs actually changed in this push. Lets the CD matrix
+  # skip release jobs for untouched libs (semantic-release is a no-op
+  # in that case anyway, but skipping the whole job saves install +
+  # checkout + node setup overhead — meaningful when most pushes only
+  # touch one or two libs).
+  changed-libs:
     if: github.ref == 'refs/heads/master'
     needs: ci
     runs-on: ubuntu-latest
+    outputs:
+      libs: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            act-patch:   ['libs/act-patch/**']
+            act:         ['libs/act/**']
+            act-sse:     ['libs/act-sse/**']
+            act-pg:      ['libs/act-pg/**']
+            act-sqlite:  ['libs/act-sqlite/**']
+            act-pino:    ['libs/act-pino/**']
+            act-diagram: ['libs/act-diagram/**']
+
+  cd:
+    if: github.ref == 'refs/heads/master' && needs.changed-libs.outputs.libs != '[]'
+    needs: [ci, changed-libs]
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 1 # prevents concurrent pull/push conflicts on main branch
+      fail-fast: false
       matrix:
-        lib: [act-patch, act, act-sse, act-pg, act-sqlite, act-pino, act-diagram]
+        lib: ${{ fromJson(needs.changed-libs.outputs.libs) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -82,7 +145,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install
-      - run: pnpm -F @rotorsoft/${{ matrix.lib }}... build
+
+      # Restore the dist files built during CI — semantic-release
+      # publishes whatever sits in `libs/<lib>/dist/`, so we don't need
+      # to rebuild here. Default download path is the workspace root,
+      # which matches the workspace-relative paths the artifact was
+      # uploaded with (`libs/*/dist`).
+      - uses: actions/download-artifact@v4
+        with:
+          name: act-libs-dist
 
       - name: configure git
         run: |

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: "v8",
-      reporter: ["text", "lcov", "html"],
+      reporter: ["text", "lcov", "html", "json-summary"],
       reportsDirectory: "./coverage",
       include: ["libs/**/src/**/*.ts"],
       exclude: [


### PR DESCRIPTION
## Summary

Three independent CI/CD improvements that cut release-pipeline turnaround and surface coverage in PR checks.

### 1. Build once, reuse in CD

The `ci` job already builds every lib via `pnpm typecheck` (which runs `pnpm build` internally). Upload the resulting `libs/*/dist/` as an artifact, then each CD matrix entry downloads it and skips the build step.

Before: each of 7 matrix entries ran `pnpm -F @rotorsoft/<lib>... build`, rebuilding the full transitive dependency tree from scratch (act-patch built 6× across the matrix; act built 5×; etc.).

After: dist is built once in CI and reused. Saves ~30-90s per matrix entry × 7 serial entries.

### 2. Skip CD for unchanged libs

New `changed-libs` job uses `dorny/paths-filter@v3` (same pattern as `deploy-docs.yml`) to determine which libs were actually touched in the push. The `cd` matrix is built dynamically from that list.

Before: every push to master ran all 7 release jobs even when only one lib changed; semantic-release exited cheaply on the others, but each still paid for checkout + setup + `pnpm install`.

After: a push touching only `libs/act-pg/` runs exactly one CD job.

### 3. Coverage in PR/run summary

Added `json-summary` to vitest v8 coverage reporters (`vite.config.ts`). New "Coverage summary" step parses `coverage/coverage-summary.json` into a markdown table written to `$GITHUB_STEP_SUMMARY`.

Renders as:

| Metric | % | Covered / Total |
|---|---:|---:|
| Statements | 100.00% | 2748/2748 |
| Branches | 100.00% | 1411/1411 |
| Functions | 100.00% | 506/506 |
| Lines | 100.00% | 2522/2522 |

Visible on every PR check and master run alongside the existing Coveralls upload.

## What's not changed

- Coveralls integration (kept).
- Perf bench (kept; unrelated to release).
- `pnpm typecheck`'s internal `pnpm build` step (worth a separate look — looks redundant given path mapping in `tsconfig.eslint.json` — but out of scope here).
- `stress.yml` and `deploy-docs.yml` (unrelated).

## Test plan

- [x] YAML parses cleanly (`js-yaml` validation)
- [x] Coverage summary script verified locally against real `coverage-summary.json` (renders the table above)
- [x] All 1001 tests pass with new `json-summary` reporter enabled
- [ ] Verify on first push to master that the artifact handoff works end-to-end (download path resolves to `libs/<lib>/dist/`)
- [ ] Verify `changed-libs` filter correctly emits an empty matrix on docs-only pushes (cd job should be skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)