### PR TITLE
feat(act-tck): re-export port types + trigger initial 0.1.0 release

### DIFF
--- a/libs/act-tck/src/index.ts
+++ b/libs/act-tck/src/index.ts
@@ -59,6 +59,18 @@
  * adapters keep passing until they explicitly opt in.
  */
 
+// Re-export the port contracts so adapter authors only need a single
+// import line in their test files (`@rotorsoft/act-tck`) rather than
+// reaching into `@rotorsoft/act/types` for the interfaces and the TCK
+// for the run* functions. Same types — keeps the two paths from
+// drifting in adapter-author code.
+export type {
+  Cache,
+  CacheEntry,
+  Logger,
+  Store,
+  StoreNotification,
+} from "@rotorsoft/act/types";
 export type { CacheTckOptions } from "./cache-tck.js";
 export { runCacheTck } from "./cache-tck.js";
 export type { CounterEvents } from "./fixtures/events.js";


### PR DESCRIPTION
## Summary
- Re-export \`Store\`, \`Cache\`, \`Logger\`, \`CacheEntry\`, and \`StoreNotification\` from \`@rotorsoft/act-tck\`. Adapter authors writing TCK-driven tests previously needed imports from both \`@rotorsoft/act/types\` and \`@rotorsoft/act-tck\`; a single import now covers the whole adapter-test contract.
- Doubles as the trigger commit for the package's initial 0.1.0 release. The \`@rotorsoft/act-tck-v0.0.0\` baseline tag was pushed ahead of #716, but the CD matrix never enumerated \`act-tck\` until the filter map was fixed in #717. semantic-release will see this \`feat\` commit on top of the baseline tag and publish 0.1.0.

## Health
- 1237/1237 tests pass
- 100% coverage (statements / branches / functions / lines)
- Typecheck clean
- Lint clean

## Test plan
- [ ] CI runs against the act-tck path, CD matrix includes \`act-tck\`
- [ ] semantic-release publishes \`@rotorsoft/act-tck@0.1.0\` to npm
- [ ] \`pnpm install\` from a fresh consumer resolves \`@rotorsoft/act-tck\` with type declarations available

🤖 Generated with [Claude Code](https://claude.com/claude-code)