### PR TITLE
docs: add stability charter for upcoming 1.0 (ACT-301)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ pnpm -F shared drizzle:migrate   # migrations (also auto-run before tests)
 - Events are immutable — never mutate event data; evolve via [versioned event names](docs/docs/architecture/event-schema-evolution.md)
 - All actions need actor context (`{ id, name }`)
 - ESM only (`"type": "module"`, `.js` import extensions)
+- Public API stability is governed by [STABILITY.md](STABILITY.md) — read before changing any builder API, `IAct` method, `Store`/`Cache` contract, lifecycle event, or public type export
 
 ## Commit Message Format
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Open an issue or join the discussion on [GitHub Discussions](https://github.com/
 ## Versioning
 
 This project follows [Semantic Versioning (SemVer)](https://semver.org/).  
-See [CHANGELOG.md](./CHANGELOG.md) for release notes and breaking changes.
+See [STABILITY.md](./STABILITY.md) for the stability charter — what semver protects and what it doesn't — and [CHANGELOG.md](./CHANGELOG.md) for release notes and breaking changes.
 
 ## Examples
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,97 @@
+# Stability Charter
+
+Act has been used in production with a public API that hasn't regressed in months. Every breaking change has been a deliberate version-bump preface, not an accident. This document is the explicit contract: what semver protects, what it doesn't, and how we evolve in each category.
+
+> **Status:** This charter takes effect with the **1.0** release, which is gated on completion of [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1). The current 0.x line already follows it in spirit — treat anything listed under "Covered" as stable in practice today, and anything under "Not covered" as subject to change.
+
+## Covered by semver
+
+Breaking changes to anything in this list require a **major** version bump and an entry in the relevant `CHANGELOG.md`.
+
+### Builder API
+
+The fluent surfaces exported from `@rotorsoft/act`:
+
+- `state(...)` — including `.init`, `.patch`, `.snap`, `.given`, `.build`
+- `slice(...)` — including `.actions`, `.given`, `.build`
+- `projection(...)` — including `.from`, `.on`, `.build`
+- `act(...)` — including `.with`, `.build`
+
+Adding new optional builder methods or new optional fields to existing return types is **not** a breaking change. Removing or renaming a method, changing a required parameter, or narrowing an output type **is**.
+
+### `IAct` interface
+
+The runtime surface returned from `act(...).build()`:
+
+- `do`, `load`, `query`, `query_array`
+- `drain`, `settle`, `correlate`
+- `reset`, `close`
+
+The signatures, return shapes, and behavioral contracts of these methods are stable. Additive new methods on `IAct` are not breaking. Changing the meaning of an existing call (e.g., what `settle()` guarantees) is.
+
+### Store and Cache adapter contracts
+
+The `Store` and `Cache` interfaces in `libs/act/src/types/` define what an adapter must implement. Once 1.0 ships:
+
+- Adding a **required** method to `Store` or `Cache` is a breaking change.
+- Adding an **optional** method (with a default fallback in the orchestrator) is not.
+- Changing the semantics of an existing method (return shape, error contract, ordering guarantees) is breaking.
+
+This is the contract third-party adapters depend on. We will be explicit in release notes when this surface changes.
+
+### Lifecycle events
+
+The events emitted by the orchestrator on the public event bus (`ActLifecycleEvents` in `libs/act/src/act.ts`):
+
+- `committed` — events committed by an action in this process (`Snapshot[]`)
+- `acked` — reactions that processed successfully (`Lease[]`)
+- `blocked` — reactions that exhausted their retry budget (`BlockedLease[]`)
+- `settled` — a drain cycle settled (`Drain`)
+- `closed` — a close-the-books cycle completed (`CloseResult`)
+- `notified` — a different process committed to the same backing store (`StoreNotification`); fires only when `Store.notify` is implemented and at least one reaction is registered
+
+Their names and payload shapes are stable. Adding new optional fields to a payload is not breaking; renaming or removing fields is. Adding new lifecycle event names is not breaking.
+
+### Public type exports
+
+Everything exported from `@rotorsoft/act` and `@rotorsoft/act/types`. If you can `import { Foo } from "@rotorsoft/act"` (or `/types`), the shape of `Foo` is covered.
+
+## Not covered
+
+These may change in **any** release, including patches. Don't depend on them in user code.
+
+- **`internal/`** — anything under `libs/act/src/internal/` or any adapter's internals. These modules are not exported from the package entry points; if you reach into them via deep imports, you are off the contract.
+- **Performance characteristics** — throughput, drain latency, cache hit rates. These are best-effort and tracked per-package in `PERFORMANCE.md`. We will not call a regression here a breaking change, but we will document changes in release notes when they meaningfully shift.
+- **Adapter implementation details** — connection pooling defaults, SQL/SQLite statement shape, internal queue mechanics, lease bookkeeping. The behavior the adapter is required to deliver is in the `Store`/`Cache` contract; everything else is implementation.
+- **Logging formats and trace breadcrumb shapes** — log line text, metadata keys, and trace event shapes are debug aids, not API. Wire-up via `Logger` adapters is covered (see contracts above); the content emitted through them is not.
+
+## How we evolve in each category
+
+- **Builder / `IAct` / public types** — additive changes go in `feat` commits and ship in minor releases. Breaking changes need a major bump and a written migration note in the release.
+- **Lifecycle events** — additive (new fields, new events) in minor. Breaking renames or removals in major, with at least one minor release shipping a deprecation alias when feasible.
+- **Adapter contracts** — new optional methods land in minor, with the orchestrator providing a default. New required methods or changed semantics land only in major.
+- **Events on disk** — schemas are never mutated. Breaking event shape changes use versioned event names (`TicketOpened` → `TicketOpened_v2`); see [Event Schema Evolution](docs/docs/architecture/event-schema-evolution.md). This is a runtime data contract, separate from the API contract above.
+
+## Per-library status
+
+| Package | Tracks core 1.0? |
+|---|---|
+| `@rotorsoft/act` | Yes — defines the charter |
+| `@rotorsoft/act-pg` | Yes — `Store` adapter, same contract |
+| `@rotorsoft/act-sqlite` | Yes — `Store` adapter, same contract |
+| `@rotorsoft/act-patch` | Yes — stable utility, depended on by `act` reducers |
+| `@rotorsoft/act-sse` | Yes — public broadcast surface |
+| `@rotorsoft/act-pino` | Yes — `Logger` adapter, narrow surface |
+| `@rotorsoft/act-diagram` | Goes to 1.0 alongside core. Diagram output shape (SVG structure, click-through anchors) is *not* part of the stability surface and may evolve. |
+
+Each library's `README.md` carries a one-line stability note linking back to this document.
+
+## Out of scope for the charter
+
+- Documentation under `docs/` and `.claude/skills/` — these evolve continuously and are not versioned with the libraries.
+- Example packages under `packages/` — `calculator`, `wolfdesk`, `server`, `client`, `inspector` are reference implementations, not published libraries.
+- Tools and scripts under `scripts/`.
+
+## Questions or proposed changes
+
+If you depend on a surface and aren't sure whether it's covered, open an issue. If you think something *should* be covered and isn't, open an issue — this charter is a living contract and we expect to tighten or loosen it as real-world usage exposes the edges.

--- a/libs/act-diagram/README.md
+++ b/libs/act-diagram/README.md
@@ -6,6 +6,8 @@
 
 Interactive domain model diagram for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act) event-sourced apps. Extracts states, actions, events, reactions, slices, and projections from TypeScript source code and renders them as an interactive SVG.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). The diagram **output shape** (SVG structure, click-through anchors) is *not* part of the stability surface and may evolve. Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Features
 
 - **Real-time visualization** — SVG diagram updates as source files change

--- a/libs/act-patch/README.md
+++ b/libs/act-patch/README.md
@@ -6,6 +6,8 @@
 
 Immutable deep-merge patch utility for [Act](https://github.com/rotorsoft/act-root) event-sourced apps. Zero dependencies, browser-safe.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Install
 
 ```sh

--- a/libs/act-pg/README.md
+++ b/libs/act-pg/README.md
@@ -6,6 +6,8 @@
 
 PostgreSQL event store adapter for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act). Provides persistent, production-ready event storage with ACID guarantees, connection pooling, and distributed stream processing.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Installation
 
 ```sh

--- a/libs/act-pino/README.md
+++ b/libs/act-pino/README.md
@@ -8,6 +8,8 @@ Pino logger adapter for the [@rotorsoft/act](https://www.npmjs.com/package/@roto
 
 Replaces Act's built-in `ConsoleLogger` with [pino](https://getpino.io/) — structured JSON logging, log levels, transports, redaction, and pretty-printing in development.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Install
 
 ```bash

--- a/libs/act-sqlite/README.md
+++ b/libs/act-sqlite/README.md
@@ -6,6 +6,8 @@
 
 SQLite event store adapter for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act). Provides persistent, file-based event storage with ACID guarantees via [`@libsql/client`](https://github.com/tursodatabase/libsql-client-ts). Ideal for single-server deployments, edge functions, and embedded applications.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Installation
 
 ```sh

--- a/libs/act-sse/README.md
+++ b/libs/act-sse/README.md
@@ -8,6 +8,8 @@ Incremental state broadcast over SSE for [@rotorsoft/act](https://www.npmjs.com/
 
 Instead of sending full aggregate state after each action, `act-sse` forwards the domain patches that event handlers already compute — sending only what changed as version-keyed partials.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Installation
 
 ```sh

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -6,6 +6,8 @@
 
 [Act](../../README.md) core library — Event Sourcing + CQRS framework for TypeScript, built around DDD aggregates and reaction-driven workflows.
 
+> **Stability:** Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
## Summary

- Adds `STABILITY.md` at the repo root: what semver protects (builder API, `IAct`, `Store`/`Cache` contracts, lifecycle events incl. `notified`, public type exports) and what it doesn't (`internal/`, performance, adapter internals, log/trace shapes).
- Links the charter from `README.md` (Versioning) and `CLAUDE.md` (Important Constraints).
- Adds a one-line stability pointer to each published lib README: `act`, `act-pg`, `act-sqlite`, `act-patch`, `act-sse`, `act-pino`, `act-diagram`. The `act-diagram` line also flags that the diagram **output shape** (SVG structure, anchors) is outside the stability surface.
- Charter takes effect at 1.0, **gated on completion of [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)**. No version bumps in this PR.

Refs ACT-301 (#678). Release-mechanics follow-up tracked in ACT-304 (#702).

## Test plan

- [ ] Render `STABILITY.md` on GitHub and confirm anchors + lib status table render correctly
- [ ] Click through the Versioning link in `README.md` to confirm it resolves to `STABILITY.md`
- [ ] Click through the lib README pointers (relative `../../STABILITY.md`) and confirm they resolve from each lib path
- [ ] Confirm CI is green (no code changed — should be a no-op for tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)