### PR TITLE
docs(act): fix Correlator JSDoc that broke Docusaurus SSG

### DIFF
--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -163,9 +163,18 @@ export type CorrelatorContext = {
  * a readable + index-friendly default (`{state[:4]}-{action[:4]}-{ts}{rnd}`).
  *
  * Common patterns apps plug in:
- * - Embed a tenant id: `(ctx) => \`${tenantOf(ctx.actor)}-...\``
- * - Propagate an inbound trace id when present (HTTP middleware sets it
- *   on the actor or context).
+ *
+ * ```ts
+ * // Embed a tenant id pulled from the actor
+ * const tenantPrefixed: Correlator = (ctx) =>
+ *   tenantOf(ctx.actor) + "-" + defaultSuffix(ctx);
+ *
+ * // Propagate an inbound trace id when present
+ * const tracePropagating: Correlator = (ctx) =>
+ *   currentTraceId() ?? defaultCorrelator(ctx);
+ * ```
+ *
+ * Other shapes:
  * - Use ULID / UUIDv7 if you've standardized on those elsewhere.
  * - Call a database sequence for hard-monotonic ids (one extra round-trip
  *   per commit).


### PR DESCRIPTION
## Summary

Hotfix for the failed deploy on master after #726. TypeDoc renders the \`Correlator\` JSDoc to MDX; MDX reads \`\${tenantOf(ctx.actor)}\` as a JSX expression and throws \`ReferenceError: tenantOf is not defined\` at SSG time.

Replaced the inline template-literal example with a fenced code block, which MDX treats as plain text.

## Test plan

- [x] \`pnpm -F docs build:all\` succeeds locally
- [x] Affected page (\`/act-root/docs/api/act/src/type-aliases/Correlator\`) renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)