### PR TITLE
feat(act): enforce reference identity for cross-slice event schemas (ACT-401)

### DIFF
--- a/.claude/skills/scaffold-act-app/domain.md
+++ b/.claude/skills/scaffold-act-app/domain.md
@@ -113,6 +113,20 @@ export const Item = state({ Item: ItemState })
 
 **Partial states**: Multiple states sharing the same name (e.g., `state({ Ticket: PartialA })` and `state({ Ticket: PartialB })`) merge automatically in slices/act. When a partial redeclares an event in `.emits()` without a `.patch()`, it gets a passthrough reducer that yields to any custom reducer from another partial. Two different custom patches for the same event throw at build time.
 
+**Shared event schemas across partials**: when two partials of the same state declare the same event name in `.emits({...})`, both must reference the **same Zod schema instance** — different references throw at build time (ACT-401). Extract any cross-partial event schema to a shared module and import it in every partial that declares it:
+
+```typescript
+// schemas/events.ts
+export const TicketOpened = z.object({ title: z.string() });
+
+// each partial
+import { TicketOpened } from "./schemas/events.js";
+state({ Ticket: PartialA }).emits({ TicketOpened })  // shorthand
+state({ Ticket: PartialB }).emits({ TicketOpened })  // same reference, no drift
+```
+
+This is the canonical pattern for cross-slice events. Inlining the schema (`emits({ TicketOpened: z.object({...}) })`) in each partial produces silent contract drift the type system can't see.
+
 ## Slices with Co-located Projections
 
 **When to use a slice vs a standalone reaction at the act level:** Use slices when the reaction is part of a feature's vertical slice — it naturally groups with the state it modifies. Use act-level reactions (`.on("Event").do(handler)`) only for cross-cutting concerns that don't belong to any single feature (e.g., global audit logging). In practice, almost all reactions belong in slices.
@@ -123,7 +137,7 @@ export const Item = state({ Item: ItemState })
 - **One slice per reaction flow** — when reaction chains grow, each serial chain (event → reaction → action → state → event → reaction → …) lives in its own slice. A long serial chain stays in one slice when there is no fan-out at any junction point.
 - **Slices are minimal and self-contained** — each slice includes only the state it owns. It defines its own actions, events, patches, reactions, and projections.
 - **Single state schema, multiple partials** — one Zod schema defines the full state shape. Each slice declares a partial via `state({ Name: Schema })` with its own `.init()`, `.emits()`, `.patch()`, and `.on()`. The framework merges partials at build time.
-- **Redeclare trigger events via `.emits()`** — when a slice reacts to an event it doesn't produce, it redeclares the event in `.emits()` so `.on("EventName")` compiles. The passthrough default is discarded in favor of the custom reducer from the owning partial.
+- **Redeclare trigger events via `.emits()`** — when a slice reacts to an event it doesn't produce, it redeclares the event in `.emits()` so `.on("EventName")` compiles. The passthrough default is discarded in favor of the custom reducer from the owning partial. **The redeclaration must reuse the original Zod schema reference** — extract it to a shared module and import it (build throws on different references; ACT-401).
 - **One custom patch per event enforced at build time** — conflicting custom patches throw. Passthroughs always yield to custom reducers.
 - **Serial chains connect slices** — when one slice's output event is another's input with no other subscribers, they can be merged into a single slice.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ These are easy to get subtly wrong. Read the linked docs before editing related 
 - **Projection rebuild:** always `app.reset(targets)`, never `store().reset(targets)` directly. Only `app.reset` raises the orchestrator's drain-armed flag — without it, a settled app short-circuits and skips the replay. See [event-sourcing.md § Projection Rebuild](docs/docs/concepts/event-sourcing.md).
 - **Reactions auto-inject `reactingTo`:** inside a slice handler, `app.do(...)` automatically threads the triggering event as `reactingTo`. Pass an explicit fourth argument only when overriding. See [state-management.md § Auto-injected `reactingTo`](docs/docs/concepts/state-management.md).
 - **Single-key records:** `state({})`, `.on({})`, `.emits({})` accept exactly one key. Multi-key throws at runtime.
+- **Cross-slice event schemas:** when two same-name state partials declare the same event in `.emits({...})`, both must reference the **same Zod schema instance**. The merge throws on different references — extract shared event schemas to a module (`export const TicketOpened = z.object({...})`) and import in every slice that declares them. See [state-management.md § Cross-slice event schemas](docs/docs/concepts/state-management.md).
 - **Tests:** `store().seed()` in `beforeEach`; `dispose()()` in `afterAll`. In tests, prefer the explicit `await app.correlate(); await app.drain();` pair over `settle()` so cycle counts are deterministic.
 
 ## Code Organization (pointers, not duplication)

--- a/docs/docs/concepts/state-management.md
+++ b/docs/docs/concepts/state-management.md
@@ -67,6 +67,42 @@ const TicketOperations = state({ Ticket: z.object({ status: z.string() }) })
 
 This means a partial can redeclare an event in `.emits()` (to react to it via `.on()`) without overwriting the custom reducer from the partial that owns the event.
 
+### Cross-slice event schemas — reference identity
+
+When a partial redeclares an event so it can `.on()` it (or for a slice that reacts to events owned by another slice), the **Zod schema in both partials must be the same JS reference**. The merge throws at build time if two partials declare the same event with different schema instances — silent contract drift is the failure mode this rule prevents.
+
+```typescript
+// events/ticket.ts — single source of truth for the shared schema
+import { z } from "zod";
+
+export const TicketOpened = z.object({ title: z.string() });
+
+// slice A — owns the event
+import { TicketOpened } from "./events/ticket.js";
+
+const TicketCreation = state({ Ticket: TicketState })
+  .init(() => ({ title: "" }))
+  .emits({ TicketOpened })  // ← shorthand: { TicketOpened: TicketOpened }
+  .patch({ TicketOpened: (e, s) => ({ ...s, title: e.data.title }) })
+  // ...
+  .build();
+
+// slice B — reacts to the event; same reference, no schema redeclaration
+import { TicketOpened } from "./events/ticket.js";
+
+const TicketAudit = state({ Ticket: AuditState })
+  .init(() => ({ auditedAt: 0 }))
+  .emits({ TicketOpened })  // ← same reference, no drift possible
+  // ...
+  .build();
+```
+
+Inlining the schema in each partial — `.emits({ TicketOpened: z.object({...}) })` in slice A and a separate `z.object({...})` in slice B — produces two different references with potentially-different shapes, refinements, or enum constraints that TypeScript can't detect. The merge throws with a message that names the event, the state, and the fix:
+
+> Event "TicketOpened" in state "Ticket" is declared with different Zod schemas across slices. Cross-slice event schemas must reference the same instance — extract a shared schema (e.g. `export const TicketOpened = z.object({ ... })` in a shared module) and import it in every slice that declares it.
+
+Cross-state collisions (two slices declaring the same event name in *different* state names) still throw `Duplicate event` regardless of reference, because the same event name can only be owned by one state.
+
 ## Invariants
 
 Business rules enforced before actions execute:

--- a/libs/act/src/internal/merge.ts
+++ b/libs/act/src/internal/merge.ts
@@ -129,9 +129,20 @@ function mergeIntoExisting(
   for (const name of Object.keys(state.events)) {
     // Same schema reference means the same partial re-registered via another slice
     if (existing.events[name] === state.events[name]) continue;
-    // Allow same-name state partials to redeclare the same event
-    // (e.g., a partial that only needs the event name for .on() reactions)
-    if (existing.events[name]) continue;
+    // Same event name registered in a same-name state partial with a
+    // different Zod schema reference — silent contract drift that the
+    // type system can't catch (structurally compatible shapes flow
+    // through TS even when refinements/enums/literals disagree).
+    // Reference identity is the rule: cross-slice event schemas must
+    // come from a single shared instance.
+    if (existing.events[name]) {
+      throw new Error(
+        `Event "${name}" in state "${state.name}" is declared with different Zod schemas across slices. ` +
+          `Cross-slice event schemas must reference the same instance — ` +
+          `extract a shared schema (e.g. \`export const ${name} = z.object({ ... })\` in a shared module) ` +
+          `and import it in every slice that declares it.`
+      );
+    }
     if (events[name]) throw new Error(`Duplicate event "${name}"`);
   }
 

--- a/libs/act/test/partial-state.spec.ts
+++ b/libs/act/test/partial-state.spec.ts
@@ -7,9 +7,13 @@ describe("partial-state", () => {
     label: z.string(),
   });
 
+  // Cross-slice event schemas are reference-identity checked (ACT-401).
+  // Hoist any event schema shared between partials to a single instance.
+  const Incremented = z.object({ by: z.number() });
+
   const PartA = state({ Thing: schema })
     .init(() => ({ count: 0, label: "" }))
-    .emits({ Incremented: z.object({ by: z.number() }) })
+    .emits({ Incremented })
     .patch({
       Incremented: (event, state) => ({ count: state.count + event.data.by }),
     })
@@ -73,9 +77,11 @@ describe("partial-state", () => {
   });
 
   it("should throw on conflicting custom patches for same event across partials", () => {
+    // Share the `Incremented` schema with PartA (ACT-401 reference
+    // identity); the test concern is *patch* divergence.
     const DupEvent = state({ Thing: schema })
       .init(() => ({ count: 0, label: "" }))
-      .emits({ Incremented: z.object({ by: z.number() }) })
+      .emits({ Incremented })
       .patch({ Incremented: () => ({}) })
       .on({ other: ZodEmpty })
       .emit(() => ["Incremented", { by: 0 }])
@@ -336,13 +342,18 @@ describe("partial-state", () => {
   });
 
   describe("patch merge priority (passthrough vs custom)", () => {
+    // Shared event schema for cross-partial reuse (ACT-401 reference
+    // identity). These tests assert *patch* resolution, not schema
+    // identity, so the event schema is hoisted to a single instance.
+    const ListArchived = z.object({ reason: z.string() });
+
     it("should keep custom patch when existing is passthrough", async () => {
       // AutoArchive partial defines a custom patch for ListArchived
       const AutoArchive = state({
         TodoList: z.object({ status: z.string() }),
       })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         .patch({
           ListArchived: () => ({ status: "archived" }),
         })
@@ -353,7 +364,7 @@ describe("partial-state", () => {
       // Audit partial redeclares ListArchived with passthrough (just needs the event registered)
       const Audit = state({ TodoList: z.object({ status: z.string() }) })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         // no .patch() — passthrough is the default
         .on({ auditList: z.object({ note: z.string() }) })
         .emit(() => ["ListArchived", { reason: "audit" }])
@@ -370,7 +381,7 @@ describe("partial-state", () => {
       // Passthrough partial registered first
       const Audit = state({ TodoList: z.object({ status: z.string() }) })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         // passthrough default
         .on({ auditList: z.object({ note: z.string() }) })
         .emit(() => ["ListArchived", { reason: "audit" }])
@@ -381,7 +392,7 @@ describe("partial-state", () => {
         TodoList: z.object({ status: z.string() }),
       })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         .patch({
           ListArchived: () => ({ status: "archived" }),
         })
@@ -399,7 +410,7 @@ describe("partial-state", () => {
       const customPatch = () => ({ status: "archived" });
       const PartA = state({ TodoList: z.object({ status: z.string() }) })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         .patch({ ListArchived: customPatch })
         .on({ archiveA: z.object({ reason: z.string() }) })
         .emit((a) => ["ListArchived", { reason: a.reason }])
@@ -407,7 +418,7 @@ describe("partial-state", () => {
 
       const PartB = state({ TodoList: z.object({ status: z.string() }) })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         .patch({ ListArchived: customPatch }) // same function reference
         .on({ archiveB: z.object({ reason: z.string() }) })
         .emit((a) => ["ListArchived", { reason: a.reason }])
@@ -447,7 +458,7 @@ describe("partial-state", () => {
     it("should throw on two different custom patches for the same event", () => {
       const PartA = state({ TodoList: z.object({ status: z.string() }) })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         .patch({ ListArchived: () => ({ status: "archived" }) })
         .on({ archiveA: z.object({ reason: z.string() }) })
         .emit((a) => ["ListArchived", { reason: a.reason }])
@@ -455,7 +466,7 @@ describe("partial-state", () => {
 
       const PartB = state({ TodoList: z.object({ status: z.string() }) })
         .init(() => ({ status: "active" }))
-        .emits({ ListArchived: z.object({ reason: z.string() }) })
+        .emits({ ListArchived })
         .patch({ ListArchived: () => ({ status: "deleted" }) }) // different custom patch
         .on({ archiveB: z.object({ reason: z.string() }) })
         .emit((a) => ["ListArchived", { reason: a.reason }])

--- a/libs/act/test/slice.spec.ts
+++ b/libs/act/test/slice.spec.ts
@@ -231,6 +231,109 @@ describe("slice", () => {
     );
   });
 
+  // ACT-401: cross-slice event contract check via reference identity.
+  // Same-name state partials in different slices may redeclare the
+  // same event name (e.g. one slice produces, another reacts), but
+  // they MUST point at the same Zod schema instance. Different
+  // references = silent contract drift the type system can't see.
+  describe("cross-slice event contract (ACT-401)", () => {
+    it("allows same-name state partials that share the schema reference", () => {
+      // Shared schema constant in a real codebase — extracted to its
+      // own module and imported into every slice that declares it.
+      const Counted = z.object({ n: z.number() });
+
+      const CountA = state({ Counter: z.object({ total: z.number() }) })
+        .init(() => ({ total: 0 }))
+        .emits({ Counted })
+        .patch({ Counted: (e, s) => ({ total: s.total + e.data.n }) })
+        .on({ count: z.object({ n: z.number() }) })
+        .emit((a) => ["Counted", { n: a.n }])
+        .build();
+
+      const CountB = state({ Counter: z.object({ tag: z.string() }) })
+        .init(() => ({ tag: "" }))
+        .emits({ Counted }) // same reference — fine
+        .build();
+
+      const SliceA = slice().withState(CountA).build();
+      const SliceB = slice().withState(CountB).build();
+
+      expect(() => act().withSlice(SliceA).withSlice(SliceB)).not.toThrow();
+    });
+
+    it("throws when same-name state partials use different schema references for the same event", () => {
+      // Two inline declarations — structurally identical, but
+      // different JS references. This is the silent-drift case the
+      // check catches at build time.
+      const CountA = state({ Counter: z.object({ total: z.number() }) })
+        .init(() => ({ total: 0 }))
+        .emits({ Counted: z.object({ n: z.number() }) })
+        .patch({ Counted: (e, s) => ({ total: s.total + e.data.n }) })
+        .on({ count: z.object({ n: z.number() }) })
+        .emit((a) => ["Counted", { n: a.n }])
+        .build();
+
+      const CountB = state({ Counter: z.object({ tag: z.string() }) })
+        .init(() => ({ tag: "" }))
+        .emits({ Counted: z.object({ n: z.number() }) }) // structurally same, different ref
+        .build();
+
+      const SliceA = slice().withState(CountA).build();
+      const SliceB = slice().withState(CountB).build();
+
+      expect(() => act().withSlice(SliceA).withSlice(SliceB)).toThrow(
+        /Event "Counted" in state "Counter" is declared with different Zod schemas across slices/
+      );
+    });
+
+    it("error message points the developer at the shared-schema fix", () => {
+      const A = state({ Thing: z.object({ a: z.number() }) })
+        .init(() => ({ a: 0 }))
+        .emits({ Pinged: z.object({ at: z.number() }) })
+        .patch({ Pinged: (_, s) => s })
+        .on({ ping: z.object({ at: z.number() }) })
+        .emit((a) => ["Pinged", { at: a.at }])
+        .build();
+
+      const B = state({ Thing: z.object({ b: z.number() }) })
+        .init(() => ({ b: 0 }))
+        .emits({ Pinged: z.object({ at: z.number() }) }) // different ref
+        .build();
+
+      const SliceA = slice().withState(A).build();
+      const SliceB = slice().withState(B).build();
+
+      expect(() => act().withSlice(SliceA).withSlice(SliceB)).toThrow(
+        /extract a shared schema.*export const Pinged.*import it in every slice/s
+      );
+    });
+
+    it("throws on structurally-divergent schemas with the same name", () => {
+      // Schemas that aren't even structurally compatible. The check
+      // doesn't compare shape — it just enforces reference identity.
+      // Structural divergence is caught as a side effect.
+      const A = state({ Order: z.object({ id: z.string() }) })
+        .init(() => ({ id: "" }))
+        .emits({ OrderPaid: z.object({ amount: z.number().positive() }) })
+        .patch({ OrderPaid: (_, s) => s })
+        .on({ pay: z.object({ amount: z.number().positive() }) })
+        .emit((a) => ["OrderPaid", { amount: a.amount }])
+        .build();
+
+      const B = state({ Order: z.object({ note: z.string() }) })
+        .init(() => ({ note: "" }))
+        .emits({ OrderPaid: z.object({ amount: z.string() }) }) // diverged: string vs number
+        .build();
+
+      const SliceA = slice().withState(A).build();
+      const SliceB = slice().withState(B).build();
+
+      expect(() => act().withSlice(SliceA).withSlice(SliceB)).toThrow(
+        /Event "OrderPaid".*different Zod schemas/
+      );
+    });
+  });
+
   it("should support cross-slice reactions at the act level", async () => {
     const stream = nextStream();
 


### PR DESCRIPTION
Closes #681.

## Summary

When two same-name state partials in different slices both declare the same event in `.emits({...})`, the merge now requires them to point at the same Zod schema instance. Different references throw at build time with an explanatory message.

```
Event "OrderPaid" in state "Order" is declared with different Zod schemas across slices.
Cross-slice event schemas must reference the same instance — extract a shared schema
(e.g. `export const OrderPaid = z.object({ ... })` in a shared module) and import it in
every slice that declares it.
```

## Why

TypeScript can't catch this. Two structurally-compatible `z.object({...})` calls flow through the type system even when their Zod refinements / enums / literals disagree. The previous merge silently kept one partial's schema and dropped the other's, producing delayed `ZodError` at the next `load()` far from the cause. In chained-reaction scenarios it could leave events permanently unreadable for slices on the original contract.

Reference identity is a build-time forcing function for the right design: shared event schemas belong in a shared module. The fix for developers is mechanical — extract + import.

## Scope decisions

- **Reference identity over structural comparison.** Three reasons in the ticket discussion: ~10 LOC vs hundreds, better error message ("share the module" beats "field X diverges"), no false-positive equivalence between independently-declared structurally-identical schemas.
- **Throw day one, not warn-then-throw.** There's no "this is fine" path for parallel declarations — every case is fixable by extraction. A single major-version-boundary break is cleaner than dragging a warning through 1.x.

## Behavior change

Existing apps with parallel `.emits({...})` inlines of the same event (even structurally identical) will fail to build on upgrade. Migration is a one-import-per-slice mechanical change.

Cross-state collisions (different state names declaring the same event name) still throw `Duplicate event` regardless of reference. Wolfdesk in the repo already follows the shared-schema pattern, so no example or test app was broken by the new check.

## Tests

- **+4 in `slice.spec.ts`** — allow shared ref, throw on different ref, error message includes the fix advice, structurally divergent throws too.
- **5 updated in `partial-state.spec.ts`** — those tests' concern was patch resolution, not schema identity, so they now share the event schema instance via a hoisted const.
- 1069 tests pass, 100% coverage preserved (one new covered branch in `merge.ts`).

## Docs

- `CLAUDE.md` safety-critical one-liner pointing at the doc.
- `docs/docs/concepts/state-management.md` — new "Cross-slice event schemas — reference identity" section with example, shorthand pattern, and error message.
- `.claude/skills/scaffold-act-app/domain.md` — canonical pattern for cross-slice events; called out in the slice design decisions list.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1069 passed, 100% coverage
- [x] `pnpm lint` clean
- [ ] CI confirms tests + benches green
- [ ] Verify error message renders correctly in a real build failure (manual sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)