### PR TITLE
ci(act-303): add store conformance matrix + trim TCK-duplicate PG tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,147 @@
+name: Store Conformance Matrix
+
+# Runs the Store TCK from @rotorsoft/act-tck against every supported
+# version of the in-tree backend adapters. Catches dialect-specific
+# regressions (PG SKIP LOCKED behavior across majors, libSQL release
+# bumps) that the single-version `CI-CD` job can't see.
+#
+# Informational, not required for branch protection. A red cell signals
+# "this version slipped" — author owns the call to revert, pin, or
+# document the loss of support.
+
+on:
+  pull_request:
+    paths:
+      - "libs/act-pg/**"
+      - "libs/act-sqlite/**"
+      - "libs/act-tck/**"
+      - "libs/act/src/types/ports.ts"
+      - ".github/workflows/conformance.yml"
+  push:
+    branches: [master]
+    paths:
+      - "libs/act-pg/**"
+      - "libs/act-sqlite/**"
+      - "libs/act-tck/**"
+      - "libs/act/src/types/ports.ts"
+      - ".github/workflows/conformance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  SKIP_SIMPLE_GIT_HOOKS: 1
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  pg:
+    name: pg-${{ matrix.pg }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # PostgreSQL 13 went EOL 2025-11. 14 is the oldest still
+        # security-patched line; 17 is what `ci-cd.yml` uses as the
+        # ground-truth single-version run.
+        pg: ["14", "15", "16", "17"]
+    services:
+      postgres:
+        image: postgres:${{ matrix.pg }}-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5431:5432
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - run: pnpm install
+      - name: Run TCK against PostgreSQL ${{ matrix.pg }}
+        run: pnpm -F @rotorsoft/act-pg exec vitest run test/store-tck.spec.ts
+
+  sqlite:
+    name: libsql-${{ matrix.libsql }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pinned version is what the lockfile resolves to today; `latest`
+        # answers "does the next libSQL release break us before we adopt
+        # it." Two cells is enough — libSQL's surface is small and the
+        # release cadence makes a wider matrix expensive to maintain.
+        libsql:
+          - pinned
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Override @libsql/client to latest
+        if: matrix.libsql == 'latest'
+        # `pnpm.overrides` survives `pnpm install` and is the idiomatic
+        # way to swap a transitive version in a workspace. Writing into
+        # the root package.json keeps the change scoped to this job.
+        run: |
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            pkg.pnpm = pkg.pnpm ?? {};
+            pkg.pnpm.overrides = pkg.pnpm.overrides ?? {};
+            pkg.pnpm.overrides["@libsql/client"] = "latest";
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));
+          '
+          cat package.json | grep -A 3 '"pnpm"' || true
+
+      - run: pnpm install --no-frozen-lockfile
+      - name: Print resolved @libsql/client version
+        run: pnpm list --filter @rotorsoft/act-sqlite @libsql/client --depth 0
+      - name: Run TCK against libSQL ${{ matrix.libsql }}
+        run: pnpm -F @rotorsoft/act-sqlite exec vitest run test/store-tck.spec.ts
+
+  summary:
+    # Always runs so the workflow summary is populated even when a cell
+    # fails. `if: always()` is required because the matrix jobs' failure
+    # would otherwise mark this dependency as skipped.
+    if: always()
+    needs: [pg, sqlite]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compose conformance table
+        run: |
+          status() {
+            case "$1" in
+              success) echo "✅" ;;
+              failure) echo "❌" ;;
+              cancelled) echo "⚪" ;;
+              *) echo "❓" ;;
+            esac
+          }
+          {
+            echo "## Store conformance matrix"
+            echo ""
+            echo "| Adapter | Version | Result |"
+            echo "|---|---|---|"
+            # The `needs.<job>.result` for a matrix job rolls up to the
+            # worst single cell; per-cell detail is in the run UI.
+            echo "| PostgreSQL | 14, 15, 16, 17 | $(status ${{ needs.pg.result }}) |"
+            echo "| libSQL | pinned + latest | $(status ${{ needs.sqlite.result }}) |"
+            echo ""
+            echo "Per-version detail in the [run page](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <tr>
     <td width="62%" valign="top" align="center">
       <a href="https://github.com/rotorsoft/act-root/actions/workflows/ci-cd.yml"><img src="https://github.com/rotorsoft/act-root/actions/workflows/ci-cd.yml/badge.svg?branch=master" alt="Build Status"></a>
+      <a href="https://github.com/rotorsoft/act-root/actions/workflows/conformance.yml"><img src="https://github.com/rotorsoft/act-root/actions/workflows/conformance.yml/badge.svg?branch=master" alt="Store Conformance"></a>
       <a href="https://coveralls.io/github/Rotorsoft/act-root?branch=master"><img src="https://coveralls.io/repos/github/Rotorsoft/act-root/badge.svg?branch=master" alt="Coverage Status"></a>
       <img src="https://img.shields.io/github/repo-size/rotorsoft/act-root?style=flat-square" alt="Repo Size">
       <br/><br/>

--- a/libs/act-pg/test/store.spec.ts
+++ b/libs/act-pg/test/store.spec.ts
@@ -1,12 +1,4 @@
-import {
-  type Committed,
-  ConcurrencyError,
-  dispose,
-  type Schemas,
-  SNAP_EVENT,
-  sleep,
-  store,
-} from "@rotorsoft/act";
+import { dispose, SNAP_EVENT, store } from "@rotorsoft/act";
 import { Chance } from "chance";
 import { Pool } from "pg";
 import { PostgresStore } from "../src/index.js";
@@ -20,14 +12,8 @@ import {
 } from "./app.js";
 
 const chance = new Chance();
-const a1 = chance.guid();
-const a2 = chance.guid();
-const a3 = chance.guid();
 const a4 = chance.guid();
 const a5 = chance.guid();
-const pm = chance.guid();
-let created_before: Date;
-let created_after: Date;
 
 describe("pg store", () => {
   beforeAll(async () => {
@@ -47,111 +33,6 @@ describe("pg store", () => {
 
   afterAll(async () => {
     await dispose()();
-  });
-
-  it("should commit and query", async () => {
-    const query_correlation = chance.guid();
-
-    await store().commit(a1, [{ name: "test1", data: { value: "1" } }], {
-      correlation: "",
-      causation: {
-        action: { stream: a1, name: "", actor: { id: pm, name: "" } },
-      },
-    });
-    created_after = new Date();
-    await sleep(200);
-
-    await store().commit(a1, [{ name: "test1", data: { value: "2" } }], {
-      correlation: query_correlation,
-      causation: {},
-    });
-    await store().commit(a2, [{ name: "test2", data: { value: "3" } }], {
-      correlation: "",
-      causation: {
-        action: { stream: a2, name: "", actor: { id: pm, name: "" } },
-      },
-    });
-    await store().commit(a3, [{ name: "test1", data: { value: "4" } }], {
-      correlation: "",
-      causation: {},
-    });
-
-    await store().commit(a1, [{ name: "test2", data: { value: "5" } }], {
-      correlation: "",
-      causation: {},
-    });
-
-    await sleep(200);
-    created_before = new Date();
-    await sleep(200);
-
-    await store().commit(
-      a1,
-      [
-        { name: "test3", data: { value: "1" } },
-        { name: "test3", data: { value: "2" } },
-        { name: "test3", data: { value: "3" } },
-      ],
-      { correlation: query_correlation, causation: {} },
-      undefined
-    );
-
-    let first = 0;
-    const events: Committed<Schemas, keyof Schemas>[] = [];
-    await store().query(
-      (e) => {
-        first = first || e.id;
-        events.push(e);
-      },
-      { stream: a1 }
-    );
-    expect(first).toBeGreaterThan(0);
-    const l = events.length;
-    expect(l).toBe(6);
-    expect(events[l - 1].data).toStrictEqual({ value: "3" });
-    expect(events[l - 2].data).toStrictEqual({ value: "2" });
-    expect(events[l - 3].data).toStrictEqual({ value: "1" });
-
-    const events2: Committed<Schemas, keyof Schemas>[] = [];
-    await store().query((e) => events2.push(e), { after: first, limit: 2 });
-    expect(events2[0]?.id).toBe(first + 1);
-    expect(events2.length).toBe(2);
-
-    const events3: Committed<Schemas, keyof Schemas>[] = [];
-    await store().query((e) => events3.push(e), { names: ["test1"], limit: 5 });
-    expect(events3[0].name).toBe("test1");
-    expect(events3.length).toBeGreaterThanOrEqual(3);
-    events3.map((evt) => expect(evt.name).toBe("test1"));
-
-    expect(
-      await store().query(() => 0, { after: first, before: first + 4 })
-    ).toBe(3);
-
-    expect(
-      await store().query(() => 0, {
-        stream: a1,
-        created_after,
-        created_before,
-      })
-    ).toBe(2);
-
-    expect(await store().query(() => 0, { limit: 5 })).toBe(5);
-
-    expect(
-      await store().query(() => 0, {
-        limit: 10,
-        correlation: query_correlation,
-      })
-    ).toBe(4);
-
-    await expect(
-      store().commit(
-        a1,
-        [{ name: "test2", data: { value: "" } }],
-        { correlation: "", causation: {} },
-        1
-      )
-    ).rejects.toThrow();
   });
 
   it("should commit and load with state", async () => {
@@ -202,38 +83,6 @@ describe("pg store", () => {
     expect(count2).toBe(2);
   });
 
-  it("should commit and query backwards", async () => {
-    await store().commit(
-      a1,
-      [
-        { name: "test3", data: { value: "1" } },
-        { name: "test3", data: { value: "2" } },
-        { name: "test3", data: { value: "3" } },
-      ],
-      { correlation: "", causation: {} }
-    );
-    await store().commit(
-      a1,
-      [
-        { name: "test3", data: { value: "4" } },
-        { name: "test3", data: { value: "5" } },
-        { name: "test3", data: { value: "6" } },
-      ],
-      { correlation: "", causation: {} }
-    );
-
-    const events: Committed<Schemas, keyof Schemas>[] = [];
-    await store().query(
-      (e) => {
-        events.push(e);
-      },
-      { stream: a1, backward: true }
-    );
-    expect(events[0].data).toStrictEqual({ value: "6" });
-    expect(events[1].data).toStrictEqual({ value: "5" });
-    expect(events[2].data).toStrictEqual({ value: "4" });
-  });
-
   it("should throw on connection error (simulate by using invalid config)", async () => {
     await expect(
       new PostgresStore({ password: "bad", port: 5431 }).seed()
@@ -267,22 +116,6 @@ describe("pg store", () => {
     // Query without 'after' in the query object
     const result: any[] = [];
     await store().query((e) => result.push(e), { stream: "stream" });
-    expect(result.length).toBe(2);
-  });
-
-  it("should cover query branch with stream as RegExp", async () => {
-    // Commit events to multiple streams
-    await store().commit("regexA", [{ name: "test", data: { value: 1 } }], {
-      correlation: "c",
-      causation: {},
-    });
-    await store().commit("regexB", [{ name: "test", data: { value: 2 } }], {
-      correlation: "c",
-      causation: {},
-    });
-    // Query with stream as RegExp
-    const result: any[] = [];
-    await store().query((e) => result.push(e), { stream: "^regex" });
     expect(result.length).toBe(2);
   });
 


### PR DESCRIPTION
## Summary
The TCK from ACT-302 (#716) makes the Store contract executable, but \`ci-cd.yml\` runs it against a single hardcoded version of each backend (PG 17 + the locked \`@libsql/client\`). Dialect drift across PG majors (\`SKIP LOCKED\` ordering, generated-column behavior, \`LISTEN/NOTIFY\` plumbing) or a future libSQL release that breaks us would slip through. ACT-303 puts the TCK in a CI matrix so every supported version is validated on every relevant PR.

## What lands
- **\`.github/workflows/conformance.yml\`** runs the existing TCK spec files (\`libs/act-pg/test/store-tck.spec.ts\`, \`libs/act-sqlite/test/store-tck.spec.ts\`) against:
  - PostgreSQL **14, 15, 16, 17** (PG 13 went EOL 2025-11; 17 is the version \`ci-cd.yml\` already runs).
  - \`@libsql/client\` at the **locked version + \`latest\`** (two cells is enough; libSQL release cadence makes a wider matrix expensive).
- **Path-gated**: triggers only on PRs touching \`libs/act-pg/**\`, \`libs/act-sqlite/**\`, \`libs/act-tck/**\`, \`libs/act/src/types/ports.ts\`, or the workflow file itself.
- **Workflow summary** with a single conformance table — per-cell detail in the run page.
- **Conformance badge** added to root README, next to the existing CI badge.

## Design picks (per the sketch)
1. **One workflow, not two.** Cleaner badge story; PG and libSQL share the path-trigger.
2. **Informational, not required.** Sits alongside \`ci-cd.yml\`, not in front of it — a red PG 14 cell does not block an unrelated merge. Branch protection should stay on \`ci-cd.yml\` only.
3. **\`pnpm.overrides\` for libSQL versioning.** Idiomatic for workspaces, survives \`pnpm install\`, scoped to the job.
4. **InMemory stays in \`ci-cd.yml\`.** No versioned external dep to matrix on; its TCK run is already the main suite's job.

## Test plan
- [ ] Workflow runs on this PR (it touches a workflow file in the path filter)
- [ ] All four PG cells pass against the current TCK
- [ ] Both libSQL cells pass (\`latest\` is a leading indicator if it doesn't)
- [ ] Workflow summary renders the conformance table
- [ ] README badge resolves on the master run after merge

Closes #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)