### PR TITLE
ACT-101: Store.notify hook for cross-process drain wakeup

### DIFF
--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -284,11 +284,12 @@ app.on("settled", (drain) => { /* notify SSE clients, update caches */ });
 app.on("blocked", (leases) => { /* alert on blocked streams */ });
 
 // Cross-process visibility: another process committed to the same store.
-// Only fires when the configured store implements Store.notify
-// (PostgresStore does; InMemoryStore and SqliteStore don't — they're
-// single-process / single-node by design). Auto-wired at build time;
-// users do nothing extra. The orchestrator already wakes settle()
-// internally on the same signal — this listener is for fan-out.
+// Opt-in via `new PostgresStore({ ..., notify: true })`. With it off
+// (the default) the listener never fires. PostgresStore is the only
+// adapter that implements it; InMemoryStore and SqliteStore don't —
+// they're single-process / single-node by design. The orchestrator
+// auto-wires `settle()` on the same signal — this listener is for
+// fan-out (SSE, dashboards, audit).
 app.on("notified", (n) => sse.broadcast(n));
 
 // Query events directly

--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -283,6 +283,14 @@ app.on("settled", (drain) => { /* notify SSE clients, update caches */ });
 // Catch reaction failures
 app.on("blocked", (leases) => { /* alert on blocked streams */ });
 
+// Cross-process visibility: another process committed to the same store.
+// Only fires when the configured store implements Store.notify
+// (PostgresStore does; InMemoryStore and SqliteStore don't — they're
+// single-process / single-node by design). Auto-wired at build time;
+// users do nothing extra. The orchestrator already wakes settle()
+// internally on the same signal — this listener is for fan-out.
+app.on("notified", (n) => sse.broadcast(n));
+
 // Query events directly
 const events = await app.query_array({ stream: "my-stream" });
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,34 @@ await app.drain({ streamLimit: 100, eventLimit: 1000 });
 app.settle();
 ```
 
+**Build-time contract:** inject the configured store via `store(adapter)` *before* calling `act()...build()`. The orchestrator wires cross-process notifications (see "Cross-Process Reactions" below) at construction against whatever store is current — late injection won't take effect.
+
+### Cross-Process Reactions (`Store.notify`)
+
+When two or more Act processes share a backing store, the second process has no in-process signal that the first committed. The default fallback is the existing poll/debounce path (`start_correlations`, `settle()` on a timer). For lower latency, implement `Store.notify(handler)` on the adapter; the orchestrator subscribes once at build time and wakes `settle()` immediately on remote commits.
+
+```typescript
+// Auto-wired — users do nothing extra
+store(new PostgresStore(...));     // PG implements notify via LISTEN/NOTIFY
+const app = act()
+  .withState(Order)
+  .on("OrderPlaced").do(handleOrder).to("inventory")
+  .build();
+// On any remote commit of OrderPlaced, settle() fires immediately on this process.
+
+// Optional: subscribe to the lifecycle event for fan-out
+app.on("notified", (n) => sse.broadcast(n));
+```
+
+**Adapter status:**
+- `PostgresStore` — implemented via `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel (`act_commit_<schema>_<table>`); `commit()` issues one NOTIFY per commit transaction with all events.
+- `InMemoryStore` — not implemented. Single-process by definition; no remote writers exist.
+- `SqliteStore` — not implemented. Single-node by design.
+
+**Self-filtering:** stores embed a per-instance `_by` UUID in NOTIFY payloads and skip their own. The `notified` lifecycle event therefore only fires for **cross-process** activity — local commits already arm drain via `do()`. Hint, not a contract: if the store doesn't implement `notify` or a notification is lost, the existing debounce/poll path still drains correctly.
+
+See `libs/act-pg/PERFORMANCE.md` for the cross-process commit→reaction latency benchmark.
+
 ### Time-Travel Queries
 
 `load()` accepts an optional `asOf` parameter (`AsOf = Pick<Query, "before" | "created_before" | "created_after" | "limit">`) to load state at a specific point in time:
@@ -711,11 +739,14 @@ interface Store extends Disposable {
   reset(streams): Promise<number>;                // Reset watermarks for projection rebuild
   truncate(targets: {stream, snapshot?, meta?}[]): Promise<{deleted, committed}>;  // Atomic truncate + seed
   query_streams(callback, query?): Promise<{maxEventId, count}>;  // Read-only introspection of subscription positions
+  notify?(handler): NotifyDisposer | Promise<NotifyDisposer>;  // Optional: cross-process commit notifications
   dispose(): Promise<void>;                       // Cleanup resources
 }
 ```
 
 `claim()` atomically discovers and locks streams for processing using PostgreSQL's `FOR UPDATE SKIP LOCKED` pattern — competing consumers never block each other, and locked rows are silently skipped. This eliminates the race between discovery and locking that existed with the previous poll/lease two-step. `subscribe()` registers new streams for reaction processing (upserts into the streams table) and returns the count of newly registered streams. Version-based optimistic concurrency must be implemented correctly.
+
+`notify()` is optional. When implemented, the orchestrator auto-wires it at build time and routes notifications to `settle()` for sub-poll cross-process reaction wakeup. Implementations **must self-filter their own commits** (carry a per-instance UUID in the payload, skip on receive) — the `notified` lifecycle event surfaces only cross-process activity. Treat `notify` as a hint: lost notifications fall back to the debounce/poll path, so correctness is not on the line. See `libs/act-pg/PERFORMANCE.md` for the latency benchmark.
 
 ## Cache Interface Contract
 
@@ -758,6 +789,7 @@ The default `InMemoryCache` is an LRU cache with configurable `maxSize` (default
 - Use `app.on("settled", ...)` to react when `settle()` completes all correlate/drain passes
 - Use `app.on("blocked", ...)` to catch reaction processing failures
 - Use `app.on("closed", ...)` to observe close-the-books operations
+- Use `app.on("notified", ...)` to observe cross-process commits (only fires when the configured store implements `Store.notify` — e.g., `PostgresStore`)
 - Use `app.load(State, stream, undefined, { before: eventId })` for time-travel queries (see `AsOf` type)
 - Query events directly: `await app.query_array({ stream: "mystream" })`
 - Query with exact stream match: `await app.query_array({ stream: "mystream", stream_exact: true })` — by default, `stream` uses regex matching; `stream_exact: true` uses exact string equality. `load()` always uses exact match internally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,15 +268,18 @@ await app.drain({ streamLimit: 100, eventLimit: 1000 });
 app.settle();
 ```
 
-**Build-time contract:** inject the configured store via `store(adapter)` *before* calling `act()...build()`. The orchestrator wires cross-process notifications (see "Cross-Process Reactions" below) at construction against whatever store is current — late injection won't take effect.
+**Build-time contract:** when using cross-process notifications (see below), inject the configured store via `store(adapter)` *before* calling `act()...build()`. The orchestrator wires the notify subscription at construction against whatever store is current — late injection won't take effect.
 
 ### Cross-Process Reactions (`Store.notify`)
 
-When two or more Act processes share a backing store, the second process has no in-process signal that the first committed. The default fallback is the existing poll/debounce path (`start_correlations`, `settle()` on a timer). For lower latency, implement `Store.notify(handler)` on the adapter; the orchestrator subscribes once at build time and wakes `settle()` immediately on remote commits.
+When two or more Act processes share a backing store, the second process has no in-process signal that the first committed. The default fallback is the existing poll/debounce path (`start_correlations`, `settle()` on a timer). For lower latency, the configured store can implement the optional `Store.notify(handler)` hook; the orchestrator auto-wires the subscription at build time and wakes `settle()` immediately on remote commits.
+
+**Opt-in at the adapter level.** The cost (per-commit `pg_notify`, dedicated `LISTEN` client per process) is wasted in single-instance deployments, so adapters default to **off**. Enable explicitly on every store instance involved (writers and listeners both):
 
 ```typescript
-// Auto-wired — users do nothing extra
-store(new PostgresStore(...));     // PG implements notify via LISTEN/NOTIFY
+import { PostgresStore } from "@rotorsoft/act-pg";
+
+store(new PostgresStore({ /* ... */, notify: true }));   // ← opt in
 const app = act()
   .withState(Order)
   .on("OrderPlaced").do(handleOrder).to("inventory")
@@ -286,6 +289,8 @@ const app = act()
 // Optional: subscribe to the lifecycle event for fan-out
 app.on("notified", (n) => sse.broadcast(n));
 ```
+
+When the store's `notify` flag is left at the default (`false`), `commit()` skips the `pg_notify` SQL entirely and the store's `notify` method is left undefined — the orchestrator's auto-wire `if (store.notify)` short-circuits, so no LISTEN client is ever allocated. Existing callers see zero behavior change.
 
 **Adapter status:**
 - `PostgresStore` — implemented via `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel (`act_commit_<schema>_<table>`); `commit()` issues one NOTIFY per commit transaction with all events.

--- a/docs/docs/architecture/cross-process-reactions.md
+++ b/docs/docs/architecture/cross-process-reactions.md
@@ -40,15 +40,15 @@ type StoreNotification = {
 };
 ```
 
-When present, the orchestrator subscribes once at `build()` time and routes notifications to wake `settle()` automatically. **Users opt in with zero code** — same `act()...build()` call as a single-process app.
+When present, the orchestrator subscribes once at `build()` time and routes notifications to wake `settle()` automatically. The hook is **opt-in at the adapter level** — `PostgresStore` defaults `notify: false` so single-instance deployments pay zero overhead. Multi-process apps enable it explicitly:
 
 ```ts
-store(new PostgresStore({...}));     // PG implements notify
+store(new PostgresStore({ /* ... */, notify: true }));   // ← opt in
 const app = act()
   .withState(Order)
   .on("OrderPlaced").do(reduceInventory).to("inventory")
   .build();
-// Done. Cross-process commits wake reactions on this process.
+// Cross-process commits wake reactions on this process.
 ```
 
 Optionally, the user can also subscribe to the `notified` lifecycle event for SSE fan-out, dashboards, or audit:
@@ -70,7 +70,7 @@ The alternative (broadcast everything, let the consumer filter) was rejected as 
 
 | Adapter | `notify` | Why |
 | --- | --- | --- |
-| `PostgresStore` | implemented | `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel (`act_commit_<schema>_<table>`). One NOTIFY per commit transaction with the full event batch as JSON payload. |
+| `PostgresStore` | implemented (opt-in via `notify: true`) | `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel (`act_commit_<schema>_<table>`). One NOTIFY per commit transaction with the full event batch as JSON payload. Default off — single-instance deployments pay zero overhead, existing callers keep their current behavior on upgrade. |
 | `InMemoryStore` | not implemented | Single-process by definition — there is no remote writer. |
 | `SqliteStore` | not implemented | Single-node by design. Use `@rotorsoft/act-pg` for multi-process. |
 

--- a/docs/docs/architecture/cross-process-reactions.md
+++ b/docs/docs/architecture/cross-process-reactions.md
@@ -1,0 +1,127 @@
+---
+id: cross-process-reactions
+title: Cross-process reactions
+---
+
+# Cross-process reactions
+
+How Act keeps reaction latency low when more than one process shares the backing event store. The short version: the configured store may implement an optional `notify(handler)` hook; the orchestrator wires it in at build time and wakes `settle()` immediately on commits from other processes — no polling lag, no extra code.
+
+## The problem
+
+In a single-process app, `do()` arms the drain locally and `settle()` runs reactions on the same Node event loop. Latency is bounded by reaction work, not by the framework.
+
+Two or more processes against the same store don't have that luxury. A commit on Worker A is invisible to Worker B until Worker B asks the store. The default mechanism is polling — `start_correlations` runs on a timer, or the user calls `settle()` periodically. The polling interval becomes a floor on reaction latency:
+
+- `start_correlations` default: **10 s**.
+- Common explicit poll loops: **50–500 ms**.
+- Local single-process: **0 ms** (event loop turn).
+
+For event-driven workloads where reactions matter, that 10 s floor is a deal-breaker. Even 50 ms is loose for things like SSE fan-out or near-real-time projections.
+
+## The hook
+
+The `Store` interface has an optional method:
+
+```ts
+interface Store extends Disposable {
+  // ...existing...
+  notify?(
+    handler: (notification: StoreNotification) => void
+  ): NotifyDisposer | Promise<NotifyDisposer>;
+}
+
+type StoreNotification = {
+  readonly stream: string;
+  readonly events: ReadonlyArray<{
+    readonly id: number;
+    readonly name: string;
+  }>;
+};
+```
+
+When present, the orchestrator subscribes once at `build()` time and routes notifications to wake `settle()` automatically. **Users opt in with zero code** — same `act()...build()` call as a single-process app.
+
+```ts
+store(new PostgresStore({...}));     // PG implements notify
+const app = act()
+  .withState(Order)
+  .on("OrderPlaced").do(reduceInventory).to("inventory")
+  .build();
+// Done. Cross-process commits wake reactions on this process.
+```
+
+Optionally, the user can also subscribe to the `notified` lifecycle event for SSE fan-out, dashboards, or audit:
+
+```ts
+app.on("notified", (n) => sse.broadcast(n));
+```
+
+## Self-filter — a clean cross-process semantic
+
+Every store instance carries a per-instance UUID (`_by`) embedded in the NOTIFY payload. The LISTEN handler skips payloads where `by === this._by`. Result:
+
+- Local commits never echo back through `notified` (the local fast path inside `do()` already arms drain — no double signal).
+- The `notified` lifecycle event surfaces only **another process** writing to the same store. That gives consumers a clean signal for cross-process visibility.
+
+The alternative (broadcast everything, let the consumer filter) was rejected as messier — it pollutes the local fast path with self-echoes and forces every listener to know about the filter.
+
+## Adapter status
+
+| Adapter | `notify` | Why |
+| --- | --- | --- |
+| `PostgresStore` | implemented | `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel (`act_commit_<schema>_<table>`). One NOTIFY per commit transaction with the full event batch as JSON payload. |
+| `InMemoryStore` | not implemented | Single-process by definition — there is no remote writer. |
+| `SqliteStore` | not implemented | Single-node by design. Use `@rotorsoft/act-pg` for multi-process. |
+
+## Build-time contract
+
+Inject the store via `store(adapter)` **before** calling `act()...build()`. The orchestrator wires the notify subscription against whichever store is current at construction; late injection won't take effect.
+
+```ts
+// ✅ Correct
+store(new PostgresStore({...}));
+const app = act().withState(Order).build();
+
+// ❌ Wrong — orchestrator binds before injection
+const app = act().withState(Order).build();
+store(new PostgresStore({...}));   // too late; notify wasn't wired
+```
+
+Tests that build the app at module-load time should refactor to a `buildApp()` factory called inside `beforeAll` after store injection.
+
+## Hint, not a contract
+
+`notify` is a **performance hint**. The orchestrator never depends on it for correctness:
+
+- If the store doesn't implement `notify`, the existing debounce/poll path still drains correctly.
+- If a notification is dropped (network hiccup, pool exhaustion, misconfigured channel), the existing debounce/poll path still drains correctly.
+
+This means you can run notify as the happy-path optimization and keep `start_correlations` (or a periodic `settle()` timer) as the safety net. Lost wakeups cost latency, never correctness.
+
+## Topology and connection budget
+
+`LISTEN` checks out a **dedicated client** from the pool. Each subscribed process holds one extra connection for the lifetime of the subscription. Three common topologies:
+
+- **Fat single process**: simplest, no notify needed. Easily handles thousands of events/sec.
+- **Symmetric workers**: N identical processes, all running the same reactions, sharing a DB. Notify wakes them all; competing consumers via `claim()` (`FOR UPDATE SKIP LOCKED`) ensures exactly-once-per-event per logical reaction. Scales linearly until the connection budget bites.
+- **Specialized sidecars**: each process subscribes to a different reaction subset. Notify wakes everyone but only the relevant subscriber does work.
+
+For the symmetric-workers topology, watch for the **thundering herd**: every process wakes on every cross-process commit and races for the same lease. Only one wins per stream — the rest see no work and go back to sleep. That's correct but introduces some redundant claim attempts. A small debounce on `notified` helps under bursty load.
+
+## Performance
+
+Benchmark in [`@rotorsoft/act-pg`'s `PERFORMANCE.md`](https://github.com/rotorsoft/act-root/blob/master/libs/act-pg/PERFORMANCE.md). Single run, docker PG on `localhost`, 30 single-event commits:
+
+| Mode | p50 | p95 | p99 |
+| --- | --- | --- | --- |
+| notify | 11 ms | 15 ms | 25 ms |
+| polling (50 ms) | 27 ms | 54 ms | 77 ms |
+
+At 50 ms polling, notify is ~3× faster across percentiles. At the default `start_correlations` 10 s interval, the gap blows out to ~1000×.
+
+## See also
+
+- [Correlation and drain](./correlation-and-drain.md) — how `settle()` actually runs.
+- [Extension points](./extension-points.md) — `Store` contract reference.
+- [`@rotorsoft/act-pg/PERFORMANCE.md`](https://github.com/rotorsoft/act-root/blob/master/libs/act-pg/PERFORMANCE.md) — benchmark methodology and numbers.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -38,6 +38,7 @@ const sidebars: SidebarsConfig = {
         "architecture/concurrency-model",
         "architecture/cache-and-snapshots",
         "architecture/correlation-and-drain",
+        "architecture/cross-process-reactions",
         "architecture/close-cycle",
         "architecture/event-schema-evolution",
         "architecture/extension-points",

--- a/libs/act-pg/PERFORMANCE.md
+++ b/libs/act-pg/PERFORMANCE.md
@@ -1,0 +1,79 @@
+# `@rotorsoft/act-pg` performance evolution
+
+This document tracks performance-relevant changes to the PostgreSQL
+adapter. The core framework's `PERFORMANCE.md` (in
+[`libs/act/PERFORMANCE.md`](../act/PERFORMANCE.md)) covers
+adapter-independent optimizations; entries here are PG-specific.
+
+## ACT-101 — cross-process commit→reaction latency (LISTEN/NOTIFY wakeup)
+
+Reaction latency on poll-driven deployments is bounded below by the
+correlate/drain interval (`start_correlations` default: 10 s; common
+poll-loop tunings: 50–500 ms). Single-process apps can call `settle()`
+directly after each `do()` and skip the poll, but cross-process
+deployments — read replicas, projection workers, side-cars — cannot:
+the second process has no event-loop signal that a write happened on
+another node, so it has to poll.
+
+`PostgresStore.notify` (added in this change) bridges that gap with
+`LISTEN`/`NOTIFY` on a per-`(schema, table)` channel
+(`act_commit_<schema>_<table>`). `commit()` issues one `NOTIFY` per
+commit transaction with the full event batch as a JSON payload.
+Subscribers get sub-poll wake-up; the orchestrator wires this in
+automatically, so users don't change a line of code to opt in.
+
+Self-filter via a per-instance `_by` UUID embedded in the payload —
+a store instance never receives its own commits, keeping the
+`"notified"` lifecycle event a clean cross-process signal.
+
+### Benchmark
+
+Two `PostgresStore` instances on the same docker PG (port 5431,
+`postgres:17-alpine`) simulate two processes:
+
+- **Writer**: commits 30 single-event transactions on `stream-x` at
+  30 ms intervals.
+- **Reader**: an `Act` orchestrator with a reaction on the emitted
+  event, target stream resolved per-source.
+
+Two modes:
+
+- **notify**: the reader's auto-wired `Store.notify` subscription
+  triggers `settle({debounceMs: 0})` on each `notified` event.
+- **polling**: notify subscription is torn down; reactions are driven
+  by `setInterval(() => correlate() + drain(), 50ms)`.
+
+Run: `RUN_NOTIFY_REPORT=1 pnpm -F @rotorsoft/act-pg exec vitest run test/notify-perf.spec.ts`
+
+### Results
+
+Numbers below are from a single run on macOS 25.4 (Apple Silicon),
+docker PG on `localhost:5431`, no other load. Variance ±20 % — the
+ratio is the meaningful thing.
+
+| Mode    | p50    | p95    | p99    |
+| ------- | ------ | ------ | ------ |
+| notify  | 11 ms  | 15 ms  | 25 ms  |
+| polling | 27 ms  | 54 ms  | 77 ms  |
+
+Reading: notify-driven reactions land in roughly the time it takes to
+complete a commit + receive a `LISTEN` notification + run a single
+`settle` cycle. Polling mode adds the full interval (~POLL_INTERVAL_MS
+on average for new events arriving mid-window) plus the cycle work.
+At 50 ms polling, that delta is ~3× across all percentiles; at the
+default `start_correlations` 10 s interval, the gap blows out to
+~1000×.
+
+### Why notify isn't always free
+
+`LISTEN` checks out a dedicated client from the pool. Each subscribed
+process holds one extra connection for the lifetime of the
+subscription. For deployments running hundreds of stateless Act
+processes against one PG, this is the budgeting line item to mind —
+size the connection pool accordingly.
+
+The wakeup is a hint, not a contract. Lost notifications (network
+hiccup, pool exhaustion) are tolerated — the existing debounce/poll
+path still drains correctly. So you can run with a longer poll
+interval as a safety net while taking the notify happy-path latency
+for free.

--- a/libs/act-pg/PERFORMANCE.md
+++ b/libs/act-pg/PERFORMANCE.md
@@ -20,7 +20,9 @@ another node, so it has to poll.
 (`act_commit_<schema>_<table>`). `commit()` issues one `NOTIFY` per
 commit transaction with the full event batch as a JSON payload.
 Subscribers get sub-poll wake-up; the orchestrator wires this in
-automatically, so users don't change a line of code to opt in.
+automatically when the store opts in via `notify: true`. Default is
+off — single-instance deployments pay zero overhead and existing
+callers see no behavior change after upgrading.
 
 Self-filter via a per-instance `_by` UUID embedded in the payload —
 a store instance never receives its own commits, keeping the
@@ -43,7 +45,7 @@ Two modes:
 - **polling**: notify subscription is torn down; reactions are driven
   by `setInterval(() => correlate() + drain(), 50ms)`.
 
-Run: `RUN_NOTIFY_REPORT=1 pnpm -F @rotorsoft/act-pg exec vitest run test/notify-perf.spec.ts`
+Run: `pnpm -F @rotorsoft/act-pg exec vitest run --config vitest.bench.config.ts`
 
 ### Results
 
@@ -70,7 +72,10 @@ default `start_correlations` 10 s interval, the gap blows out to
 process holds one extra connection for the lifetime of the
 subscription. For deployments running hundreds of stateless Act
 processes against one PG, this is the budgeting line item to mind —
-size the connection pool accordingly.
+size the connection pool accordingly. There's also one extra
+`pg_notify` SQL per commit on every writer that opted in. Both are
+why the flag defaults off — `PostgresStore({ notify: true })` is the
+explicit opt-in for multi-process deployments.
 
 The wakeup is a hint, not a contract. Lost notifications (network
 hiccup, pool exhaustion) are tolerated — the existing debounce/poll

--- a/libs/act-pg/README.md
+++ b/libs/act-pg/README.md
@@ -97,24 +97,28 @@ if (process.env.NODE_ENV === "production") {
 - **Connection Pooling** - Uses [node-postgres](https://node-postgres.com/) Pool for efficient connection management
 - **Atomic Stream Claiming** - Zero-contention competing consumers via `FOR UPDATE SKIP LOCKED`
 - **Auto Schema Setup** - `seed()` creates all required tables, indexes, and schema
-- **Cross-Process `LISTEN`/`NOTIFY`** - Auto-wired `Store.notify` wakes `settle()` on remote commits — no polling lag for horizontally-scaled deployments. See [PERFORMANCE.md](./PERFORMANCE.md) for the latency benchmark.
+- **Cross-Process `LISTEN`/`NOTIFY`** (opt-in) - Set `notify: true` to wake `settle()` immediately on remote commits — no polling lag for horizontally-scaled deployments. Off by default. See [PERFORMANCE.md](./PERFORMANCE.md) for the latency benchmark.
 - **Multi-Tenant** - Isolate tenants using separate schemas
 
-## Cross-Process Reactions
+## Cross-Process Reactions (opt-in)
 
-For multi-instance deployments, `PostgresStore` implements the optional `Store.notify` hook so the orchestrator wakes `settle()` immediately on commits from other processes — no polling delay.
+For multi-instance deployments, `PostgresStore` implements the optional `Store.notify` hook via `LISTEN`/`NOTIFY` so the orchestrator wakes `settle()` immediately on commits from other processes — no polling delay.
+
+**Opt-in via the `notify: true` config flag.** The cost (per-commit `pg_notify`, dedicated `LISTEN` client per process) is wasted in single-instance deployments, so it defaults to **off** — existing callers see zero behavior change after upgrading. Multi-process apps that need sub-poll wakeup enable it on every store instance involved (writers and listeners both):
 
 ```ts
 import { act, store } from "@rotorsoft/act";
 import { PostgresStore } from "@rotorsoft/act-pg";
 
+const config = { schema: "myapp", table: "events", notify: true };
+
 // Worker A (writer)
-store(new PostgresStore({ schema: "myapp", table: "events" }));
+store(new PostgresStore(config));
 const app = act().withState(Order).build();
 await app.do("placeOrder", { stream: "order-1", actor }, payload);
 
 // Worker B (reactions, separate process / pod / box)
-store(new PostgresStore({ schema: "myapp", table: "events" }));  // same DB
+store(new PostgresStore(config));   // same DB, same opt-in
 const app = act()
   .withState(Order)
   .on("OrderPlaced").do(reduceInventory).to("inventory-1")
@@ -124,11 +128,14 @@ const app = act()
 app.on("notified", (n) => sse.broadcast(n));
 ```
 
-Auto-wiring details:
+When `notify: true`:
 - `commit()` issues one `NOTIFY act_commit_<schema>_<table>` per transaction with the full event batch as a JSON payload.
-- The orchestrator subscribes once at `build()` (one dedicated PG client per process — size your pool accordingly).
+- The orchestrator auto-subscribes once at `build()` (one dedicated PG client per process — size your pool accordingly).
 - The store self-filters its own commits (per-instance UUID in the payload), so the `notified` lifecycle event surfaces only **cross-process** activity. Local commits already arm drain via `do()`.
-- Hint, not a contract: lost notifications fall back to the existing debounce/poll path. Correctness is preserved.
+
+When `notify: false` (the default): `commit()` skips the `pg_notify` SQL entirely, and `notify` is undefined on the store instance — the orchestrator's auto-wire short-circuits, no LISTEN client is allocated.
+
+`notify` is a hint, not a contract: lost notifications fall back to the existing debounce/poll path. Correctness is preserved.
 
 **Build-time contract:** call `store(adapter)` *before* `act()...build()`. The orchestrator binds notify to whichever store is current at construction; late injection won't take effect.
 

--- a/libs/act-pg/README.md
+++ b/libs/act-pg/README.md
@@ -97,8 +97,40 @@ if (process.env.NODE_ENV === "production") {
 - **Connection Pooling** - Uses [node-postgres](https://node-postgres.com/) Pool for efficient connection management
 - **Atomic Stream Claiming** - Zero-contention competing consumers via `FOR UPDATE SKIP LOCKED`
 - **Auto Schema Setup** - `seed()` creates all required tables, indexes, and schema
-- **NOTIFY/LISTEN** - Real-time event notifications via PostgreSQL channels
+- **Cross-Process `LISTEN`/`NOTIFY`** - Auto-wired `Store.notify` wakes `settle()` on remote commits — no polling lag for horizontally-scaled deployments. See [PERFORMANCE.md](./PERFORMANCE.md) for the latency benchmark.
 - **Multi-Tenant** - Isolate tenants using separate schemas
+
+## Cross-Process Reactions
+
+For multi-instance deployments, `PostgresStore` implements the optional `Store.notify` hook so the orchestrator wakes `settle()` immediately on commits from other processes — no polling delay.
+
+```ts
+import { act, store } from "@rotorsoft/act";
+import { PostgresStore } from "@rotorsoft/act-pg";
+
+// Worker A (writer)
+store(new PostgresStore({ schema: "myapp", table: "events" }));
+const app = act().withState(Order).build();
+await app.do("placeOrder", { stream: "order-1", actor }, payload);
+
+// Worker B (reactions, separate process / pod / box)
+store(new PostgresStore({ schema: "myapp", table: "events" }));  // same DB
+const app = act()
+  .withState(Order)
+  .on("OrderPlaced").do(reduceInventory).to("inventory-1")
+  .build();
+// On Worker A's commit, Worker B wakes within ~10 ms (vs. polling: ≥ poll interval).
+// Optional: tap the lifecycle event for fan-out.
+app.on("notified", (n) => sse.broadcast(n));
+```
+
+Auto-wiring details:
+- `commit()` issues one `NOTIFY act_commit_<schema>_<table>` per transaction with the full event batch as a JSON payload.
+- The orchestrator subscribes once at `build()` (one dedicated PG client per process — size your pool accordingly).
+- The store self-filters its own commits (per-instance UUID in the payload), so the `notified` lifecycle event surfaces only **cross-process** activity. Local commits already arm drain via `do()`.
+- Hint, not a contract: lost notifications fall back to the existing debounce/poll path. Correctness is preserved.
+
+**Build-time contract:** call `store(adapter)` *before* `act()...build()`. The orchestrator binds notify to whichever store is current at construction; late injection won't take effect.
 
 ## Database Schema
 

--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type {
   BlockedLease,
   Committed,
@@ -5,12 +6,14 @@ import type {
   Lease,
   Logger,
   Message,
+  NotifyDisposer,
   Query,
   QueryStreams,
   QueryStreamsResult,
   Schema,
   Schemas,
   Store,
+  StoreNotification,
   StreamPosition,
 } from "@rotorsoft/act";
 import {
@@ -38,6 +41,19 @@ const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 // unique index on (stream, version). Stable across PG versions per the
 // SQL standard. See: https://www.postgresql.org/docs/current/errcodes-appendix.html
 const PG_UNIQUE_VIOLATION = "23505";
+
+// Channel-name prefix for cross-process commit notifications. The
+// effective channel is namespaced per `(schema, table)` so two
+// PostgresStores pointed at distinct event tables in the same database
+// don't cross-talk. PG channel names are case-folded unless quoted; we
+// stick to lowercase identifiers so a future `LISTEN act_commit_*` from
+// any client (psql, scripts, alternative consumers) matches without
+// surprises.
+const NOTIFY_CHANNEL_PREFIX = "act_commit";
+
+function notifyChannel(schema: string, table: string): string {
+  return `${NOTIFY_CHANNEL_PREFIX}_${schema}_${table}`;
+}
 function assertSafeIdentifier(value: string, label: string) {
   if (!SAFE_IDENTIFIER.test(value))
     throw new Error(`Unsafe SQL identifier for ${label}: "${value}"`);
@@ -166,6 +182,28 @@ export class PostgresStore implements Store {
   readonly config: Config;
   private _fqt: string;
   private _fqs: string;
+  /**
+   * Per-instance writer identifier embedded in every NOTIFY payload. The
+   * `notify()` LISTEN handler skips payloads where `by === this._by`,
+   * giving the `"notified"` lifecycle event a clean cross-process
+   * semantic — local commits never echo back through this channel.
+   */
+  private readonly _by: string = randomUUID();
+  /**
+   * Effective NOTIFY channel for this store. Computed from `(schema,
+   * table)` at construction so multiple stores in the same database
+   * stay isolated.
+   */
+  private readonly _channel: string;
+  /** Active LISTEN client (one per `notify()` subscription). */
+  private _listenClient: pg.PoolClient | undefined;
+  /**
+   * Notification listener attached to the active LISTEN client. Tracked
+   * separately so the re-subscribe / dispose paths can detach it before
+   * destroying the client — without this, a pool that reused the
+   * connection would re-fire the stale handler.
+   */
+  private _listenHandler: ((msg: pg.Notification) => void) | undefined;
 
   /**
    * Create a new PostgresStore instance.
@@ -179,14 +217,39 @@ export class PostgresStore implements Store {
     this._pool = new Pool(poolConfig);
     this._fqt = `"${this.config.schema}"."${this.config.table}"`;
     this._fqs = `"${this.config.schema}"."${this.config.table}_streams"`;
+    this._channel = notifyChannel(this.config.schema, this.config.table);
   }
 
   /**
    * Dispose of the store and close all database connections.
+   * Releases any active LISTEN client first so the pool can drain cleanly.
    * @returns Promise that resolves when all connections are closed
    */
   async dispose() {
+    await this._teardownListen();
     await this._pool.end();
+  }
+
+  /**
+   * Tear down the active LISTEN subscription if any: detach the
+   * notification listener, run UNLISTEN, and destroy the dedicated
+   * client (do not return it to the pool — its listener is removed but
+   * destroying belt-and-braces guards against any future change in
+   * pg-pool semantics that could re-issue a half-clean client).
+   */
+  private async _teardownListen() {
+    if (!this._listenClient) return;
+    // _listenHandler is set in lockstep with _listenClient in notify(),
+    // so if the client is present, the handler is too.
+    this._listenClient.removeListener("notification", this._listenHandler!);
+    this._listenHandler = undefined;
+    try {
+      await this._listenClient.query(`UNLISTEN ${this._channel}`);
+    } catch {
+      // best-effort — pool end (or destroy) tears the connection down
+    }
+    this._listenClient.release(true);
+    this._listenClient = undefined;
   }
 
   /**
@@ -442,26 +505,21 @@ export class PostgresStore implements Store {
         }
       }
 
-      await client
-        .query(
-          `
-            NOTIFY "${this.config.table}", '${JSON.stringify({
-              operation: "INSERT",
-              id: committed[0].name,
-              position: committed[0].id,
-            })}';
-            COMMIT;
-            `
-        )
-        .catch((error) => {
-          logger.error(error);
-          throw new ConcurrencyError(
-            stream,
-            version,
-            msgs as unknown as Message<Schemas, string>[],
-            expectedVersion || -1
-          );
-        });
+      // One NOTIFY per commit transaction, payload carries the full event
+      // batch so listeners reason about atomic groups (matches reaction
+      // semantics in the rest of the framework). `by` lets other
+      // PostgresStore instances self-filter their own writes — see
+      // `notify()`. PG NOTIFY payloads cap at 8000 bytes; for typical
+      // commits (1–10 events) this is comfortably under, and the polling
+      // fallback path handles the rare overflow case correctly.
+      const payload = JSON.stringify({
+        stream,
+        events: committed.map((c) => ({ id: c.id, name: c.name as string })),
+        by: this._by,
+      });
+      await client.query(`SELECT pg_notify($1, $2)`, [this._channel, payload]);
+
+      await client.query("COMMIT");
       return committed;
     } catch (error) {
       await client.query("ROLLBACK").catch(() => {});
@@ -812,6 +870,109 @@ export class PostgresStore implements Store {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Subscribes to cross-process commit notifications via PostgreSQL
+   * `LISTEN`/`NOTIFY`.
+   *
+   * Checks out a dedicated long-lived client from the pool, runs
+   * `LISTEN act_commit`, and parses each incoming notification payload.
+   * The handler is invoked exactly once per **remote** commit — payloads
+   * originating from this same store instance (matched by the per-instance
+   * `_by` UUID) are silently skipped, giving callers a clean
+   * cross-process semantic.
+   *
+   * Multiple subscriptions on the same store instance are not supported —
+   * this method releases any prior LISTEN client before opening a new one.
+   * The returned disposer cleanly UNLISTENs and releases the dedicated
+   * client; pool disposal also tears the subscription down as a safety
+   * net.
+   *
+   * @param handler Called for each cross-process commit notification.
+   * @returns Disposer that releases the LISTEN client.
+   */
+  async notify(
+    handler: (notification: StoreNotification) => void
+  ): Promise<NotifyDisposer> {
+    // Close any prior subscription so callers don't silently double-listen.
+    await this._teardownListen();
+
+    const client = await this._pool.connect();
+    const onNotification = (msg: pg.Notification) => {
+      // Channel filter: this client only `LISTEN`s on `this._channel`,
+      // but pg-pool can in theory deliver buffered notifications when a
+      // connection is reused — guard rather than trust.
+      if (msg.channel !== this._channel) return;
+      if (!msg.payload) return;
+      let parsed: {
+        stream?: unknown;
+        events?: unknown;
+        by?: unknown;
+      };
+      try {
+        parsed = JSON.parse(msg.payload);
+      } catch (err) {
+        // A malformed payload is a bug somewhere upstream — log and skip
+        // instead of tearing down the listener.
+        logger.error(
+          { err, payload: msg.payload },
+          "act_commit: malformed payload, skipping"
+        );
+        return;
+      }
+      // Self-filter: skip notifications that originated from this same
+      // store instance. This is what gives `notified` its cross-process
+      // semantic — local commits already arm the drain via `do()`.
+      if (parsed.by === this._by) return;
+      if (typeof parsed.stream !== "string" || !Array.isArray(parsed.events)) {
+        logger.error(
+          { payload: msg.payload },
+          "act_commit: payload missing required fields, skipping"
+        );
+        return;
+      }
+      const events: Array<{ id: number; name: string }> = [];
+      for (const raw of parsed.events) {
+        if (
+          raw &&
+          typeof raw === "object" &&
+          typeof (raw as { id?: unknown }).id === "number" &&
+          typeof (raw as { name?: unknown }).name === "string"
+        ) {
+          events.push({
+            id: (raw as { id: number }).id,
+            name: (raw as { name: string }).name,
+          });
+        }
+      }
+      if (events.length === 0) return;
+      try {
+        handler({ stream: parsed.stream, events });
+      } catch (err) {
+        // Never let a handler error tear the listener down — the user
+        // gets the same async error semantics as any other lifecycle
+        // listener.
+        logger.error(err, "act_commit: handler threw, listener preserved");
+      }
+    };
+    client.on("notification", onNotification);
+    try {
+      await client.query(`LISTEN ${this._channel}`);
+    } catch (err) {
+      client.removeListener("notification", onNotification);
+      client.release(true);
+      throw err;
+    }
+    this._listenClient = client;
+    this._listenHandler = onNotification;
+
+    return async () => {
+      // No-op when this disposer is stale (a later notify() call already
+      // tore the subscription down).
+      if (this._listenClient !== client) return;
+      await this._teardownListen();
+    };
   }
 
   /**

--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -32,7 +32,35 @@ types.setTypeParser(types.builtins.JSONB, (val) =>
   JSON.parse(val, dateReviver)
 );
 
-type Config = Readonly<{ schema: string; table: string }> & pg.PoolConfig;
+type Config = Readonly<{
+  schema: string;
+  table: string;
+  /**
+   * Opt in to cross-process commit notifications via `LISTEN`/`NOTIFY`.
+   * Optional — defaults to `false` so existing callers keep their
+   * current behavior. Setting it to `true` is the only behavior change
+   * an upgrading deployment needs to make to enable cross-process
+   * reaction wakeup.
+   *
+   * When `true`:
+   * - `commit()` issues `pg_notify` after each successful insert.
+   * - `notify(handler)` checks out a dedicated long-lived `LISTEN`
+   *   client from the pool and delivers cross-process notifications.
+   *
+   * When `false` (default):
+   * - `commit()` skips the notify SQL entirely — zero per-write
+   *   overhead.
+   * - The `notify` method is **not present on the instance**, so the
+   *   orchestrator's `if (store.notify)` auto-wire short-circuits and
+   *   no LISTEN client is allocated.
+   *
+   * Single-instance deployments should leave this off. Multi-process
+   * deployments that need sub-poll reaction latency turn it on
+   * **on every store instance** (writers and listeners both).
+   */
+  notify?: boolean;
+}> &
+  pg.PoolConfig;
 
 const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -67,6 +95,7 @@ const DEFAULT_CONFIG: Config = {
   password: "postgres",
   schema: "public",
   table: "events",
+  notify: false,
 };
 
 /**
@@ -204,6 +233,19 @@ export class PostgresStore implements Store {
    * connection would re-fire the stale handler.
    */
   private _listenHandler: ((msg: pg.Notification) => void) | undefined;
+  /**
+   * Cross-process commit subscription. **Present only when
+   * `config.notify === true`** — the orchestrator's auto-wire path
+   * checks `if (store.notify)`, so omitting the method keeps
+   * single-instance deployments free of any LISTEN/NOTIFY overhead
+   * (no dedicated client, no per-commit `pg_notify`).
+   *
+   * @see {@link Config.notify} for the rationale and the multi-process
+   *   contract.
+   */
+  notify?: (
+    handler: (notification: StoreNotification) => void
+  ) => Promise<NotifyDisposer>;
 
   /**
    * Create a new PostgresStore instance.
@@ -218,6 +260,12 @@ export class PostgresStore implements Store {
     this._fqt = `"${this.config.schema}"."${this.config.table}"`;
     this._fqs = `"${this.config.schema}"."${this.config.table}_streams"`;
     this._channel = notifyChannel(this.config.schema, this.config.table);
+    // Attach the notify subscriber only when the user opted in. With
+    // notify off, `this.notify` is `undefined`, the orchestrator skips
+    // its auto-wire, and no LISTEN client is ever allocated.
+    if (this.config.notify) {
+      this.notify = this._subscribeNotifications.bind(this);
+    }
   }
 
   /**
@@ -509,15 +557,23 @@ export class PostgresStore implements Store {
       // batch so listeners reason about atomic groups (matches reaction
       // semantics in the rest of the framework). `by` lets other
       // PostgresStore instances self-filter their own writes — see
-      // `notify()`. PG NOTIFY payloads cap at 8000 bytes; for typical
-      // commits (1–10 events) this is comfortably under, and the polling
-      // fallback path handles the rare overflow case correctly.
-      const payload = JSON.stringify({
-        stream,
-        events: committed.map((c) => ({ id: c.id, name: c.name as string })),
-        by: this._by,
-      });
-      await client.query(`SELECT pg_notify($1, $2)`, [this._channel, payload]);
+      // `_subscribeNotifications()`. PG NOTIFY payloads cap at 8000
+      // bytes; for typical commits (1–10 events) this is comfortably
+      // under, and the polling fallback path handles the rare overflow
+      // case correctly. Skipped entirely when `config.notify === false`
+      // (the default) so single-instance deployments pay zero
+      // per-write overhead.
+      if (this.config.notify) {
+        const payload = JSON.stringify({
+          stream,
+          events: committed.map((c) => ({ id: c.id, name: c.name as string })),
+          by: this._by,
+        });
+        await client.query(`SELECT pg_notify($1, $2)`, [
+          this._channel,
+          payload,
+        ]);
+      }
 
       await client.query("COMMIT");
       return committed;
@@ -873,15 +929,16 @@ export class PostgresStore implements Store {
   }
 
   /**
-   * Subscribes to cross-process commit notifications via PostgreSQL
-   * `LISTEN`/`NOTIFY`.
+   * Implementation of the optional `Store.notify` hook. Bound onto
+   * `this.notify` in the constructor when `config.notify === true`,
+   * left detached otherwise — see {@link Config.notify}.
    *
    * Checks out a dedicated long-lived client from the pool, runs
-   * `LISTEN act_commit`, and parses each incoming notification payload.
-   * The handler is invoked exactly once per **remote** commit — payloads
-   * originating from this same store instance (matched by the per-instance
-   * `_by` UUID) are silently skipped, giving callers a clean
-   * cross-process semantic.
+   * `LISTEN act_commit_<schema>_<table>`, and parses each incoming
+   * notification payload. The handler is invoked exactly once per
+   * **remote** commit — payloads originating from this same store
+   * instance (matched by the per-instance `_by` UUID) are silently
+   * skipped, giving callers a clean cross-process semantic.
    *
    * Multiple subscriptions on the same store instance are not supported —
    * this method releases any prior LISTEN client before opening a new one.
@@ -892,7 +949,7 @@ export class PostgresStore implements Store {
    * @param handler Called for each cross-process commit notification.
    * @returns Disposer that releases the LISTEN client.
    */
-  async notify(
+  private async _subscribeNotifications(
     handler: (notification: StoreNotification) => void
   ): Promise<NotifyDisposer> {
     // Close any prior subscription so callers don't silently double-listen.

--- a/libs/act-pg/src/PostgresStore.ts
+++ b/libs/act-pg/src/PostgresStore.ts
@@ -1004,12 +1004,16 @@ export class PostgresStore implements Store {
         }
       }
       if (events.length === 0) return;
+      // Adapter-level robustness: a throwing handler must not tear
+      // down the dedicated LISTEN client. The orchestrator wraps its
+      // own `notified` emit + drain wakeup separately
+      // (`Act._wireNotify`) — defense in depth, with each layer
+      // protecting its own resources. Direct callers of
+      // `store.notify(handler)` (tests, custom integrations) inherit
+      // the adapter wrap.
       try {
         handler({ stream: parsed.stream, events });
       } catch (err) {
-        // Never let a handler error tear the listener down — the user
-        // gets the same async error semantics as any other lifecycle
-        // listener.
         logger.error(err, "act_commit: handler threw, listener preserved");
       }
     };

--- a/libs/act-pg/test/app.ts
+++ b/libs/act-pg/test/app.ts
@@ -20,40 +20,73 @@ const counter = state({ Counter: z.object({ count: z.number() }) })
   .emit(() => ["decremented", {}])
   .build();
 
-export const onIncremented = vi.fn().mockImplementation(async () => {
-  await sleep(100);
-});
-export const onDecremented = vi.fn().mockImplementation(async () => {
-  await sleep(100);
-  throw new Error("onDecremented failed");
-});
+// Explicit type annotation needed because tsc declaration emit otherwise
+// references the private `@vitest/spy` path; declaring the surface as the
+// orchestrator's `ReactionHandler` keeps the .d.ts portable.
+type AnyReaction = ReactionHandler<
+  {
+    incremented: Record<string, never>;
+    decremented: Record<string, never>;
+  },
+  "incremented" | "decremented"
+>;
 
-export const app = act()
-  .withState(counter)
-  .on("incremented")
-  .do(
-    onIncremented as ReactionHandler<
+export const onIncremented: AnyReaction = vi
+  .fn()
+  .mockImplementation(async () => {
+    await sleep(100);
+  });
+export const onDecremented: AnyReaction = vi
+  .fn()
+  .mockImplementation(async () => {
+    await sleep(100);
+    throw new Error("onDecremented failed");
+  });
+
+/**
+ * Build the test app on demand — `act()...build()` wires the orchestrator
+ * against whichever store is current, so tests must call this *after*
+ * injecting their `PostgresStore` via `store(adapter)`.
+ */
+export function buildApp() {
+  return act()
+    .withState(counter)
+    .on("incremented")
+    .do(
+      onIncremented as ReactionHandler<
+        {
+          incremented: Record<string, never>;
+          decremented: Record<string, never>;
+        },
+        "incremented"
+      >
+    )
+    .on("decremented")
+    .do(
+      onDecremented as ReactionHandler<
+        {
+          incremented: Record<string, never>;
+          decremented: Record<string, never>;
+        },
+        "decremented"
+      >,
       {
-        incremented: Record<string, never>;
-        decremented: Record<string, never>;
-      },
-      "incremented"
-    >
-  )
-  .on("decremented")
-  .do(
-    onDecremented as ReactionHandler<
-      {
-        incremented: Record<string, never>;
-        decremented: Record<string, never>;
-      },
-      "decremented"
-    >,
-    {
-      maxRetries: 2,
-      blockOnError: true,
-    }
-  )
-  .build();
+        maxRetries: 2,
+        blockOnError: true,
+      }
+    )
+    .build();
+}
+
+/**
+ * Late-bound alias populated by the test's `beforeAll`. Exported so
+ * spec files can keep their existing `app.do(...)` ergonomics — but the
+ * binding is filled only after the store has been injected.
+ */
+export let app: ReturnType<typeof buildApp>;
+
+export function setApp(instance: ReturnType<typeof buildApp>) {
+  app = instance;
+}
 
 export const actor = { id: "a", name: "a" };

--- a/libs/act-pg/test/commit.error.spec.ts
+++ b/libs/act-pg/test/commit.error.spec.ts
@@ -10,8 +10,11 @@ import { PostgresStore } from "../src/index.js";
 const query = (
   sql: string
 ): Promise<QueryResult<Committed<Schemas, keyof Schemas>>> => {
-  const commit = sql.indexOf("COMMIT");
-  if (commit > 0) return Promise.reject(Error("mocked commit error"));
+  // The post-INSERT path issues `SELECT pg_notify(...)` and then a
+  // standalone `COMMIT`. Match either to simulate a failure on the
+  // commit-side of the transaction.
+  if (sql.includes("COMMIT") || sql.includes("pg_notify"))
+    return Promise.reject(Error("mocked commit error"));
 
   return Promise.resolve({
     rowCount: 1,

--- a/libs/act-pg/test/notify-perf.bench.ts
+++ b/libs/act-pg/test/notify-perf.bench.ts
@@ -17,7 +17,7 @@
  * (`*.{test,spec}.ts`) skips it — the docker round-trip cost doesn't
  * inflate ordinary CI runtime. Numbers feed `PERFORMANCE.md`.
  *
- * Run: `pnpm -F @rotorsoft/act-pg exec vitest run --include test/notify-perf.bench.ts`
+ * Run: `pnpm -F @rotorsoft/act-pg exec vitest run --config vitest.bench.config.ts`
  */
 import {
   act,
@@ -77,7 +77,18 @@ function pct(samples: number[], p: number) {
 }
 
 async function setupReader(notifyEnabled: boolean, rec: LatencyRecorder) {
-  store(new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE }));
+  // notify path requires the store to opt in on both sides; the
+  // polling baseline still uses notify=true on the writer so the
+  // comparison isolates the wakeup mechanism (LISTEN vs poll), not
+  // whether NOTIFYs are emitted.
+  store(
+    new PostgresStore({
+      port: PORT,
+      schema: SCHEMA,
+      table: TABLE,
+      notify: true,
+    })
+  );
   await store().drop();
   await store().seed();
 
@@ -130,6 +141,7 @@ async function runScenario(
     port: PORT,
     schema: SCHEMA,
     table: TABLE,
+    notify: true,
   });
 
   try {

--- a/libs/act-pg/test/notify-perf.bench.ts
+++ b/libs/act-pg/test/notify-perf.bench.ts
@@ -1,0 +1,189 @@
+/**
+ * Cross-process commit→reaction latency report.
+ *
+ * Two `PostgresStore` instances on the same docker DB simulate two
+ * processes: a *writer* commits events, a *reader* runs reactions. We
+ * record commit→reaction latency for each event and report p50/p95/p99
+ * for two modes:
+ *
+ *   - **notify mode**: the reader builds an `Act` orchestrator against
+ *     its own store, so `Store.notify` auto-wires and `settle()` wakes
+ *     immediately on the writer's NOTIFY (no polling delay).
+ *   - **polling mode**: same orchestrator, with notify subscription
+ *     released and reactions driven by an explicit
+ *     `setInterval(correlate→drain, …)` pump.
+ *
+ * Filename uses `.bench.ts` so the default `vitest run` include pattern
+ * (`*.{test,spec}.ts`) skips it — the docker round-trip cost doesn't
+ * inflate ordinary CI runtime. Numbers feed `PERFORMANCE.md`.
+ *
+ * Run: `pnpm -F @rotorsoft/act-pg exec vitest run --include test/notify-perf.bench.ts`
+ */
+import {
+  act,
+  dispose,
+  type ReactionHandler,
+  state,
+  store,
+  ZodEmpty,
+} from "@rotorsoft/act";
+import { z } from "zod";
+import { PostgresStore } from "../src/PostgresStore.js";
+
+const PORT = 5431;
+const SCHEMA = "schema_notify_bench";
+const TABLE = "notify_bench";
+const ACTOR = { id: "bench", name: "bench" };
+const POLL_INTERVAL_MS = 50;
+const COMMITS = 30;
+const COMMIT_GAP_MS = 30;
+
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Tick: ZodEmpty })
+  .patch({ Tick: (_, s) => ({ count: s.count + 1 }) })
+  .on({ tick: ZodEmpty })
+  .emit(() => ["Tick", {}])
+  .build();
+
+type LatencyRecorder = {
+  start: (id: string) => void;
+  finish: (id: string) => void;
+  drain: () => number[];
+};
+
+function recorder(): LatencyRecorder {
+  const starts = new Map<string, number>();
+  const samples: number[] = [];
+  return {
+    start: (id) => starts.set(id, performance.now()),
+    finish: (id) => {
+      const t = starts.get(id);
+      if (t !== undefined) {
+        samples.push(performance.now() - t);
+        starts.delete(id);
+      }
+    },
+    drain: () => samples.splice(0),
+  };
+}
+
+function pct(samples: number[], p: number) {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  return sorted[
+    Math.min(sorted.length - 1, Math.floor((sorted.length * p) / 100))
+  ];
+}
+
+async function setupReader(notifyEnabled: boolean, rec: LatencyRecorder) {
+  store(new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE }));
+  await store().drop();
+  await store().seed();
+
+  async function handler(event: { meta: { correlation: string } }) {
+    rec.finish(event.meta.correlation);
+  }
+
+  const reader = act()
+    .withState(Counter)
+    .on("Tick")
+    .do(handler as ReactionHandler<{ Tick: Record<string, never> }, "Tick">)
+    .to((e) => ({ source: e.stream, target: `proj-${e.stream}` }))
+    .build();
+
+  let pollTimer: NodeJS.Timeout | undefined;
+  if (!notifyEnabled) {
+    // Tear down the auto-wired notify subscription and drive reactions
+    // with an explicit correlate→drain pump — the classic poll-based
+    // deployment shape. Avoid `settle()` here because its debounce
+    // coalesces rapid schedules and would mask the polling-only
+    // baseline we want to measure.
+    const disposer = await (
+      reader as unknown as {
+        _notify_disposer: Promise<(() => void | Promise<void>) | undefined>;
+      }
+    )._notify_disposer;
+    if (disposer) await disposer();
+    pollTimer = setInterval(async () => {
+      try {
+        await reader.correlate({ limit: 100 });
+        await reader.drain({ streamLimit: 50, eventLimit: 100 });
+      } catch {
+        // best-effort — pool may close mid-flight at teardown
+      }
+    }, POLL_INTERVAL_MS);
+  } else {
+    reader.on("notified", () => reader.settle({ debounceMs: 0 }));
+  }
+
+  return { reader, pollTimer };
+}
+
+async function runScenario(
+  prefix: string,
+  notifyEnabled: boolean
+): Promise<number[]> {
+  const rec = recorder();
+  const { reader, pollTimer } = await setupReader(notifyEnabled, rec);
+  const writer = new PostgresStore({
+    port: PORT,
+    schema: SCHEMA,
+    table: TABLE,
+  });
+
+  try {
+    for (let i = 0; i < COMMITS; i++) {
+      const id = `${prefix}-${i}`;
+      rec.start(id);
+      await writer.commit("stream-x", [{ name: "Tick", data: {} }], {
+        correlation: id,
+        causation: {
+          action: { stream: "stream-x", name: "tick", actor: ACTOR },
+        },
+      });
+      await new Promise((r) => setTimeout(r, COMMIT_GAP_MS));
+    }
+    // Allow trailing reactions to drain. Polling needs more headroom
+    // because each correlate→drain pass fires at most every
+    // POLL_INTERVAL_MS.
+    await new Promise((r) =>
+      setTimeout(r, notifyEnabled ? 500 : POLL_INTERVAL_MS * 8)
+    );
+    return rec.drain();
+  } finally {
+    if (pollTimer) clearInterval(pollTimer);
+    reader.stop_correlations();
+    reader.stop_settling();
+    await writer.dispose();
+    await dispose()();
+  }
+}
+
+describe("ACT-101 cross-process commit→reaction latency", () => {
+  it("p50/p95/p99 — notify vs polling", async () => {
+    const notifySamples = await runScenario("notify", true);
+    const pollSamples = await runScenario("poll", false);
+
+    const notifyKey = `notify (n=${notifySamples.length})`;
+    const pollKey = `polling (n=${pollSamples.length})`;
+    // eslint-disable-next-line no-console
+    console.log("\n=== ACT-101 cross-process commit→reaction latency ===");
+    // eslint-disable-next-line no-console
+    console.table({
+      [notifyKey]: {
+        p50: pct(notifySamples, 50).toFixed(1) + " ms",
+        p95: pct(notifySamples, 95).toFixed(1) + " ms",
+        p99: pct(notifySamples, 99).toFixed(1) + " ms",
+      },
+      [pollKey]: {
+        p50: pct(pollSamples, 50).toFixed(1) + " ms",
+        p95: pct(pollSamples, 95).toFixed(1) + " ms",
+        p99: pct(pollSamples, 99).toFixed(1) + " ms",
+      },
+    });
+    // The notify path SHOULD be meaningfully faster at p99 — assert
+    // a permissive bound so the report doubles as a regression guard.
+    expect(pct(notifySamples, 99)).toBeLessThan(pct(pollSamples, 99));
+  }, 60_000);
+});

--- a/libs/act-pg/test/notify.spec.ts
+++ b/libs/act-pg/test/notify.spec.ts
@@ -37,8 +37,20 @@ describe("PostgresStore.notify", () => {
     // One writer creates the schema/table; both stores point at the same
     // backing physical store but use different per-instance `_by` UUIDs,
     // simulating two processes.
-    writer = new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE });
-    listener = new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE });
+    // Enable cross-process notifications on both stores — the default
+    // is opt-out (no `pg_notify` per commit, no `notify` method).
+    writer = new PostgresStore({
+      port: PORT,
+      schema: SCHEMA,
+      table: TABLE,
+      notify: true,
+    });
+    listener = new PostgresStore({
+      port: PORT,
+      schema: SCHEMA,
+      table: TABLE,
+      notify: true,
+    });
     await writer.drop();
     await writer.seed();
   });
@@ -50,7 +62,7 @@ describe("PostgresStore.notify", () => {
 
   it("delivers a notification when a different store commits", async () => {
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
 
     await writer.commit("stream-A", [{ name: "EventX", data: { v: 1 } }], {
       correlation: "c",
@@ -72,7 +84,7 @@ describe("PostgresStore.notify", () => {
     // its own NOTIFY because the LISTEN handler skips payloads where
     // by === this._by.
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
 
     await listener.commit("stream-self", [{ name: "SelfEvent", data: {} }], {
       correlation: "c",
@@ -88,7 +100,7 @@ describe("PostgresStore.notify", () => {
 
   it("delivers the full event batch in a single notification", async () => {
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
 
     await writer.commit(
       "stream-batch",
@@ -114,7 +126,7 @@ describe("PostgresStore.notify", () => {
 
   it("disposer stops further deliveries", async () => {
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
     await dispose();
 
     await writer.commit(
@@ -131,9 +143,9 @@ describe("PostgresStore.notify", () => {
     const firstSeen: any[] = [];
     const secondSeen: any[] = [];
 
-    const firstDispose = await listener.notify((n) => firstSeen.push(n));
+    const firstDispose = await listener.notify!((n) => firstSeen.push(n));
     // Re-subscribe — should release the prior LISTEN client and start fresh.
-    const secondDispose = await listener.notify((n) => secondSeen.push(n));
+    const secondDispose = await listener.notify!((n) => secondSeen.push(n));
 
     await writer.commit("stream-rewire", [{ name: "Rewired", data: {} }], {
       correlation: "c",
@@ -151,7 +163,7 @@ describe("PostgresStore.notify", () => {
 
   it("survives malformed payloads on the channel without tearing down", async () => {
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
 
     // Inject a raw NOTIFY with a non-JSON payload via the writer's pool.
     // Use the same namespaced channel the writer/listener pair uses.
@@ -177,7 +189,7 @@ describe("PostgresStore.notify", () => {
 
   it("ignores NOTIFYs with no payload", async () => {
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
 
     const channel = (writer as any)._channel as string;
     const rawClient = await (writer as any)._pool.connect();
@@ -204,7 +216,7 @@ describe("PostgresStore.notify", () => {
 
   it("skips JSON payloads missing required fields", async () => {
     const received: any[] = [];
-    const dispose = await listener.notify((n) => received.push(n));
+    const dispose = await listener.notify!((n) => received.push(n));
 
     const channel = (writer as any)._channel as string;
     const rawClient = await (writer as any)._pool.connect();
@@ -256,15 +268,58 @@ describe("PostgresStore.notify", () => {
       port: PORT,
       schema: SCHEMA,
       table: "notify_listen_fail",
+      notify: true,
     });
     await broken.dispose();
-    await expect(broken.notify(() => {})).rejects.toBeDefined();
+    await expect(broken.notify!(() => {})).rejects.toBeDefined();
+  });
+
+  it("notify is undefined when config.notify is false (the default)", async () => {
+    // Default opt-out keeps the LISTEN path entirely off — the
+    // orchestrator's `if (store.notify)` short-circuits and no
+    // dedicated client is allocated.
+    const optedOut = new PostgresStore({
+      port: PORT,
+      schema: SCHEMA,
+      table: "notify_optout_test",
+    });
+    try {
+      expect(optedOut.notify).toBeUndefined();
+    } finally {
+      await optedOut.dispose();
+    }
+  });
+
+  it("commit() skips pg_notify when config.notify is false", async () => {
+    // Spin up a writer without notify and a listener with notify on the
+    // same channel — confirm nothing is delivered. This is the proof
+    // that opt-out actually saves the per-write `pg_notify`.
+    const optOutWriter = new PostgresStore({
+      port: PORT,
+      schema: SCHEMA,
+      table: TABLE,
+      // notify omitted → defaults false
+    });
+    const received: any[] = [];
+    const dispose = await listener.notify!((n) => received.push(n));
+    try {
+      await optOutWriter.commit(
+        "stream-no-notify",
+        [{ name: "Quiet", data: {} }],
+        { correlation: "c", causation: {} }
+      );
+      await sleep(200);
+      expect(received).toHaveLength(0);
+    } finally {
+      await dispose();
+      await optOutWriter.dispose();
+    }
   });
 
   it("survives a handler that throws — listener stays connected", async () => {
     const received: any[] = [];
     let throwOnce = true;
-    const dispose = await listener.notify((n) => {
+    const dispose = await listener.notify!((n) => {
       if (throwOnce) {
         throwOnce = false;
         throw new Error("handler boom");

--- a/libs/act-pg/test/notify.spec.ts
+++ b/libs/act-pg/test/notify.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Integration tests for `PostgresStore.notify` against the docker PG
+ * instance (port 5431, see docker-compose.yml at the repo root). Uses an
+ * isolated schema per file to avoid interfering with the wider PG suite.
+ */
+import { sleep } from "@rotorsoft/act";
+import { PostgresStore } from "../src/PostgresStore.js";
+
+const PORT = 5431;
+const SCHEMA = "schema_notify_test";
+const TABLE = "notify_test";
+
+/**
+ * Wait until `predicate()` returns true or the timeout elapses. Polling
+ * keeps the integration tests robust against PG's asynchronous LISTEN
+ * delivery — `pg_notify` round-trips are typically <5 ms but vary under
+ * CI load.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  { timeout = 1500, interval = 10 } = {}
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeout) {
+      throw new Error(`waitFor timed out after ${timeout}ms`);
+    }
+    await sleep(interval);
+  }
+}
+
+describe("PostgresStore.notify", () => {
+  let writer: PostgresStore;
+  let listener: PostgresStore;
+
+  beforeAll(async () => {
+    // One writer creates the schema/table; both stores point at the same
+    // backing physical store but use different per-instance `_by` UUIDs,
+    // simulating two processes.
+    writer = new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE });
+    listener = new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE });
+    await writer.drop();
+    await writer.seed();
+  });
+
+  afterAll(async () => {
+    await listener.dispose();
+    await writer.dispose();
+  });
+
+  it("delivers a notification when a different store commits", async () => {
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+
+    await writer.commit("stream-A", [{ name: "EventX", data: { v: 1 } }], {
+      correlation: "c",
+      causation: {},
+    });
+
+    await waitFor(() => received.length > 0);
+    expect(received).toHaveLength(1);
+    expect(received[0].stream).toBe("stream-A");
+    expect(received[0].events).toEqual([
+      { id: expect.any(Number), name: "EventX" },
+    ]);
+
+    await dispose();
+  });
+
+  it("self-filters: own commits don't fire the listener's handler", async () => {
+    // Use the listener as both writer and listener: it should NOT see
+    // its own NOTIFY because the LISTEN handler skips payloads where
+    // by === this._by.
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+
+    await listener.commit("stream-self", [{ name: "SelfEvent", data: {} }], {
+      correlation: "c",
+      causation: {},
+    });
+
+    // Wait long enough for any spurious notification to arrive.
+    await sleep(200);
+    expect(received).toHaveLength(0);
+
+    await dispose();
+  });
+
+  it("delivers the full event batch in a single notification", async () => {
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+
+    await writer.commit(
+      "stream-batch",
+      [
+        { name: "BatchA", data: {} },
+        { name: "BatchB", data: {} },
+        { name: "BatchC", data: {} },
+      ],
+      { correlation: "c", causation: {} }
+    );
+
+    await waitFor(() => received.length > 0);
+    expect(received).toHaveLength(1);
+    expect(received[0].stream).toBe("stream-batch");
+    expect(received[0].events.map((e: any) => e.name)).toEqual([
+      "BatchA",
+      "BatchB",
+      "BatchC",
+    ]);
+
+    await dispose();
+  });
+
+  it("disposer stops further deliveries", async () => {
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+    await dispose();
+
+    await writer.commit(
+      "stream-after-dispose",
+      [{ name: "PostDispose", data: {} }],
+      { correlation: "c", causation: {} }
+    );
+
+    await sleep(200);
+    expect(received).toHaveLength(0);
+  });
+
+  it("re-subscribing replaces the prior listen client", async () => {
+    const firstSeen: any[] = [];
+    const secondSeen: any[] = [];
+
+    const firstDispose = await listener.notify((n) => firstSeen.push(n));
+    // Re-subscribe — should release the prior LISTEN client and start fresh.
+    const secondDispose = await listener.notify((n) => secondSeen.push(n));
+
+    await writer.commit("stream-rewire", [{ name: "Rewired", data: {} }], {
+      correlation: "c",
+      causation: {},
+    });
+
+    await waitFor(() => secondSeen.length > 0);
+    expect(secondSeen).toHaveLength(1);
+    expect(firstSeen).toHaveLength(0);
+
+    // The first disposer is now stale but must remain safe to call.
+    await firstDispose();
+    await secondDispose();
+  });
+
+  it("survives malformed payloads on the channel without tearing down", async () => {
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+
+    // Inject a raw NOTIFY with a non-JSON payload via the writer's pool.
+    // Use the same namespaced channel the writer/listener pair uses.
+    const channel = (writer as any)._channel as string;
+    const rawClient = await (writer as any)._pool.connect();
+    try {
+      await rawClient.query(`SELECT pg_notify($1, 'not-json')`, [channel]);
+    } finally {
+      rawClient.release();
+    }
+    // Then send a valid commit and ensure the listener is still alive.
+    await sleep(50);
+    await writer.commit("stream-after-bad", [{ name: "AfterBad", data: {} }], {
+      correlation: "c",
+      causation: {},
+    });
+    await waitFor(() => received.length > 0);
+    expect(received).toHaveLength(1);
+    expect(received[0].stream).toBe("stream-after-bad");
+
+    await dispose();
+  });
+
+  it("ignores NOTIFYs with no payload", async () => {
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+
+    const channel = (writer as any)._channel as string;
+    const rawClient = await (writer as any)._pool.connect();
+    try {
+      // `NOTIFY chan` (no payload) — pg delivers msg.payload as ''.
+      await rawClient.query(`NOTIFY ${channel}`);
+    } finally {
+      rawClient.release();
+    }
+    await sleep(100);
+    expect(received).toHaveLength(0);
+
+    // Listener still alive — a real commit is delivered.
+    await writer.commit(
+      "stream-after-empty",
+      [{ name: "AfterEmpty", data: {} }],
+      { correlation: "c", causation: {} }
+    );
+    await waitFor(() => received.length > 0);
+    expect(received[0].stream).toBe("stream-after-empty");
+
+    await dispose();
+  });
+
+  it("skips JSON payloads missing required fields", async () => {
+    const received: any[] = [];
+    const dispose = await listener.notify((n) => received.push(n));
+
+    const channel = (writer as any)._channel as string;
+    const rawClient = await (writer as any)._pool.connect();
+    try {
+      // Valid JSON but missing `stream` (number instead of string).
+      await rawClient.query(`SELECT pg_notify($1, $2)`, [
+        channel,
+        JSON.stringify({ stream: 42, events: [], by: "other" }),
+      ]);
+      // Valid JSON but `events` not an array.
+      await rawClient.query(`SELECT pg_notify($1, $2)`, [
+        channel,
+        JSON.stringify({ stream: "ok", events: "nope", by: "other" }),
+      ]);
+      // Valid envelope but events array contains malformed entries
+      // (drop those, deliver no event when nothing valid remains).
+      await rawClient.query(`SELECT pg_notify($1, $2)`, [
+        channel,
+        JSON.stringify({
+          stream: "ok",
+          events: [{ id: "not-a-number", name: "X" }],
+          by: "other",
+        }),
+      ]);
+    } finally {
+      rawClient.release();
+    }
+    await sleep(100);
+    expect(received).toHaveLength(0);
+
+    // Listener still alive — a real commit is delivered.
+    await writer.commit(
+      "stream-after-bad-fields",
+      [{ name: "AfterBadFields", data: {} }],
+      { correlation: "c", causation: {} }
+    );
+    await waitFor(() => received.length > 0);
+    expect(received[0].stream).toBe("stream-after-bad-fields");
+
+    await dispose();
+  });
+
+  it("propagates LISTEN failures from notify()", async () => {
+    // Fresh store with a closed pool — LISTEN throws because no
+    // connection can be obtained. Confirms the error bubbles up
+    // (caught by the orchestrator's wireNotify and logged) rather
+    // than silently leaving the store in a half-set state.
+    const broken = new PostgresStore({
+      port: PORT,
+      schema: SCHEMA,
+      table: "notify_listen_fail",
+    });
+    await broken.dispose();
+    await expect(broken.notify(() => {})).rejects.toBeDefined();
+  });
+
+  it("survives a handler that throws — listener stays connected", async () => {
+    const received: any[] = [];
+    let throwOnce = true;
+    const dispose = await listener.notify((n) => {
+      if (throwOnce) {
+        throwOnce = false;
+        throw new Error("handler boom");
+      }
+      received.push(n);
+    });
+
+    // First commit triggers the throwing path.
+    await writer.commit("stream-throw", [{ name: "ThrowOnce", data: {} }], {
+      correlation: "c",
+      causation: {},
+    });
+    await sleep(100);
+    // Second commit should still be delivered to the recovered handler.
+    await writer.commit(
+      "stream-after-throw",
+      [{ name: "AfterThrow", data: {} }],
+      { correlation: "c", causation: {} }
+    );
+    await waitFor(() => received.length > 0);
+    expect(received[0].stream).toBe("stream-after-throw");
+
+    await dispose();
+  });
+});

--- a/libs/act-pg/test/store.error.spec.ts
+++ b/libs/act-pg/test/store.error.spec.ts
@@ -196,6 +196,23 @@ describe("PostgresStore", () => {
   });
 
   describe("notify", () => {
+    // The notify subscription is opt-in via `notify: true` in the
+    // store config — without it, `store.notify` is undefined and the
+    // orchestrator never wires LISTEN/NOTIFY.
+    let notifyStore: PostgresStore;
+    beforeEach(() => {
+      notifyStore = new PostgresStore({
+        port: 5431,
+        table: "store_error_test",
+        notify: true,
+      });
+    });
+
+    it("is undefined when config.notify is false", () => {
+      expect(store.notify).toBeUndefined();
+      expect(notifyStore.notify).toBeTypeOf("function");
+    });
+
     it("ignores notifications on a different channel", async () => {
       // Hold the registered `notification` listener so we can call it
       // directly with a synthetic message — pg-pool can in theory
@@ -215,7 +232,7 @@ describe("PostgresStore", () => {
         client
       );
       const handler = vi.fn();
-      await store.notify(handler);
+      await notifyStore.notify!(handler);
       expect(captured).toBeTypeOf("function");
       // Synthetic message on a foreign channel — must be ignored.
       captured!({ channel: "some_other_channel", payload: "{}" });
@@ -244,7 +261,9 @@ describe("PostgresStore", () => {
         // @ts-expect-error mock
         client
       );
-      await expect(store.notify(() => {})).rejects.toThrow("listen fail");
+      await expect(notifyStore.notify!(() => {})).rejects.toThrow(
+        "listen fail"
+      );
       // Listener attached then detached; client released with destroy=true.
       expect(on).toHaveBeenCalledWith("notification", expect.any(Function));
       expect(removeListener).toHaveBeenCalledWith(

--- a/libs/act-pg/test/store.error.spec.ts
+++ b/libs/act-pg/test/store.error.spec.ts
@@ -194,4 +194,64 @@ describe("PostgresStore", () => {
       ).resolves.toEqual([]);
     });
   });
+
+  describe("notify", () => {
+    it("ignores notifications on a different channel", async () => {
+      // Hold the registered `notification` listener so we can call it
+      // directly with a synthetic message — pg-pool can in theory
+      // deliver buffered notifications from a reused client even after
+      // we've LISTEN'd a fresh channel.
+      let captured: ((msg: any) => void) | undefined;
+      const client = {
+        query: vi.fn().mockResolvedValue({}),
+        on: vi.fn((event: string, fn: any) => {
+          if (event === "notification") captured = fn;
+        }),
+        removeListener: vi.fn(),
+        release: vi.fn(),
+      };
+      vi.spyOn(pg.Pool.prototype, "connect").mockResolvedValue(
+        // @ts-expect-error mock
+        client
+      );
+      const handler = vi.fn();
+      await store.notify(handler);
+      expect(captured).toBeTypeOf("function");
+      // Synthetic message on a foreign channel — must be ignored.
+      captured!({ channel: "some_other_channel", payload: "{}" });
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("releases the listen client when LISTEN throws", async () => {
+      // Successful connect, but LISTEN fails — exercises the clean-up
+      // branch in `notify()` that detaches the listener and destroys
+      // the client before rethrowing. Without this branch, a bad LISTEN
+      // would leak a connection from the pool.
+      const release = vi.fn();
+      const on = vi.fn();
+      const removeListener = vi.fn();
+      const client = {
+        query: vi
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.reject(new Error("listen fail"))
+          ),
+        on,
+        removeListener,
+        release,
+      };
+      vi.spyOn(pg.Pool.prototype, "connect").mockResolvedValue(
+        // @ts-expect-error mock
+        client
+      );
+      await expect(store.notify(() => {})).rejects.toThrow("listen fail");
+      // Listener attached then detached; client released with destroy=true.
+      expect(on).toHaveBeenCalledWith("notification", expect.any(Function));
+      expect(removeListener).toHaveBeenCalledWith(
+        "notification",
+        expect.any(Function)
+      );
+      expect(release).toHaveBeenCalledWith(true);
+    });
+  });
 });

--- a/libs/act-pg/test/store.spec.ts
+++ b/libs/act-pg/test/store.spec.ts
@@ -10,7 +10,14 @@ import {
 import { Chance } from "chance";
 import { Pool } from "pg";
 import { PostgresStore } from "../src/index.js";
-import { actor, app, onDecremented, onIncremented } from "./app.js";
+import {
+  actor,
+  app,
+  buildApp,
+  onDecremented,
+  onIncremented,
+  setApp,
+} from "./app.js";
 
 const chance = new Chance();
 const a1 = chance.guid();
@@ -33,6 +40,9 @@ describe("pg store", () => {
     );
     await store().drop();
     await store().seed();
+    // Build the orchestrator AFTER injecting the store — the notify
+    // wiring binds at construction, so late injection wouldn't take.
+    setApp(buildApp());
   });
 
   afterAll(async () => {

--- a/libs/act-pg/vitest.bench.config.ts
+++ b/libs/act-pg/vitest.bench.config.ts
@@ -1,0 +1,20 @@
+/**
+ * Vitest config for `*.bench.ts` files. The default test run uses the
+ * standard `*.{test,spec}.ts` glob — bench files are excluded so the
+ * docker round-trip cost stays out of normal CI cycles. Invoke this
+ * config explicitly to record performance numbers for `PERFORMANCE.md`:
+ *
+ *   pnpm -F @rotorsoft/act-pg exec vitest run --config vitest.bench.config.ts
+ */
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Only the notify-perf bench is shaped as a vitest spec (it uses
+    // `it()` and asserts a regression bound). The other `.bench.ts`
+    // files in this directory are vitest-bench-mode files (run via
+    // `vitest bench`), so they're excluded from this run.
+    include: ["test/notify-perf.bench.ts"],
+    globals: true,
+  },
+});

--- a/libs/act-sqlite/README.md
+++ b/libs/act-sqlite/README.md
@@ -110,6 +110,10 @@ SQLite serializes all write transactions at the database level. This means:
 
 For multi-server deployments requiring distributed stream processing, use [@rotorsoft/act-pg](https://www.npmjs.com/package/@rotorsoft/act-pg) instead.
 
+## What's *not* implemented
+
+- **`Store.notify`** is intentionally absent. The notify hook is a cross-process wake-up signal that lets a horizontally-scaled Act deployment skip the polling lag on remote commits. SQLite is single-node by design — there's no remote writer to be notified of — so the {@link Act} orchestrator falls back to the existing debounce/poll path, which is correct for this topology. If you outgrow that, switch to `@rotorsoft/act-pg`.
+
 ## SQLite vs PostgreSQL
 
 | Feature | act-sqlite | act-pg |

--- a/libs/act-sqlite/src/SqliteStore.ts
+++ b/libs/act-sqlite/src/SqliteStore.ts
@@ -62,6 +62,13 @@ export function streamPatternToLike(input: string): string {
  * model is equivalent to PostgreSQL's `FOR UPDATE SKIP LOCKED` for
  * single-server deployments.
  *
+ * **`Store.notify` is intentionally not implemented.** The notify hook is
+ * a cross-process wake-up signal that lets a horizontally-scaled Act
+ * deployment wake `settle()` immediately on remote commits. SQLite is
+ * single-node by design — there is no remote writer to be notified of —
+ * so the {@link Act} orchestrator falls back to the existing
+ * debounce/poll path, which is correct for this topology.
+ *
  * @example
  * ```typescript
  * import { store } from "@rotorsoft/act";

--- a/libs/act-sqlite/test/app.ts
+++ b/libs/act-sqlite/test/app.ts
@@ -20,40 +20,53 @@ const counter = state({ Counter: z.object({ count: z.number() }) })
   .emit(() => ["decremented", {}])
   .build();
 
-export const onIncremented = vi.fn().mockImplementation(async () => {
-  await sleep(100);
-});
-export const onDecremented = vi.fn().mockImplementation(async () => {
-  await sleep(100);
-  throw new Error("onDecremented failed");
-});
+// Explicit type annotation needed because tsc declaration emit otherwise
+// references the private `@vitest/spy` path; declaring the surface as the
+// orchestrator's `ReactionHandler` keeps the .d.ts portable.
+type AnyReaction = ReactionHandler<
+  {
+    incremented: Record<string, never>;
+    decremented: Record<string, never>;
+  },
+  "incremented" | "decremented"
+>;
 
-export const app = act()
-  .withState(counter)
-  .on("incremented")
-  .do(
-    onIncremented as ReactionHandler<
-      {
-        incremented: Record<string, never>;
-        decremented: Record<string, never>;
-      },
-      "incremented"
-    >
-  )
-  .on("decremented")
-  .do(
-    onDecremented as ReactionHandler<
-      {
-        incremented: Record<string, never>;
-        decremented: Record<string, never>;
-      },
-      "decremented"
-    >,
-    {
-      maxRetries: 2,
-      blockOnError: true,
-    }
-  )
-  .build();
+export const onIncremented: AnyReaction = vi
+  .fn()
+  .mockImplementation(async () => {
+    await sleep(100);
+  });
+export const onDecremented: AnyReaction = vi
+  .fn()
+  .mockImplementation(async () => {
+    await sleep(100);
+    throw new Error("onDecremented failed");
+  });
+
+/**
+ * Build the test app on demand — `act()...build()` wires the orchestrator
+ * against whichever store is current, so tests must call this *after*
+ * injecting their `SqliteStore` via `store(adapter)`.
+ */
+export function buildApp() {
+  return act()
+    .withState(counter)
+    .on("incremented")
+    .do(onIncremented)
+    .on("decremented")
+    .do(onDecremented, { maxRetries: 2, blockOnError: true })
+    .build();
+}
+
+/**
+ * Late-bound alias populated by the test's `beforeAll`. Exported so spec
+ * files can keep their existing `app.do(...)` ergonomics — but the
+ * binding is filled only after the store has been injected.
+ */
+export let app: ReturnType<typeof buildApp>;
+
+export function setApp(instance: ReturnType<typeof buildApp>) {
+  app = instance;
+}
 
 export const actor = { id: "a", name: "a" };

--- a/libs/act-sqlite/test/store.spec.ts
+++ b/libs/act-sqlite/test/store.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "@rotorsoft/act";
 import { Chance } from "chance";
 import { SqliteStore } from "../src/index.js";
-import { actor, app } from "./app.js";
+import { actor, app, buildApp, setApp } from "./app.js";
 
 const chance = new Chance();
 const a1 = chance.guid();
@@ -23,6 +23,9 @@ describe("sqlite store", () => {
     store(new SqliteStore({ url: "file:test-store.db" }));
     await store().drop();
     await store().seed();
+    // Build orchestrator AFTER injecting the store (notify wiring binds
+    // at construction; late injection wouldn't take).
+    setApp(buildApp());
   });
 
   afterAll(async () => {

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -309,9 +309,32 @@ The `settle()` method is the recommended production pattern — it debounces rap
 
 **Batched projection replay:** Static-target projections can register a `.batch()` handler that receives all events in a single call, enabling bulk DB operations in one transaction. When defined, the batch handler replaces individual `.do()` handlers during drain — reducing N DB writes to 1. See [PERFORMANCE.md](PERFORMANCE.md) for benchmarks.
 
-### Real-Time Notifications
+### Cross-Process Reactions (`Store.notify`)
 
-When using the PostgreSQL backend, the store emits `NOTIFY` events on each commit, enabling consumers to react immediately via `LISTEN` rather than polling. This reduces latency and unnecessary database queries in production deployments.
+When two or more Act processes share a backing store, the second process has no in-process signal that the first committed. The default fallback is the polling/debounce path, which floors reaction latency at the poll interval. For lower latency, the configured store can implement the optional `Store.notify(handler)` hook; the orchestrator subscribes once at `build()` and wakes `settle()` immediately on remote commits.
+
+```ts
+// Auto-wired — users do nothing extra
+store(new PostgresStore({...}));     // PG implements notify via LISTEN/NOTIFY
+const app = act()
+  .withState(Order)
+  .on("OrderPlaced").do(reduceInventory).to("inventory")
+  .build();
+// Worker B wakes within ~10 ms of Worker A's commit (vs. polling: ≥ poll interval).
+
+// Optional: tap the lifecycle event for fan-out (SSE, dashboards, audit)
+app.on("notified", (n) => sse.broadcast(n));
+```
+
+Adapter status:
+
+- `PostgresStore` (`@rotorsoft/act-pg`) — implemented via `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel.
+- `InMemoryStore` — not implemented; single-process, no remote writers.
+- `SqliteStore` (`@rotorsoft/act-sqlite`) — not implemented; single-node by design.
+
+Stores **self-filter** their own commits (per-instance UUID in the payload) so the `"notified"` lifecycle event surfaces only **cross-process** activity. Local commits already arm drain via `do()` — the notify path stays out of the local fast path.
+
+`notify` is a hint, not a contract: if the store doesn't implement it, or a notification is dropped, the existing debounce/poll path still drains correctly. Build-time contract: inject the configured store via `store(adapter)` *before* `act()...build()` — wiring binds at construction.
 
 ## Dual-Frontier Drain
 

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -311,11 +311,12 @@ The `settle()` method is the recommended production pattern — it debounces rap
 
 ### Cross-Process Reactions (`Store.notify`)
 
-When two or more Act processes share a backing store, the second process has no in-process signal that the first committed. The default fallback is the polling/debounce path, which floors reaction latency at the poll interval. For lower latency, the configured store can implement the optional `Store.notify(handler)` hook; the orchestrator subscribes once at `build()` and wakes `settle()` immediately on remote commits.
+When two or more Act processes share a backing store, the second process has no in-process signal that the first committed. The default fallback is the polling/debounce path, which floors reaction latency at the poll interval. For lower latency, the configured store can implement the optional `Store.notify(handler)` hook; the orchestrator auto-wires the subscription at `build()` and wakes `settle()` immediately on remote commits.
+
+**Opt-in at the adapter level.** The cost (per-commit notification, dedicated DB connection per process) is wasted in single-instance deployments, so adapters default to off. Multi-process apps that need sub-poll wakeup enable it explicitly on every store instance:
 
 ```ts
-// Auto-wired — users do nothing extra
-store(new PostgresStore({...}));     // PG implements notify via LISTEN/NOTIFY
+store(new PostgresStore({ ..., notify: true }));   // opt in
 const app = act()
   .withState(Order)
   .on("OrderPlaced").do(reduceInventory).to("inventory")

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -293,13 +293,18 @@ export class Act<
     );
 
     // Auto-wire cross-process notifications when the configured store
-    // supports them and there is at least one reaction to wake. Stores
-    // self-filter their own commits, so the handler fires only for remote
-    // writers — the local fast path inside `do()` already arms the drain.
+    // exposes `Store.notify`. Adapters that opt out (PostgresStore with
+    // `notify: false` — the default — or stores that don't support
+    // notifications at all like InMemoryStore/SqliteStore) leave the
+    // method undefined, and the orchestrator skips subscription with
+    // zero overhead. Stores self-filter their own commits, so the
+    // handler fires only for remote writers — the local fast path
+    // inside `do()` already arms the drain.
     //
-    // Contract: callers must inject the store via `store(adapter)` BEFORE
-    // calling `build()`. The wiring binds to whatever store is current at
-    // construction; late injection won't take effect.
+    // Build-time contract: callers must inject the store via
+    // `store(adapter)` BEFORE calling `build()`. The wiring binds to
+    // whatever store is current at construction; late injection won't
+    // take effect.
     this._notify_disposer = this._wireNotify();
 
     dispose(async () => {

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -36,6 +36,7 @@ import type {
   SettleOptions,
   Snapshot,
   State,
+  StoreNotification,
   Target,
 } from "./types/index.js";
 
@@ -95,6 +96,20 @@ export type ActLifecycleEvents<
   blocked: BlockedLease[];
   settled: Drain<TEvents>;
   closed: CloseResult;
+  /**
+   * A **different process** committed an event to the same backing store.
+   *
+   * Fires only when the configured store implements
+   * {@link Store.notify} and there is at least one registered reaction.
+   * The orchestrator uses the same signal internally to wake `settle()`
+   * — listeners get the raw payload for SSE fan-out, dashboards, and
+   * audit logs.
+   *
+   * Local commits do *not* fire `notified` (use `committed` for those):
+   * stores self-filter their own writes so this channel has a clean
+   * cross-process semantic.
+   */
+  notified: StoreNotification;
 };
 
 /**
@@ -129,6 +144,22 @@ export class Act<
   private readonly _correlate: CorrelateCycle<TSchemaReg, TEvents, TActions>;
   /** Debounced correlate→drain catch-up loop. */
   private readonly _settle: SettleLoop<TEvents>;
+  /**
+   * Disposer for the cross-process notify subscription, set up eagerly
+   * during construction. Held as a promise because the subscription
+   * itself may be async (the PG adapter checks out a dedicated client
+   * and runs `LISTEN` before resolving). Resolves to `undefined` when
+   * the store doesn't implement `notify` or there are no registered
+   * reactions.
+   *
+   * **Contract:** the configured store must be injected via
+   * {@link store}`(adapter)` *before* calling `act()...build()`. The
+   * orchestrator wires notify against whatever store is current at
+   * construction time — late injection after build is unsupported.
+   */
+  private readonly _notify_disposer: Promise<
+    (() => void | Promise<void>) | undefined
+  >;
 
   /**
    * Emit a lifecycle event. The payload type is inferred from the event name
@@ -261,12 +292,57 @@ export class Act<
       options.settleDebounceMs ?? DEFAULT_SETTLE_DEBOUNCE_MS
     );
 
-    dispose(() => {
+    // Auto-wire cross-process notifications when the configured store
+    // supports them and there is at least one reaction to wake. Stores
+    // self-filter their own commits, so the handler fires only for remote
+    // writers — the local fast path inside `do()` already arms the drain.
+    //
+    // Contract: callers must inject the store via `store(adapter)` BEFORE
+    // calling `build()`. The wiring binds to whatever store is current at
+    // construction; late injection won't take effect.
+    this._notify_disposer = this._wireNotify();
+
+    dispose(async () => {
       this._emitter.removeAllListeners();
       this.stop_correlations();
       this.stop_settling();
-      return Promise.resolve();
+      // `_wireNotify` swallows subscription errors and resolves to
+      // `undefined`, so this promise never rejects.
+      const disposer = await this._notify_disposer;
+      if (disposer) await disposer();
     });
+  }
+
+  /**
+   * Subscribe to {@link Store.notify} when both the store and the
+   * registry support it. Returns the disposer (or `undefined` when no
+   * subscription was made). Errors during subscription are logged but
+   * never thrown — `notify` is a hint, not a contract.
+   */
+  private async _wireNotify(): Promise<
+    (() => void | Promise<void>) | undefined
+  > {
+    if (this._reactive_events.size === 0) return undefined;
+    const s = store();
+    if (!s.notify) return undefined;
+    try {
+      return await s.notify((notification) => {
+        this.emit("notified", notification);
+        // Wake once per commit when at least one event has a local
+        // reaction. Avoids spurious wake-ups for remote commits
+        // belonging to bounded contexts this process doesn't react to.
+        const hasReactive = notification.events.some((e) =>
+          this._reactive_events.has(e.name)
+        );
+        if (hasReactive) {
+          this._drain.arm();
+          this._settle.schedule({ debounceMs: 0 });
+        }
+      });
+    } catch (err) {
+      this._logger.error(err, "Store.notify subscription failed");
+      return undefined;
+    }
   }
 
   /**

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -332,16 +332,25 @@ export class Act<
     if (!s.notify) return undefined;
     try {
       return await s.notify((notification) => {
-        this.emit("notified", notification);
-        // Wake once per commit when at least one event has a local
-        // reaction. Avoids spurious wake-ups for remote commits
-        // belonging to bounded contexts this process doesn't react to.
-        const hasReactive = notification.events.some((e) =>
-          this._reactive_events.has(e.name)
-        );
-        if (hasReactive) {
-          this._drain.arm();
-          this._settle.schedule({ debounceMs: 0 });
+        // Generic concerns (lifecycle emit, drain wakeup, listener
+        // error containment) live here so adapters only have to
+        // handle their own wire format. Errors in user-registered
+        // `notified` listeners or in our own bookkeeping are logged
+        // and swallowed — the store's listener stays alive.
+        try {
+          this.emit("notified", notification);
+          // Wake once per commit when at least one event has a local
+          // reaction. Avoids spurious wake-ups for remote commits
+          // belonging to bounded contexts this process doesn't react to.
+          const hasReactive = notification.events.some((e) =>
+            this._reactive_events.has(e.name)
+          );
+          if (hasReactive) {
+            this._drain.arm();
+            this._settle.schedule({ debounceMs: 0 });
+          }
+        } catch (err) {
+          this._logger.error(err, "notified handler threw");
         }
       });
     } catch (err) {

--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -172,6 +172,12 @@ class InMemoryStream {
  * - Snapshot support
  * - Fast performance (no I/O overhead)
  *
+ * **`Store.notify` is intentionally not implemented.** The notify hook is a
+ * cross-process wake-up signal — local commits already arm the drain via
+ * `do()`. An in-memory store is single-process by definition, so there is
+ * no remote writer to be notified of. The {@link Act} orchestrator
+ * detects the absence and falls back to the existing debounce/poll path.
+ *
  * @example Using in tests
  * ```typescript
  * import { store } from "@rotorsoft/act";

--- a/libs/act/src/ports.ts
+++ b/libs/act/src/ports.ts
@@ -170,7 +170,7 @@ export const log = port(function log(adapter?: Logger) {
  * @see {@link Store} for the interface contract
  * @see {@link InMemoryStore} for the default implementation
  */
-export const store = port(function store(adapter?: Store) {
+export const store = port(function store(adapter?: Store): Store {
   return adapter || new InMemoryStore();
 });
 

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -73,6 +73,38 @@ export type TruncateResult = Map<
 >;
 
 /**
+ * Payload delivered by {@link Store.notify} when a **different process**
+ * commits one or more events to the same backing store.
+ *
+ * Notifications are emitted **per commit transaction**, not per event —
+ * a single commit of N events produces one notification carrying all N
+ * `events`. This matches transactional semantics, minimizes wire wakeups,
+ * and lets handlers reason about atomic batches.
+ *
+ * Stores that implement `notify` self-filter their own commits — handlers
+ * receive notifications only for cross-process activity. This is the signal
+ * that lets a horizontally-scaled Act deployment wake `settle()` immediately
+ * on remote commits, instead of waiting for the next poll/debounce cycle.
+ *
+ * @property stream - Stream that was committed to
+ * @property events - Events in this commit (id + name), in commit order
+ */
+export type StoreNotification = {
+  readonly stream: string;
+  readonly events: ReadonlyArray<{
+    readonly id: number;
+    readonly name: string;
+  }>;
+};
+
+/**
+ * Disposer returned by {@link Store.notify} subscriptions. Releases the
+ * underlying listener (e.g., the dedicated PG `LISTEN` client). May be
+ * synchronous or asynchronous — callers should `await` either way.
+ */
+export type NotifyDisposer = () => void | Promise<void>;
+
+/**
  * Subscription position for a registered stream.
  *
  * Streamed by {@link Store.query_streams} to power operational dashboards
@@ -499,6 +531,41 @@ export interface Store extends Disposable {
     callback: (position: StreamPosition) => void,
     query?: QueryStreams
   ) => Promise<QueryStreamsResult>;
+
+  /**
+   * Optional cross-process commit notifications.
+   *
+   * When implemented, the {@link Act} orchestrator subscribes once at build
+   * time and routes notifications to wake `settle()` automatically — so a
+   * remote worker's commit triggers reactions on this process without
+   * waiting for the debounce/poll cycle. Subscribers also receive each
+   * notification on the `"notified"` lifecycle event for fan-out
+   * (SSE pushes, audit logs, dashboards).
+   *
+   * **Self-filtering contract:** implementations must skip their own
+   * commits. The handler fires only for commits originating from a
+   * **different process** writing to the same backing store. This keeps
+   * the local fast path (`do()` already arms drain) free of duplicate
+   * wake-ups and gives `"notified"` a clean cross-process semantic.
+   *
+   * **Hint, not a contract:** the orchestrator never depends on `notify`
+   * for correctness. If absent, dropped, or the store omits it, the
+   * existing debounce/poll path still drains correctly — `notify` only
+   * lowers cross-process p99 reaction latency.
+   *
+   * Adapter status (Act 0.x):
+   * - {@link PostgresStore}: implemented via `LISTEN`/`NOTIFY` on the
+   *   `act_commit` channel
+   * - {@link InMemoryStore}: not implemented (single-process — no remote
+   *   writers exist)
+   * - `SqliteStore`: not implemented (single-node by design)
+   *
+   * @param handler Callback invoked once per remote commit
+   * @returns Disposer releasing the underlying listener
+   */
+  notify?: (
+    handler: (notification: StoreNotification) => void
+  ) => NotifyDisposer | Promise<NotifyDisposer>;
 }
 
 // ---------------------------------------------------------------------------

--- a/libs/act/test/notify.spec.ts
+++ b/libs/act/test/notify.spec.ts
@@ -68,11 +68,16 @@ async function buildAppWithNotifyStore(
       .do(async function noopReaction() {})
       .to("counter-projection");
   }
+  // The fake store above has a `notify` method assigned, so the
+  // orchestrator auto-wires unconditionally. Real adapters control
+  // overhead at the store-config level (e.g., `PostgresStore({ notify:
+  // true })` enables LISTEN/NOTIFY; `false` leaves the method
+  // undefined).
   const app = builder.build();
 
-  // Notify wiring is eager (kicked off in the constructor) but the
-  // subscription itself is async — yield once so the wire promise
-  // resolves before tests inspect captured state.
+  // Wiring is kicked off in the constructor but the subscription
+  // itself is async — yield once so the wire promise resolves before
+  // tests inspect captured state.
   await new Promise((r) => setImmediate(r));
 
   return {

--- a/libs/act/test/notify.spec.ts
+++ b/libs/act/test/notify.spec.ts
@@ -140,6 +140,24 @@ describe("Act ↔ Store.notify auto-wiring", () => {
     expect(settled).toHaveBeenCalled();
   });
 
+  it("contains errors thrown by user 'notified' listeners", async () => {
+    // The orchestrator wraps `emit` + drain wakeup in a try/catch so a
+    // bad user listener can't tear down the wiring. The drain wakeup
+    // for *this* notification is also lost (the throw shortcuts the
+    // settle schedule call), but the listener stays alive for future
+    // notifications.
+    const { app, capturedHandler } = await buildAppWithNotifyStore();
+    app.on("notified", () => {
+      throw new Error("user listener boom");
+    });
+    expect(() =>
+      capturedHandler()!({
+        stream: "remote-stream",
+        events: [{ id: 1, name: "Pressed" }],
+      })
+    ).not.toThrow();
+  });
+
   it("does not wake when no event in the batch is reactive", async () => {
     const { app, capturedHandler } = await buildAppWithNotifyStore();
     const settled = vi.fn();

--- a/libs/act/test/notify.spec.ts
+++ b/libs/act/test/notify.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Auto-wiring tests for `Act` ↔ `Store.notify`.
+ *
+ * Each test gets a fresh module graph via `vi.resetModules()` so the
+ * `store()` / `dispose()` singletons start clean. A handful of tests
+ * exercise the success path; the rest cover the no-op / error branches
+ * the orchestrator must tolerate.
+ */
+import { z } from "zod";
+
+vi.mock("../src/config.js", () => ({
+  config: vi.fn().mockReturnValue({
+    env: "test",
+    logLevel: "fatal",
+    logSingleLine: true,
+  }),
+}));
+
+type AnyHandler = (n: {
+  stream: string;
+  events: ReadonlyArray<{ id: number; name: string }>;
+}) => void;
+
+/**
+ * Builds an Act instance with a single reaction on `Pressed`, after
+ * injecting a `notify`-capable fake store. Returns the app, the captured
+ * notify handler, and bookkeeping spies for subscribe/dispose.
+ */
+async function buildAppWithNotifyStore(
+  opts: {
+    hasNotify?: boolean;
+    notifyThrows?: Error;
+    registerReaction?: boolean;
+  } = {}
+) {
+  const { hasNotify = true, notifyThrows, registerReaction = true } = opts;
+  vi.resetModules();
+  const { InMemoryStore } = await import("../src/adapters/in-memory-store.js");
+  const { store, dispose } = await import("../src/ports.js");
+  const { act, state } = await import("../src/index.js");
+
+  let captured: AnyHandler | undefined;
+  const notifyDispose = vi.fn().mockResolvedValue(undefined);
+  const subscribe = vi.fn(async (h: AnyHandler) => {
+    if (notifyThrows) throw notifyThrows;
+    captured = h;
+    return notifyDispose;
+  });
+
+  class FakeStore extends InMemoryStore {}
+  const fake = new FakeStore() as InstanceType<typeof FakeStore> & {
+    notify?: typeof subscribe;
+  };
+  if (hasNotify) fake.notify = subscribe;
+  store(fake);
+
+  const Counter = state({ Counter: z.object({ count: z.number() }) })
+    .init(() => ({ count: 0 }))
+    .emits({ Pressed: z.object({ digit: z.string() }) })
+    .on({ press: z.object({ digit: z.string() }) })
+    .emit("Pressed")
+    .build();
+
+  let builder = act().withState(Counter);
+  if (registerReaction) {
+    builder = builder
+      .on("Pressed")
+      .do(async function noopReaction() {})
+      .to("counter-projection");
+  }
+  const app = builder.build();
+
+  // Notify wiring is eager (kicked off in the constructor) but the
+  // subscription itself is async — yield once so the wire promise
+  // resolves before tests inspect captured state.
+  await new Promise((r) => setImmediate(r));
+
+  return {
+    app,
+    dispose,
+    subscribe,
+    notifyDispose,
+    capturedHandler: () => captured,
+  };
+}
+
+describe("Act ↔ Store.notify auto-wiring", () => {
+  afterEach(async () => {
+    const { dispose } = await import("../src/ports.js");
+    await dispose()("EXIT").catch(() => {});
+  });
+
+  it("subscribes when store has notify and reactions exist", async () => {
+    const { subscribe, capturedHandler } = await buildAppWithNotifyStore();
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(capturedHandler()).toBeTypeOf("function");
+  });
+
+  it("does not subscribe when there are no reactive events", async () => {
+    const { subscribe } = await buildAppWithNotifyStore({
+      registerReaction: false,
+    });
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("does not subscribe when store lacks notify", async () => {
+    const { subscribe } = await buildAppWithNotifyStore({ hasNotify: false });
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("emits 'notified' lifecycle event on incoming notifications", async () => {
+    const { app, capturedHandler } = await buildAppWithNotifyStore();
+    const seen: any[] = [];
+    app.on("notified", (n) => seen.push(n));
+    const handler = capturedHandler()!;
+    handler({
+      stream: "remote-stream",
+      events: [{ id: 42, name: "Pressed" }],
+    });
+    expect(seen).toEqual([
+      { stream: "remote-stream", events: [{ id: 42, name: "Pressed" }] },
+    ]);
+  });
+
+  it("wakes settle when notification carries a reactive event", async () => {
+    const { app, capturedHandler } = await buildAppWithNotifyStore();
+    const settled = vi.fn();
+    app.on("settled", settled);
+    capturedHandler()!({
+      stream: "remote-stream",
+      events: [{ id: 1, name: "Pressed" }],
+    });
+    // settle() runs on a 0ms debounce; yield twice to let the loop run.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toHaveBeenCalled();
+  });
+
+  it("does not wake when no event in the batch is reactive", async () => {
+    const { app, capturedHandler } = await buildAppWithNotifyStore();
+    const settled = vi.fn();
+    app.on("settled", settled);
+    capturedHandler()!({
+      stream: "remote-stream",
+      events: [{ id: 1, name: "UnknownEvent" }],
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("disposer runs on app dispose", async () => {
+    const { dispose, notifyDispose } = await buildAppWithNotifyStore();
+    await dispose()("EXIT").catch(() => {});
+    expect(notifyDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows subscription errors and falls back to debounce/poll", async () => {
+    const result = await buildAppWithNotifyStore({
+      notifyThrows: new Error("boom"),
+    });
+    // App built without throwing; the notified handler is undefined.
+    expect(result.capturedHandler()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #672. Adds an optional `Store.notify(handler)` subscription that the orchestrator auto-wires at build time, with the cost gated behind a per-adapter opt-in.

- **`PostgresStore`**: implements `notify` via `LISTEN`/`NOTIFY` on a per-`(schema, table)` channel (`act_commit_<schema>_<table>`). **Opt-in via `notify: true`** (default `false`) — when off, `commit()` skips `pg_notify` and the `notify` method is undefined on the instance, so the orchestrator's auto-wire `if (store.notify)` short-circuits and no LISTEN client is allocated. Existing callers see zero behavior change after upgrading.
- **`InMemoryStore`, `SqliteStore`**: `notify` left undefined — single-process / single-node by design.
- **`Act` orchestrator**: subscribes once at construction when the store exposes `notify` AND reactions are registered. New `notified` lifecycle event passes the payload through for SSE fan-out, dashboards, audit. Per-instance `_by` UUID self-filter keeps the channel cross-process — local commits already arm drain via `do()`.
- **Build-time contract**: inject `store(adapter)` *before* `act()...build()` — wiring binds at construction.

## Performance

Benchmark in [`libs/act-pg/PERFORMANCE.md`](https://github.com/Rotorsoft/act-root/blob/ACT-101/libs/act-pg/PERFORMANCE.md). Two `PostgresStore` instances on docker PG, 30 commits each:

| mode    | p50    | p95    | p99    |
| ------- | ------ | ------ | ------ |
| notify  | 8 ms   | 12 ms  | 25 ms  |
| polling | 31 ms  | 54 ms  | 69 ms  |

At the default `start_correlations` 10s interval the gap blows out to ~1000×.

Run: `pnpm -F @rotorsoft/act-pg exec vitest run --config vitest.bench.config.ts`

## Coverage

100% statements / branches / functions / lines workspace-wide. 1024 tests passing.

## Docs

- `CLAUDE.md` — new "Cross-Process Reactions" section, `Store` contract amendment, troubleshooting bullet
- `libs/act/README.md`, `libs/act-pg/README.md`, `libs/act-sqlite/README.md` updated with opt-in story
- `docs/docs/architecture/cross-process-reactions.md` (new Docusaurus page)
- `.claude/skills/scaffold-act-app/server.md` — `notified` lifecycle event
- TSDoc on `Store.notify`, `StoreNotification`, `NotifyDisposer`, `ActLifecycleEvents.notified`, `Config.notify`

## Test plan

- [x] Workspace tests pass (`pnpm test`) — 1024/1024
- [x] Lint clean (`pnpm lint`)
- [x] Workspace build clean (`pnpm build`)
- [x] Coverage 100% across the board
- [x] Cross-process integration tests against docker PG (`libs/act-pg/test/notify.spec.ts`)
- [x] Default-off proof: writer with `notify: false` and listener with `notify: true` deliver no notifications
- [x] Auto-wiring unit tests with fake store (`libs/act/test/notify.spec.ts`)
- [x] Mock-based error-path tests (`libs/act-pg/test/store.error.spec.ts`)
- [x] Benchmark run: `pnpm -F @rotorsoft/act-pg exec vitest run --config vitest.bench.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)