### PR TITLE
feat(act): add Store.query_stats — batched per-stream aggregates

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -33,6 +33,8 @@ Both invocations run a single root-level vitest process — no `pnpm -r` fan-out
 | `bench/drain-skip.micro.bench.ts` | A | drain after a non-reactive event (skip optimization) vs reactive event | Documents the [drain-skip optimization](./libs/act/PERFORMANCE.md#drain-skip-for-non-reactive-events-v0240) (~3× faster). |
 | `bench/batch-projection.scenario.bench.ts` | C | per-event drain vs batched drain at 50 / 200 / 500 events | Documents the [batched projection replay](./libs/act/PERFORMANCE.md#batched-projection-replay) (~10–100× faster). |
 | `bench/reaction-latency.scenario.bench.ts` | C | commit→reaction latency (p50 / p95 / p99) at idle / 100/sec / 1000/sec on `InMemoryStore` | **ACT-103**. Built-in regression bound: idle p99 < 50 ms. See [Reaction latency](./libs/act/PERFORMANCE.md#reaction-latency-act-103). |
+| `bench/query-stats.micro.bench.ts` | A | `Store.query_stats` vs pre-ACT-639 per-stream `query()` loop at N=10/100/1000 streams × 10 events (heads-only and full-scan paths) | **ACT-639**. Demonstrates the linear-vs-quadratic scaling: ~27× faster at N=1000 on InMemory. |
+| `bench/close-bulk.scenario.bench.ts` | C | bulk close-cycle scan: per-stream loop vs `query_stats` at N=10/100/1000 streams | **ACT-639**. Built-in regression bound: ≥2× faster at N=1000 (typically ~37× in practice). |
 | `scripts/perf-bench.ts` | B | JSON-output regression baseline (commit / load / drain throughput) | CI regression guard via `bench:run` + `bench:check`. Baseline lives in `libs/act/perf-baseline.json`. |
 | `scripts/realistic-bench.ts` | B | Multi-aggregate workload throughput | Manual sanity check before releases. |
 

--- a/BENCH.md
+++ b/BENCH.md
@@ -38,6 +38,8 @@ Both invocations run a single root-level vitest process — no `pnpm -r` fan-out
 | `scripts/perf-bench.ts` | B | JSON-output regression baseline (commit / load / drain throughput) | CI regression guard via `bench:run` + `bench:check`. Baseline lives in `libs/act/perf-baseline.json`. |
 | `scripts/realistic-bench.ts` | B | Multi-aggregate workload throughput | Manual sanity check before releases. |
 
+**ACT-639 query_stats per-adapter benches:** the InMemory bench above (`bench/query-stats.micro.bench.ts`) shows the linear-vs-quadratic structural win. The PG and SQLite benches below capture the round-trip and statement-prep cost that durable adapters actually pay (the architectural motivation for the primitive).
+
 ### `@rotorsoft/act-pg`
 
 | File | Shape | Measures | Notes |
@@ -50,10 +52,17 @@ Both invocations run a single root-level vitest process — no `pnpm -r` fan-out
 | `bench/notify-perf.scenario.bench.ts` | C | cross-process commit→reaction latency, notify vs polling | **ACT-101**. Built-in regression bound: notify p99 < polling p99. See [`act-pg/PERFORMANCE.md`](./libs/act-pg/PERFORMANCE.md#act-101--cross-process-commitreaction-latency-listennotify-wakeup). |
 | `bench/priority-claim.scenario.bench.ts` | C | priority-aware claim vs dual-frontier baseline | **ACT-102**. Validates per-stream priority lanes during saturated drain. See [`libs/act/PERFORMANCE.md`](./libs/act/PERFORMANCE.md). |
 | `bench/reaction-latency.scenario.bench.ts` | C | single-process commit→reaction latency on PG, idle / 100 per sec / 1000 per sec | **ACT-103**. Built-in regression bound: idle p50 < 50 ms. Numbers in [`libs/act/PERFORMANCE.md`](./libs/act/PERFORMANCE.md#reaction-latency-act-103). |
+| `bench/query-stats.micro.bench.ts` | A | `query_stats` vs per-stream `query()` loop at N=10/100/1000 streams × 10 events | **ACT-639**. Real DB measures round-trip + transaction amortization: 6.55× faster at N=1000. |
 | `scripts/correlate-checkpoint.ts` | B | three sub-benchmarks for the correlate checkpoint optimization | Validates [correlate-checkpoint](./libs/act/PERFORMANCE.md#correlation-checkpoint--static-resolver-optimization-v0220) deltas. |
 | `scripts/drain-contention.ts` | B | many workers × many streams, measuring waste/throughput | Operational research. |
 | `scripts/watermark-claim.ts` | B | claim performance with many subscribed streams | Validates [watermark-aware claim filtering](./libs/act/PERFORMANCE.md#watermark-aware-claim-filtering-v0230). |
 | `test/stress/runner.ts` | (custom) | end-to-end stress harness | Run via `pnpm -F @rotorsoft/act-pg stress`. |
+
+### `@rotorsoft/act-sqlite`
+
+| File | Shape | Measures | Notes |
+| --- | --- | --- | --- |
+| `bench/query-stats.micro.bench.ts` | A | `query_stats` vs per-stream `query()` loop at N=10/100/1000 streams × 10 events | **ACT-639**. Embedded SQLite — no network round trips; measures statement-prep overhead. ~1.9× faster at N=1000. |
 
 ### `@rotorsoft/act-patch`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,20 @@ Source-of-truth for what lives where:
   4. Run the TCK against every in-tree adapter (InMemory, act-pg, act-sqlite, act-pino).
   Example: when `Store.query_heads(streams)` (#639) lands, add a `queryHeads` capability and a "returns latest event per stream, empty for unknown, respects pagination" block in `store-tck.ts`.
 
+### Pre-handoff workflow (mandatory before "ready for review" / PR)
+
+Branch work isn't done until `/release-check` passes cleanly. Per-slice `pnpm test -F <pkg>` during development is fine; the final gate is **not optional**.
+
+Sequence at the end of a feature branch:
+
+1. `/release-check` — runs typecheck + tests + 100% coverage + lint + build + charter-diff in parallel. See [.claude/commands/release-check.md](.claude/commands/release-check.md).
+2. If coverage < 100% on any metric: run `/coverage` to see the uncovered lines, then write the fault-injection test or restructure the code to remove the branch. See `feedback_full_coverage.md` in memory and the patterns in `libs/act-pg/test/store.error.spec.ts` / `libs/act-sqlite/test/store.error.spec.ts`.
+3. Only then: announce "ready for review", show the diff summary, offer to open a PR via `/pr`.
+
+**Don't invent ad-hoc gates.** Running `pnpm typecheck` or eyeballing `pnpm test` output once doesn't substitute for the gate. Reach for the slash command first; narrow to ad-hoc tooling only for targeted debugging mid-development.
+
+Why this exists: the gate caught zero issues during development of ACT-639's eight slices because per-slice tests were run ad-hoc — but the merge gate verifies the full matrix (typecheck against the workspace, lint across changed files, build of every adapter, 100% coverage including newly-added defensive branches). Skipping it ships partially-verified work.
+
 ### Documentation discipline
 
 - **READMEs** show current patterns and strategies — not historical benchmarks

--- a/libs/act-pg/bench/query-stats.micro.bench.ts
+++ b/libs/act-pg/bench/query-stats.micro.bench.ts
@@ -1,0 +1,87 @@
+/**
+ * Benchmark: PostgresStore.query_stats vs pre-ACT-639 per-stream
+ * query() loop.
+ *
+ * This is where the architectural win shows: on a real DB the
+ * per-stream loop pays N **round trips** and N transactions, while
+ * query_stats issues exactly one indexed `DISTINCT ON` query. The
+ * InMemory microbench (`libs/act/bench/query-stats.micro.bench.ts`)
+ * already documents the linear-vs-quadratic part; this one captures
+ * the round-trip-per-stream cost that durable adapters actually pay.
+ *
+ * Run: pnpm bench:micro libs/act-pg/bench/query-stats.micro.bench.ts
+ */
+import type { Committed, Schemas } from "@rotorsoft/act";
+import { afterAll, beforeAll, bench, describe } from "vitest";
+import { PostgresStore } from "../src/postgres-store.js";
+
+const PORT = 5431;
+const SCHEMA = "query_stats_bench";
+const TABLE = "events";
+
+const SWEEP_STREAMS = [10, 100, 1000] as const;
+const EVENTS_PER_STREAM = 10;
+
+const store = new PostgresStore({ port: PORT, schema: SCHEMA, table: TABLE });
+const seeded: { [N in (typeof SWEEP_STREAMS)[number]]?: string[] } = {};
+
+beforeAll(async () => {
+  await store.drop();
+  await store.seed();
+  for (const N of SWEEP_STREAMS) {
+    const names: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const stream = `bench-${N}-${i}`;
+      names.push(stream);
+      const msgs = Array.from({ length: EVENTS_PER_STREAM }, (_, k) => ({
+        name: "Incremented",
+        data: { by: k + 1 },
+      }));
+      await store.commit(stream, msgs, {
+        correlation: "bench",
+        causation: {},
+      });
+    }
+    seeded[N] = names;
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await store.dispose();
+});
+
+async function perStreamHeads(streams: string[]) {
+  const out = new Map<string, Committed<Schemas, keyof Schemas>>();
+  await Promise.all(
+    streams.map(async (s) => {
+      let head: Committed<Schemas, keyof Schemas> | undefined;
+      await store.query<Schemas>(
+        (e) => {
+          if (!head) head = e;
+        },
+        { stream: s, stream_exact: true, backward: true, limit: 1 }
+      );
+      if (head) out.set(s, head);
+    })
+  );
+  return out;
+}
+
+for (const N of SWEEP_STREAMS) {
+  describe(`PG query_stats N=${N} streams x ${EVENTS_PER_STREAM} events`, () => {
+    bench("per-stream query() loop (pre-ACT-639)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await perStreamHeads(seeded[N]!);
+    });
+
+    bench("query_stats — heads only (DISTINCT ON, indexed)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await store.query_stats(seeded[N]!);
+    });
+
+    bench("query_stats — count + names (CTE + jsonb_object_agg)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await store.query_stats(seeded[N]!, { count: true, names: true });
+    });
+  });
+}

--- a/libs/act-pg/src/postgres-store.ts
+++ b/libs/act-pg/src/postgres-store.ts
@@ -1109,7 +1109,7 @@ export class PostgresStore implements Store {
    * exist for subscribed streams.
    */
   async query_stats<E extends Schemas>(
-    input: string[] | StreamFilter,
+    input: string[] | Pick<StreamFilter, "stream" | "stream_exact">,
     options?: QueryStatsOptions<E>
   ): Promise<Map<string, StreamStats<E>>> {
     const exclude = options?.exclude ?? [];
@@ -1124,40 +1124,24 @@ export class PostgresStore implements Store {
       return new Map<string, StreamStats<E>>();
     }
 
-    // Build the shared WHERE clause + parameter list. The `e.` alias is
-    // used unconditionally even when no JOIN — keeps column references
-    // stable across the two code paths.
+    // Build WHERE clause + parameter list. Subscription-level filters
+    // (source, blocked) are intentionally not accepted — events live in
+    // the events table; subscription state in the streams table. For
+    // "stats for blocked subscriptions" callers compose with
+    // query_streams. So no JOIN here.
     const where: string[] = [];
     const params: unknown[] = [];
-    const isArray = Array.isArray(input);
-    const needsStreamsJoin =
-      !isArray && (input.source !== undefined || input.blocked !== undefined);
 
-    if (isArray) {
+    if (Array.isArray(input)) {
       params.push(input);
       where.push(`e.stream = ANY($${params.length})`);
-    } else {
-      if (input.stream !== undefined) {
-        params.push(input.stream);
-        where.push(
-          input.stream_exact
-            ? `e.stream = $${params.length}`
-            : `e.stream ~ $${params.length}`
-        );
-      }
-      if (input.source !== undefined) {
-        where.push(`s.source IS NOT NULL`);
-        params.push(input.source);
-        where.push(
-          input.source_exact
-            ? `s.source = $${params.length}`
-            : `s.source ~ $${params.length}`
-        );
-      }
-      if (input.blocked !== undefined) {
-        params.push(input.blocked);
-        where.push(`s.blocked = $${params.length}`);
-      }
+    } else if (input.stream !== undefined) {
+      params.push(input.stream);
+      where.push(
+        input.stream_exact
+          ? `e.stream = $${params.length}`
+          : `e.stream ~ $${params.length}`
+      );
     }
     if (exclude.length) {
       params.push(exclude);
@@ -1168,9 +1152,7 @@ export class PostgresStore implements Store {
       where.push(`e.id < $${params.length}`);
     }
 
-    const fromClause = needsStreamsJoin
-      ? `${this._fqt} e JOIN ${this._fqs} s ON s.stream = e.stream`
-      : `${this._fqt} e`;
+    const fromClause = `${this._fqt} e`;
     // Always emit a WHERE clause — `WHERE TRUE` short-circuits the
     // empty-filter case without a conditional branch on the generation
     // side. PG optimizes the trivial predicate out.

--- a/libs/act-pg/src/postgres-store.ts
+++ b/libs/act-pg/src/postgres-store.ts
@@ -8,6 +8,7 @@ import type {
   Message,
   NotifyDisposer,
   Query,
+  QueryStatsOptions,
   QueryStreams,
   QueryStreamsResult,
   Schema,
@@ -16,6 +17,7 @@ import type {
   StoreNotification,
   StreamFilter,
   StreamPosition,
+  StreamStats,
 } from "@rotorsoft/act";
 import {
   ConcurrencyError,
@@ -1077,6 +1079,24 @@ export class PostgresStore implements Store {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Per-stream aggregated stats — see {@link Store.query_stats}.
+   *
+   * **Slice scaffolding (ACT-639 slice 1+2):** stub. Real implementation
+   * lands in slice 3 of #639 (DISTINCT ON for heads, CTE with
+   * `jsonb_object_agg` for full-scan path). Throws here so the interface
+   * is satisfied but accidental callers get a clear error message until
+   * the impl lands.
+   */
+  async query_stats<E extends Schemas>(
+    _input: string[] | StreamFilter,
+    _options?: QueryStatsOptions<E>
+  ): Promise<Map<string, StreamStats<E>>> {
+    throw new Error(
+      "PostgresStore.query_stats not implemented yet — see ACT-639 slice 3"
+    );
   }
 
   /**

--- a/libs/act-pg/src/postgres-store.ts
+++ b/libs/act-pg/src/postgres-store.ts
@@ -1171,7 +1171,10 @@ export class PostgresStore implements Store {
     const fromClause = needsStreamsJoin
       ? `${this._fqt} e JOIN ${this._fqs} s ON s.stream = e.stream`
       : `${this._fqt} e`;
-    const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+    // Always emit a WHERE clause — `WHERE TRUE` short-circuits the
+    // empty-filter case without a conditional branch on the generation
+    // side. PG optimizes the trivial predicate out.
+    const whereClause = `WHERE ${where.length ? where.join(" AND ") : "TRUE"}`;
 
     return fullScan
       ? this._queryStatsFullScan<E>(
@@ -1215,17 +1218,14 @@ export class PostgresStore implements Store {
     }
     if (tailRes) {
       for (const row of tailRes.rows) {
-        const existing = out.get(row.stream);
-        // Existing must be present — head and tail share the same WHERE,
-        // so any stream returning a tail must also have returned a head.
-        if (existing) {
-          (
-            existing as {
-              head: Committed<E, keyof E>;
-              tail?: Committed<E, keyof E>;
-            }
-          ).tail = row;
-        }
+        // Head and tail share the same WHERE, so any stream returning a
+        // tail must also have returned a head — no null check needed.
+        (
+          out.get(row.stream) as {
+            head: Committed<E, keyof E>;
+            tail?: Committed<E, keyof E>;
+          }
+        ).tail = row;
       }
     }
     return out;
@@ -1328,7 +1328,11 @@ export class PostgresStore implements Store {
         } as unknown as Committed<E, keyof E>;
       }
       if (wantCount) stats.count = row.agg_count;
-      if (wantNames) stats.names = row.agg_names ?? {};
+      // `agg_names` is non-null when this row exists: heads and agg are
+      // both built from the same `ef` CTE, so any stream in heads has
+      // at least one matching event and `jsonb_object_agg` returns an
+      // object (never null) for that group.
+      if (wantNames) stats.names = row.agg_names as Record<string, number>;
       out.set(row.stream, stats as StreamStats<E>);
     }
     return out;

--- a/libs/act-pg/src/postgres-store.ts
+++ b/libs/act-pg/src/postgres-store.ts
@@ -1084,19 +1084,254 @@ export class PostgresStore implements Store {
   /**
    * Per-stream aggregated stats — see {@link Store.query_stats}.
    *
-   * **Slice scaffolding (ACT-639 slice 1+2):** stub. Real implementation
-   * lands in slice 3 of #639 (DISTINCT ON for heads, CTE with
-   * `jsonb_object_agg` for full-scan path). Throws here so the interface
-   * is satisfied but accidental callers get a clear error message until
-   * the impl lands.
+   * Two code paths chosen by the requested stats:
+   *
+   * - **Heads-only path** (no `count`, no `names`): one or two
+   *   `SELECT DISTINCT ON (stream) ... ORDER BY stream, version DESC|ASC`
+   *   queries, executed in parallel when `tail: true`. The
+   *   `(stream, version)` unique index gives index-only access — K rows
+   *   touched per query (K = matched streams), not N (events).
+   *   Ordering by `version` (not `id`) is equivalent within a stream
+   *   (versions are monotonic per stream and events are committed
+   *   sequentially) and is the column actually indexed.
+   *
+   * - **Full-scan path** (`count` or `names` set): one CTE materializes
+   *   the filtered events, then `GROUP BY stream, name` →
+   *   `jsonb_object_agg(name, n)` for the `names` map plus per-stream
+   *   `COUNT(*)` for `count`. Heads (and `tails` when requested) come
+   *   from `DISTINCT ON` over the same CTE — they ride free on the
+   *   already-paid scan.
+   *
+   * The stream universe is derived from the events table: filter form
+   * matches event-bearing streams (not subscription rows). When the
+   * filter sets `source` or `blocked`, the events table is joined
+   * against the streams subscription table since those concepts only
+   * exist for subscribed streams.
    */
   async query_stats<E extends Schemas>(
-    _input: string[] | StreamFilter,
-    _options?: QueryStatsOptions<E>
+    input: string[] | StreamFilter,
+    options?: QueryStatsOptions<E>
   ): Promise<Map<string, StreamStats<E>>> {
-    throw new Error(
-      "PostgresStore.query_stats not implemented yet — see ACT-639 slice 3"
-    );
+    const exclude = options?.exclude ?? [];
+    const wantTail = options?.tail ?? false;
+    const wantCount = options?.count ?? false;
+    const wantNames = options?.names ?? false;
+    const before = options?.before;
+    const fullScan = wantCount || wantNames;
+
+    // Empty array short-circuit — saves a round trip on a no-op.
+    if (Array.isArray(input) && input.length === 0) {
+      return new Map<string, StreamStats<E>>();
+    }
+
+    // Build the shared WHERE clause + parameter list. The `e.` alias is
+    // used unconditionally even when no JOIN — keeps column references
+    // stable across the two code paths.
+    const where: string[] = [];
+    const params: unknown[] = [];
+    const isArray = Array.isArray(input);
+    const needsStreamsJoin =
+      !isArray && (input.source !== undefined || input.blocked !== undefined);
+
+    if (isArray) {
+      params.push(input);
+      where.push(`e.stream = ANY($${params.length})`);
+    } else {
+      if (input.stream !== undefined) {
+        params.push(input.stream);
+        where.push(
+          input.stream_exact
+            ? `e.stream = $${params.length}`
+            : `e.stream ~ $${params.length}`
+        );
+      }
+      if (input.source !== undefined) {
+        where.push(`s.source IS NOT NULL`);
+        params.push(input.source);
+        where.push(
+          input.source_exact
+            ? `s.source = $${params.length}`
+            : `s.source ~ $${params.length}`
+        );
+      }
+      if (input.blocked !== undefined) {
+        params.push(input.blocked);
+        where.push(`s.blocked = $${params.length}`);
+      }
+    }
+    if (exclude.length) {
+      params.push(exclude);
+      where.push(`e.name <> ALL($${params.length})`);
+    }
+    if (before !== undefined) {
+      params.push(before);
+      where.push(`e.id < $${params.length}`);
+    }
+
+    const fromClause = needsStreamsJoin
+      ? `${this._fqt} e JOIN ${this._fqs} s ON s.stream = e.stream`
+      : `${this._fqt} e`;
+    const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+    return fullScan
+      ? this._queryStatsFullScan<E>(
+          fromClause,
+          whereClause,
+          params,
+          wantTail,
+          wantCount,
+          wantNames
+        )
+      : this._queryStatsHeadsOnly<E>(fromClause, whereClause, params, wantTail);
+  }
+
+  /**
+   * Cheap path: index-only DISTINCT ON for the head per stream, plus an
+   * optional second query (in parallel) for the tail. K rows touched
+   * per query, not N events.
+   */
+  private async _queryStatsHeadsOnly<E extends Schemas>(
+    fromClause: string,
+    whereClause: string,
+    params: unknown[],
+    wantTail: boolean
+  ): Promise<Map<string, StreamStats<E>>> {
+    const cols = `e.id, e.stream, e.version, e.name, e.data, e.created, e.meta`;
+    const headSql = `SELECT DISTINCT ON (e.stream) ${cols} FROM ${fromClause} ${whereClause} ORDER BY e.stream, e.version DESC`;
+    const tailSql = wantTail
+      ? `SELECT DISTINCT ON (e.stream) ${cols} FROM ${fromClause} ${whereClause} ORDER BY e.stream, e.version ASC`
+      : null;
+
+    const [headRes, tailRes] = await Promise.all([
+      this._pool.query<Committed<E, keyof E>>(headSql, params),
+      tailSql
+        ? this._pool.query<Committed<E, keyof E>>(tailSql, params)
+        : Promise.resolve(null),
+    ]);
+
+    const out = new Map<string, StreamStats<E>>();
+    for (const row of headRes.rows) {
+      out.set(row.stream, { head: row });
+    }
+    if (tailRes) {
+      for (const row of tailRes.rows) {
+        const existing = out.get(row.stream);
+        // Existing must be present — head and tail share the same WHERE,
+        // so any stream returning a tail must also have returned a head.
+        if (existing) {
+          (
+            existing as {
+              head: Committed<E, keyof E>;
+              tail?: Committed<E, keyof E>;
+            }
+          ).tail = row;
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Full-scan path: one CTE-based query computes the per-stream
+   * `COUNT(*)` and `jsonb_object_agg(name, n)` map alongside the head
+   * (and tail when requested). All extras share the single events scan.
+   */
+  private async _queryStatsFullScan<E extends Schemas>(
+    fromClause: string,
+    whereClause: string,
+    params: unknown[],
+    wantTail: boolean,
+    wantCount: boolean,
+    wantNames: boolean
+  ): Promise<Map<string, StreamStats<E>>> {
+    const tailCte = wantTail
+      ? `, tails AS (SELECT DISTINCT ON (stream) * FROM ef ORDER BY stream, version ASC)`
+      : "";
+    const tailJoin = wantTail ? `LEFT JOIN tails t ON t.stream = h.stream` : "";
+    const tailCols = wantTail
+      ? `, t.id AS t_id, t.stream AS t_stream, t.version AS t_version,
+           t.name AS t_name, t.data AS t_data, t.created AS t_created, t.meta AS t_meta`
+      : "";
+
+    const sql = `
+      WITH ef AS (
+        SELECT e.id, e.stream, e.version, e.name, e.data, e.created, e.meta
+        FROM ${fromClause}
+        ${whereClause}
+      ),
+      agg AS (
+        SELECT stream,
+               SUM(n)::int AS cnt,
+               jsonb_object_agg(name, n) AS names
+        FROM (
+          SELECT stream, name, COUNT(*)::int AS n
+          FROM ef
+          GROUP BY stream, name
+        ) t
+        GROUP BY stream
+      ),
+      heads AS (
+        SELECT DISTINCT ON (stream) * FROM ef ORDER BY stream, version DESC
+      )
+      ${tailCte}
+      SELECT
+        h.id, h.stream, h.version, h.name, h.data, h.created, h.meta,
+        a.cnt AS agg_count,
+        a.names AS agg_names
+        ${tailCols}
+      FROM heads h
+      LEFT JOIN agg a ON a.stream = h.stream
+      ${tailJoin}
+    `;
+
+    const res = await this._pool.query<
+      Committed<E, keyof E> & {
+        agg_count: number;
+        agg_names: Record<string, number> | null;
+        t_id?: number;
+        t_stream?: string;
+        t_version?: number;
+        t_name?: string;
+        t_data?: object;
+        t_created?: Date;
+        t_meta?: object;
+      }
+    >(sql, params);
+
+    const out = new Map<string, StreamStats<E>>();
+    for (const row of res.rows) {
+      const stats: {
+        head: Committed<E, keyof E>;
+        tail?: Committed<E, keyof E>;
+        count?: number;
+        names?: Record<string, number>;
+      } = {
+        head: {
+          id: row.id,
+          stream: row.stream,
+          version: row.version,
+          name: row.name,
+          data: row.data,
+          created: row.created,
+          meta: row.meta,
+        } as Committed<E, keyof E>,
+      };
+      if (wantTail && row.t_id !== undefined && row.t_id !== null) {
+        stats.tail = {
+          id: row.t_id,
+          stream: row.t_stream,
+          version: row.t_version,
+          name: row.t_name,
+          data: row.t_data,
+          created: row.t_created,
+          meta: row.t_meta,
+        } as unknown as Committed<E, keyof E>;
+      }
+      if (wantCount) stats.count = row.agg_count;
+      if (wantNames) stats.names = row.agg_names ?? {};
+      out.set(row.stream, stats as StreamStats<E>);
+    }
+    return out;
   }
 
   /**

--- a/libs/act-sqlite/bench/query-stats.micro.bench.ts
+++ b/libs/act-sqlite/bench/query-stats.micro.bench.ts
@@ -1,0 +1,86 @@
+/**
+ * Benchmark: SqliteStore.query_stats vs pre-ACT-639 per-stream
+ * query() loop.
+ *
+ * SQLite is embedded — there's no network "round trip" to amortize —
+ * but each `query()` call still prepares + executes a statement, so
+ * the per-stream loop is N statement preparations vs one for
+ * query_stats (with a `ROW_NUMBER() OVER (PARTITION BY stream)`
+ * window over the existing `(stream, version)` unique index).
+ *
+ * Companion to:
+ *   - `libs/act/bench/query-stats.micro.bench.ts` (InMemory baseline)
+ *   - `libs/act-pg/bench/query-stats.micro.bench.ts` (PG indexed win)
+ *
+ * Run: pnpm bench:micro libs/act-sqlite/bench/query-stats.micro.bench.ts
+ */
+import type { Committed, Schemas } from "@rotorsoft/act";
+import { afterAll, beforeAll, bench, describe } from "vitest";
+import { SqliteStore } from "../src/sqlite-store.js";
+
+const SWEEP_STREAMS = [10, 100, 1000] as const;
+const EVENTS_PER_STREAM = 10;
+
+const store = new SqliteStore({ url: "file::memory:?cache=shared" });
+const seeded: { [N in (typeof SWEEP_STREAMS)[number]]?: string[] } = {};
+
+beforeAll(async () => {
+  await store.drop();
+  await store.seed();
+  for (const N of SWEEP_STREAMS) {
+    const names: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const stream = `bench-${N}-${i}`;
+      names.push(stream);
+      const msgs = Array.from({ length: EVENTS_PER_STREAM }, (_, k) => ({
+        name: "Incremented",
+        data: { by: k + 1 },
+      }));
+      await store.commit(stream, msgs, {
+        correlation: "bench",
+        causation: {},
+      });
+    }
+    seeded[N] = names;
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await store.dispose();
+});
+
+async function perStreamHeads(streams: string[]) {
+  const out = new Map<string, Committed<Schemas, keyof Schemas>>();
+  await Promise.all(
+    streams.map(async (s) => {
+      let head: Committed<Schemas, keyof Schemas> | undefined;
+      await store.query<Schemas>(
+        (e) => {
+          if (!head) head = e;
+        },
+        { stream: s, stream_exact: true, backward: true, limit: 1 }
+      );
+      if (head) out.set(s, head);
+    })
+  );
+  return out;
+}
+
+for (const N of SWEEP_STREAMS) {
+  describe(`SQLite query_stats N=${N} streams x ${EVENTS_PER_STREAM} events`, () => {
+    bench("per-stream query() loop (pre-ACT-639)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await perStreamHeads(seeded[N]!);
+    });
+
+    bench("query_stats — heads only (ROW_NUMBER window, indexed)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await store.query_stats(seeded[N]!);
+    });
+
+    bench("query_stats — count + names (CTE + json_group_object)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await store.query_stats(seeded[N]!, { count: true, names: true });
+    });
+  });
+}

--- a/libs/act-sqlite/src/sqlite-store.ts
+++ b/libs/act-sqlite/src/sqlite-store.ts
@@ -6,12 +6,14 @@ import type {
   Lease,
   Message,
   Query,
+  QueryStatsOptions,
   QueryStreams,
   QueryStreamsResult,
   Schemas,
   Store,
   StreamFilter,
   StreamPosition,
+  StreamStats,
 } from "@rotorsoft/act";
 
 /**
@@ -620,6 +622,24 @@ export class SqliteStore implements Store {
     }
 
     return { maxEventId: Number(maxResult.rows[0].m), count };
+  }
+
+  /**
+   * Per-stream aggregated stats — see {@link Store.query_stats}.
+   *
+   * **Slice scaffolding (ACT-639 slice 1+2):** stub. Real implementation
+   * lands in slice 4 of #639 (`ROW_NUMBER()` window function for heads,
+   * `GROUP BY` with `json_group_object` for full-scan path). Throws here
+   * so the interface is satisfied but accidental callers get a clear
+   * error message until the impl lands.
+   */
+  async query_stats<E extends Schemas>(
+    _input: string[] | StreamFilter,
+    _options?: QueryStatsOptions<E>
+  ): Promise<Map<string, StreamStats<E>>> {
+    throw new Error(
+      "SqliteStore.query_stats not implemented yet — see ACT-639 slice 4"
+    );
   }
 
   // --- prioritize: bulk priority update with filter (ACT-102) ---

--- a/libs/act-sqlite/src/sqlite-store.ts
+++ b/libs/act-sqlite/src/sqlite-store.ts
@@ -714,7 +714,10 @@ export class SqliteStore implements Store {
     const fromClause = needsStreamsJoin
       ? `events e JOIN streams s ON s.stream = e.stream`
       : `events e`;
-    const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+    // Always emit a WHERE clause — `WHERE 1=1` short-circuits the
+    // empty-filter case without a conditional branch on the generation
+    // side. SQLite optimizes the trivial predicate out.
+    const whereClause = `WHERE ${where.length ? where.join(" AND ") : "1=1"}`;
 
     return fullScan
       ? this._queryStatsFullScan<E>(
@@ -756,7 +759,7 @@ export class SqliteStore implements Store {
       this.client.execute({ sql: headSql, args: args as any[] }),
       tailSql
         ? this.client.execute({ sql: tailSql, args: args as any[] })
-        : Promise.resolve(null),
+        : null,
     ]);
 
     const toCommitted = (row: Record<string, unknown>): Committed<E, keyof E> =>
@@ -778,15 +781,14 @@ export class SqliteStore implements Store {
     }
     if (tailRes) {
       for (const row of tailRes.rows) {
-        const existing = out.get(row.stream as string);
-        if (existing) {
-          (
-            existing as {
-              head: Committed<E, keyof E>;
-              tail?: Committed<E, keyof E>;
-            }
-          ).tail = toCommitted(row as Record<string, unknown>);
-        }
+        // Head and tail share the same WHERE, so any stream returning
+        // a tail must also have returned a head — no null check needed.
+        (
+          out.get(row.stream as string) as {
+            head: Committed<E, keyof E>;
+            tail?: Committed<E, keyof E>;
+          }
+        ).tail = toCommitted(row as Record<string, unknown>);
       }
     }
     return out;
@@ -903,9 +905,11 @@ export class SqliteStore implements Store {
         );
       }
       if (wantCount) stats.count = Number(r.agg_count);
-      if (wantNames) {
-        stats.names = r.agg_names ? JSON.parse(r.agg_names as string) : {};
-      }
+      // `agg_names` is non-null when this row exists: heads and agg are
+      // both built from the same `ef` CTE, so any stream in heads has
+      // at least one matching event and `json_group_object` returns a
+      // JSON string (never null) for that group.
+      if (wantNames) stats.names = JSON.parse(r.agg_names as string);
       out.set(r.stream as string, stats as StreamStats<E>);
     }
     return out;

--- a/libs/act-sqlite/src/sqlite-store.ts
+++ b/libs/act-sqlite/src/sqlite-store.ts
@@ -649,7 +649,7 @@ export class SqliteStore implements Store {
    *   since SQLite has no native array type.
    */
   async query_stats<E extends Schemas>(
-    input: string[] | StreamFilter,
+    input: string[] | Pick<StreamFilter, "stream" | "stream_exact">,
     options?: QueryStatsOptions<E>
   ): Promise<Map<string, StreamStats<E>>> {
     const exclude = options?.exclude ?? [];
@@ -663,42 +663,25 @@ export class SqliteStore implements Store {
       return new Map<string, StreamStats<E>>();
     }
 
-    // Build WHERE clause + positional args. `e.` alias is used
-    // unconditionally so the column references stay stable across the
-    // two code paths and across the JOIN-vs-no-JOIN forms.
+    // Build WHERE clause + positional args. Subscription-level filters
+    // (source, blocked) are intentionally not accepted — events live in
+    // the events table; subscription state in the streams table. For
+    // "stats for blocked subscriptions" callers compose with
+    // query_streams. So no JOIN here.
     const where: string[] = [];
     const args: unknown[] = [];
-    const isArray = Array.isArray(input);
-    const needsStreamsJoin =
-      !isArray && (input.source !== undefined || input.blocked !== undefined);
 
-    if (isArray) {
+    if (Array.isArray(input)) {
       const placeholders = input.map(() => "?").join(",");
       where.push(`e.stream IN (${placeholders})`);
       args.push(...input);
-    } else {
-      if (input.stream !== undefined) {
-        if (input.stream_exact) {
-          where.push(`e.stream = ?`);
-          args.push(input.stream);
-        } else {
-          where.push(`e.stream LIKE ?`);
-          args.push(streamPatternToLike(input.stream));
-        }
-      }
-      if (input.source !== undefined) {
-        where.push(`s.source IS NOT NULL`);
-        if (input.source_exact) {
-          where.push(`s.source = ?`);
-          args.push(input.source);
-        } else {
-          where.push(`s.source LIKE ?`);
-          args.push(streamPatternToLike(input.source));
-        }
-      }
-      if (input.blocked !== undefined) {
-        where.push(`s.blocked = ?`);
-        args.push(input.blocked ? 1 : 0);
+    } else if (input.stream !== undefined) {
+      if (input.stream_exact) {
+        where.push(`e.stream = ?`);
+        args.push(input.stream);
+      } else {
+        where.push(`e.stream LIKE ?`);
+        args.push(streamPatternToLike(input.stream));
       }
     }
     if (exclude.length) {
@@ -711,9 +694,7 @@ export class SqliteStore implements Store {
       args.push(before);
     }
 
-    const fromClause = needsStreamsJoin
-      ? `events e JOIN streams s ON s.stream = e.stream`
-      : `events e`;
+    const fromClause = `events e`;
     // Always emit a WHERE clause — `WHERE 1=1` short-circuits the
     // empty-filter case without a conditional branch on the generation
     // side. SQLite optimizes the trivial predicate out.

--- a/libs/act-sqlite/src/sqlite-store.ts
+++ b/libs/act-sqlite/src/sqlite-store.ts
@@ -627,19 +627,288 @@ export class SqliteStore implements Store {
   /**
    * Per-stream aggregated stats — see {@link Store.query_stats}.
    *
-   * **Slice scaffolding (ACT-639 slice 1+2):** stub. Real implementation
-   * lands in slice 4 of #639 (`ROW_NUMBER()` window function for heads,
-   * `GROUP BY` with `json_group_object` for full-scan path). Throws here
-   * so the interface is satisfied but accidental callers get a clear
-   * error message until the impl lands.
+   * Two code paths (mirrors the PostgresStore strategy):
+   *
+   * - **Heads-only path** (no `count`, no `names`): one or two queries
+   *   using `ROW_NUMBER() OVER (PARTITION BY stream ORDER BY version
+   *   DESC|ASC)` (SQLite lacks PG's `DISTINCT ON`). Window function +
+   *   `WHERE rn = 1` materializes the head (or tail) per stream from
+   *   the `(stream, version)` unique index. Parallel `Promise.all` when
+   *   tail is requested.
+   *
+   * - **Full-scan path** (`count` or `names` set): one CTE materializes
+   *   the filtered events, then `GROUP BY stream, name` →
+   *   `json_group_object(name, n)` for the names map plus `SUM(n)` for
+   *   count. Heads (and tails when requested) come from the same scan.
+   *
+   * SQLite specifics:
+   * - `data` and `meta` are stored as TEXT (JSON-encoded); the reader
+   *   JSON-parses them when materializing the {@link Committed} rows.
+   * - `blocked` is stored as 0/1 integer; the filter converts.
+   * - Array input expands to a placeholder list (`IN (?, ?, ...)`)
+   *   since SQLite has no native array type.
    */
   async query_stats<E extends Schemas>(
-    _input: string[] | StreamFilter,
-    _options?: QueryStatsOptions<E>
+    input: string[] | StreamFilter,
+    options?: QueryStatsOptions<E>
   ): Promise<Map<string, StreamStats<E>>> {
-    throw new Error(
-      "SqliteStore.query_stats not implemented yet — see ACT-639 slice 4"
-    );
+    const exclude = options?.exclude ?? [];
+    const wantTail = options?.tail ?? false;
+    const wantCount = options?.count ?? false;
+    const wantNames = options?.names ?? false;
+    const before = options?.before;
+    const fullScan = wantCount || wantNames;
+
+    if (Array.isArray(input) && input.length === 0) {
+      return new Map<string, StreamStats<E>>();
+    }
+
+    // Build WHERE clause + positional args. `e.` alias is used
+    // unconditionally so the column references stay stable across the
+    // two code paths and across the JOIN-vs-no-JOIN forms.
+    const where: string[] = [];
+    const args: unknown[] = [];
+    const isArray = Array.isArray(input);
+    const needsStreamsJoin =
+      !isArray && (input.source !== undefined || input.blocked !== undefined);
+
+    if (isArray) {
+      const placeholders = input.map(() => "?").join(",");
+      where.push(`e.stream IN (${placeholders})`);
+      args.push(...input);
+    } else {
+      if (input.stream !== undefined) {
+        if (input.stream_exact) {
+          where.push(`e.stream = ?`);
+          args.push(input.stream);
+        } else {
+          where.push(`e.stream LIKE ?`);
+          args.push(streamPatternToLike(input.stream));
+        }
+      }
+      if (input.source !== undefined) {
+        where.push(`s.source IS NOT NULL`);
+        if (input.source_exact) {
+          where.push(`s.source = ?`);
+          args.push(input.source);
+        } else {
+          where.push(`s.source LIKE ?`);
+          args.push(streamPatternToLike(input.source));
+        }
+      }
+      if (input.blocked !== undefined) {
+        where.push(`s.blocked = ?`);
+        args.push(input.blocked ? 1 : 0);
+      }
+    }
+    if (exclude.length) {
+      const placeholders = exclude.map(() => "?").join(",");
+      where.push(`e.name NOT IN (${placeholders})`);
+      args.push(...exclude);
+    }
+    if (before !== undefined) {
+      where.push(`e.id < ?`);
+      args.push(before);
+    }
+
+    const fromClause = needsStreamsJoin
+      ? `events e JOIN streams s ON s.stream = e.stream`
+      : `events e`;
+    const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+    return fullScan
+      ? this._queryStatsFullScan<E>(
+          fromClause,
+          whereClause,
+          args,
+          wantTail,
+          wantCount,
+          wantNames
+        )
+      : this._queryStatsHeadsOnly<E>(fromClause, whereClause, args, wantTail);
+  }
+
+  /**
+   * Cheap path — head (and optional tail) via ROW_NUMBER() over the
+   * `(stream, version)` unique index. Parallel queries when tail set.
+   */
+  private async _queryStatsHeadsOnly<E extends Schemas>(
+    fromClause: string,
+    whereClause: string,
+    args: unknown[],
+    wantTail: boolean
+  ): Promise<Map<string, StreamStats<E>>> {
+    const cols = `e.id, e.stream, e.version, e.name, e.data, e.created, e.meta`;
+    const headSql = `SELECT * FROM (
+      SELECT ${cols}, ROW_NUMBER() OVER (PARTITION BY e.stream ORDER BY e.version DESC) AS rn
+      FROM ${fromClause}
+      ${whereClause}
+    ) WHERE rn = 1`;
+    const tailSql = wantTail
+      ? `SELECT * FROM (
+          SELECT ${cols}, ROW_NUMBER() OVER (PARTITION BY e.stream ORDER BY e.version ASC) AS rn
+          FROM ${fromClause}
+          ${whereClause}
+        ) WHERE rn = 1`
+      : null;
+
+    const [headRes, tailRes] = await Promise.all([
+      this.client.execute({ sql: headSql, args: args as any[] }),
+      tailSql
+        ? this.client.execute({ sql: tailSql, args: args as any[] })
+        : Promise.resolve(null),
+    ]);
+
+    const toCommitted = (row: Record<string, unknown>): Committed<E, keyof E> =>
+      ({
+        id: Number(row.id),
+        stream: row.stream as string,
+        version: Number(row.version),
+        name: row.name as string,
+        data: JSON.parse(row.data as string),
+        meta: JSON.parse(row.meta as string),
+        created: new Date(row.created as string),
+      }) as Committed<E, keyof E>;
+
+    const out = new Map<string, StreamStats<E>>();
+    for (const row of headRes.rows) {
+      out.set(row.stream as string, {
+        head: toCommitted(row as Record<string, unknown>),
+      });
+    }
+    if (tailRes) {
+      for (const row of tailRes.rows) {
+        const existing = out.get(row.stream as string);
+        if (existing) {
+          (
+            existing as {
+              head: Committed<E, keyof E>;
+              tail?: Committed<E, keyof E>;
+            }
+          ).tail = toCommitted(row as Record<string, unknown>);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Full-scan path — one CTE-based query with per-stream `COUNT(*)` and
+   * `json_group_object(name, n)`. Heads (and optional tails) ride free
+   * on the same scan.
+   */
+  private async _queryStatsFullScan<E extends Schemas>(
+    fromClause: string,
+    whereClause: string,
+    args: unknown[],
+    wantTail: boolean,
+    wantCount: boolean,
+    wantNames: boolean
+  ): Promise<Map<string, StreamStats<E>>> {
+    const tailCte = wantTail
+      ? `, tails AS (
+          SELECT * FROM (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY stream ORDER BY version ASC) AS rn FROM ef
+          ) WHERE rn = 1
+        )`
+      : "";
+    const tailJoin = wantTail ? `LEFT JOIN tails t ON t.stream = h.stream` : "";
+    const tailCols = wantTail
+      ? `, t.id AS t_id, t.stream AS t_stream, t.version AS t_version,
+           t.name AS t_name, t.data AS t_data, t.created AS t_created, t.meta AS t_meta`
+      : "";
+
+    const sql = `
+      WITH ef AS (
+        SELECT e.id, e.stream, e.version, e.name, e.data, e.created, e.meta
+        FROM ${fromClause}
+        ${whereClause}
+      ),
+      agg AS (
+        SELECT stream,
+               SUM(n) AS cnt,
+               json_group_object(name, n) AS names
+        FROM (
+          SELECT stream, name, COUNT(*) AS n
+          FROM ef
+          GROUP BY stream, name
+        )
+        GROUP BY stream
+      ),
+      heads AS (
+        SELECT * FROM (
+          SELECT *, ROW_NUMBER() OVER (PARTITION BY stream ORDER BY version DESC) AS rn FROM ef
+        ) WHERE rn = 1
+      )
+      ${tailCte}
+      SELECT
+        h.id, h.stream, h.version, h.name, h.data, h.created, h.meta,
+        a.cnt AS agg_count,
+        a.names AS agg_names
+        ${tailCols}
+      FROM heads h
+      LEFT JOIN agg a ON a.stream = h.stream
+      ${tailJoin}
+    `;
+
+    const res = await this.client.execute({ sql, args: args as any[] });
+
+    const toCommitted = (
+      id: unknown,
+      stream: unknown,
+      version: unknown,
+      name: unknown,
+      data: unknown,
+      meta: unknown,
+      created: unknown
+    ): Committed<E, keyof E> =>
+      ({
+        id: Number(id),
+        stream: stream as string,
+        version: Number(version),
+        name: name as string,
+        data: JSON.parse(data as string),
+        meta: JSON.parse(meta as string),
+        created: new Date(created as string),
+      }) as Committed<E, keyof E>;
+
+    const out = new Map<string, StreamStats<E>>();
+    for (const row of res.rows) {
+      const r = row as unknown as Record<string, unknown>;
+      const stats: {
+        head: Committed<E, keyof E>;
+        tail?: Committed<E, keyof E>;
+        count?: number;
+        names?: Record<string, number>;
+      } = {
+        head: toCommitted(
+          r.id,
+          r.stream,
+          r.version,
+          r.name,
+          r.data,
+          r.meta,
+          r.created
+        ),
+      };
+      if (wantTail && r.t_id !== null && r.t_id !== undefined) {
+        stats.tail = toCommitted(
+          r.t_id,
+          r.t_stream,
+          r.t_version,
+          r.t_name,
+          r.t_data,
+          r.t_meta,
+          r.t_created
+        );
+      }
+      if (wantCount) stats.count = Number(r.agg_count);
+      if (wantNames) {
+        stats.names = r.agg_names ? JSON.parse(r.agg_names as string) : {};
+      }
+      out.set(r.stream as string, stats as StreamStats<E>);
+    }
+    return out;
   }
 
   // --- prioritize: bulk priority update with filter (ACT-102) ---

--- a/libs/act-tck/src/store-tck.ts
+++ b/libs/act-tck/src/store-tck.ts
@@ -1,4 +1,4 @@
-import { ConcurrencyError } from "@rotorsoft/act";
+import { ConcurrencyError, SNAP_EVENT, TOMBSTONE_EVENT } from "@rotorsoft/act";
 import type {
   BlockedLease,
   Committed,
@@ -1041,6 +1041,248 @@ export const runStoreTck = (options: StoreTckOptions): void => {
           blocked: false,
         });
         expect(unblocked).toEqual([sibling]);
+      });
+    });
+
+    describe("query_stats", () => {
+      it("array input — returns head per stream, absent when not in input", async () => {
+        const tag = uid();
+        const sA = `qst-${tag}-a`;
+        const sB = `qst-${tag}-b`;
+        const sUnasked = `qst-${tag}-unasked`;
+        await store.commit<CounterEvents>(
+          sA,
+          [inc(1), inc(2)],
+          makeMeta({ stream: sA })
+        );
+        await store.commit<CounterEvents>(
+          sB,
+          [dec(5)],
+          makeMeta({ stream: sB })
+        );
+        await store.commit<CounterEvents>(
+          sUnasked,
+          [inc(99)],
+          makeMeta({ stream: sUnasked })
+        );
+
+        const stats = await store.query_stats<CounterEvents>([sA, sB]);
+        expect(stats.size).toBe(2);
+        expect(stats.get(sA)?.head.name).toBe("Incremented");
+        expect((stats.get(sA)?.head.data as { amount: number }).amount).toBe(2);
+        expect(stats.get(sB)?.head.name).toBe("Decremented");
+        expect((stats.get(sB)?.head.data as { amount: number }).amount).toBe(5);
+        expect(stats.has(sUnasked)).toBe(false);
+
+        // Empty input — empty result.
+        const empty = await store.query_stats([]);
+        expect(empty.size).toBe(0);
+
+        // Unknown stream name — absent, not an error.
+        const unknown = await store.query_stats([`qst-${tag}-missing`]);
+        expect(unknown.size).toBe(0);
+      });
+
+      it("tail returns the earliest event per stream", async () => {
+        const tag = uid();
+        const s = `qst-tail-${tag}`;
+        await store.commit<CounterEvents>(s, [inc(1)], makeMeta({ stream: s }));
+        await store.commit<CounterEvents>(s, [inc(2)], makeMeta({ stream: s }));
+        await store.commit<CounterEvents>(s, [inc(3)], makeMeta({ stream: s }));
+
+        const stats = await store.query_stats<CounterEvents>([s], {
+          tail: true,
+        });
+        const r = stats.get(s);
+        expect(r?.head.name).toBe("Incremented");
+        expect((r?.head.data as { amount: number }).amount).toBe(3);
+        expect(r?.tail?.name).toBe("Incremented");
+        expect((r?.tail?.data as { amount: number }).amount).toBe(1);
+      });
+
+      it("count + names — full aggregates including framework markers", async () => {
+        const tag = uid();
+        const s = `qst-cn-${tag}`;
+        // 1 inc, then truncate (wipes + seeds snap), then 2 more incs + 1 dec
+        await store.commit<CounterEvents>(s, [inc(1)], makeMeta({ stream: s }));
+        await store.truncate([{ stream: s, snapshot: { count: 99 } }]);
+        await store.commit<CounterEvents>(
+          s,
+          [inc(2), inc(3), dec(1)],
+          makeMeta({ stream: s })
+        );
+
+        const stats = await store.query_stats<CounterEvents>([s], {
+          count: true,
+          names: true,
+        });
+        const r = stats.get(s);
+        // Post-truncate live events: snap + inc + inc + dec = 4
+        expect(r?.count).toBe(4);
+        expect(r?.names?.[SNAP_EVENT]).toBe(1);
+        expect(r?.names?.Incremented).toBe(2);
+        expect(r?.names?.Decremented).toBe(1);
+        // Snapshot count is derivable from the names map — no separate field needed.
+        expect(r?.names?.[SNAP_EVENT]).toBe(1);
+      });
+
+      it("exclude shifts head past filtered events; stream absent when all filtered", async () => {
+        const tag = uid();
+        const s = `qst-excl-${tag}`;
+        const sAllOut = `qst-allout-${tag}`;
+        await store.commit<CounterEvents>(
+          s,
+          [inc(1), dec(2), inc(3)],
+          makeMeta({ stream: s })
+        );
+        await store.commit<CounterEvents>(
+          sAllOut,
+          [inc(7)],
+          makeMeta({ stream: sAllOut })
+        );
+
+        // Without exclude — head is the latest Incremented.
+        const all = await store.query_stats<CounterEvents>([s]);
+        expect(all.get(s)?.head.name).toBe("Incremented");
+        expect((all.get(s)?.head.data as { amount: number }).amount).toBe(3);
+
+        // Exclude Incremented — head is now Decremented (the next-latest).
+        const excl = await store.query_stats<CounterEvents>([s], {
+          exclude: ["Incremented"],
+        });
+        expect(excl.get(s)?.head.name).toBe("Decremented");
+        expect((excl.get(s)?.head.data as { amount: number }).amount).toBe(2);
+
+        // Exclude every name on a stream — that stream is absent from result.
+        const wipe = await store.query_stats<CounterEvents>([sAllOut], {
+          exclude: ["Incremented", "Decremented", "Reset"],
+        });
+        expect(wipe.has(sAllOut)).toBe(false);
+
+        // Framework markers are typed in EventName<E> too — close-cycle pattern.
+        const noTomb = await store.query_stats<CounterEvents>([s], {
+          exclude: [TOMBSTONE_EVENT],
+        });
+        expect(noTomb.get(s)?.head.name).toBe("Incremented");
+      });
+
+      it("before — time travel narrows head/tail/count", async () => {
+        const tag = uid();
+        const s = `qst-tt-${tag}`;
+        const c1 = await store.commit<CounterEvents>(
+          s,
+          [inc(1)],
+          makeMeta({ stream: s })
+        );
+        const c2 = await store.commit<CounterEvents>(
+          s,
+          [inc(2)],
+          makeMeta({ stream: s })
+        );
+        await store.commit<CounterEvents>(s, [inc(3)], makeMeta({ stream: s }));
+
+        // Cutoff at id of c2's event — only c1's event is < cutoff
+        const before = c2[0].id;
+        const stats = await store.query_stats<CounterEvents>([s], {
+          tail: true,
+          count: true,
+          before,
+        });
+        const r = stats.get(s);
+        expect(r?.count).toBe(1);
+        expect(r?.head.id).toBe(c1[0].id);
+        expect(r?.tail?.id).toBe(c1[0].id);
+
+        // Cutoff before any event — stream absent
+        const empty = await store.query_stats<CounterEvents>([s], {
+          before: 0,
+        });
+        expect(empty.has(s)).toBe(false);
+      });
+
+      it("filter form — stream regex, stream_exact, empty {} match", async () => {
+        const tag = uid();
+        const sA = `qsf-${tag}-orders-1`;
+        const sB = `qsf-${tag}-orders-2`;
+        const sOther = `qsf-${tag}-users-1`;
+        await store.commit<CounterEvents>(
+          sA,
+          [inc(1)],
+          makeMeta({ stream: sA })
+        );
+        await store.commit<CounterEvents>(
+          sB,
+          [inc(2)],
+          makeMeta({ stream: sB })
+        );
+        await store.commit<CounterEvents>(
+          sOther,
+          [inc(3)],
+          makeMeta({ stream: sOther })
+        );
+
+        // Regex match — restrict to this tag's orders.
+        const orders = await store.query_stats<CounterEvents>({
+          stream: `^qsf-${tag}-orders-`,
+        });
+        expect([...orders.keys()].sort()).toEqual([sA, sB].sort());
+
+        // Exact match — single stream.
+        const exact = await store.query_stats<CounterEvents>({
+          stream: sA,
+          stream_exact: true,
+        });
+        expect([...exact.keys()]).toEqual([sA]);
+
+        // Empty filter — matches every event-bearing stream visible to
+        // this test's tag (filtered down to avoid sibling-test pollution).
+        const all = await store.query_stats<CounterEvents>({
+          stream: `^qsf-${tag}-`,
+        });
+        expect([...all.keys()].sort()).toEqual([sA, sB, sOther].sort());
+      });
+
+      it("filter form — source and blocked apply via subscriptions", async () => {
+        const tag = uid();
+        const sub1 = `qsfs-${tag}-sub1`;
+        const sub2 = `qsfs-${tag}-sub2`;
+        const src = `qsfs-${tag}-src`;
+        // Commit events on each subscription stream + on the source stream
+        await store.subscribe([
+          { stream: sub1, source: src },
+          { stream: sub2, source: src },
+        ]);
+        await store.commit<CounterEvents>(
+          sub1,
+          [inc(1)],
+          makeMeta({ stream: sub1 })
+        );
+        await store.commit<CounterEvents>(
+          sub2,
+          [inc(2)],
+          makeMeta({ stream: sub2 })
+        );
+
+        // source filter — both subs share src
+        const bySource = await store.query_stats<CounterEvents>({
+          stream: `^qsfs-${tag}-`,
+          source: src,
+          source_exact: true,
+        });
+        expect([...bySource.keys()].sort()).toEqual([sub1, sub2].sort());
+
+        // Block sub1; blocked: true should match only it.
+        const leased = await store.claim(100, 0, `w-${uid()}`, 100_000);
+        const mine = leased.find((l) => l.stream === sub1);
+        const others = leased.filter((l) => l.stream !== sub1);
+        if (others.length) await store.ack(others);
+        if (mine) await store.block([{ ...(mine as Lease), error: "boom" }]);
+
+        const onlyBlocked = await store.query_stats<CounterEvents>({
+          stream: `^qsfs-${tag}-`,
+          blocked: true,
+        });
+        expect([...onlyBlocked.keys()]).toEqual([sub1]);
       });
     });
 

--- a/libs/act-tck/src/store-tck.ts
+++ b/libs/act-tck/src/store-tck.ts
@@ -1253,125 +1253,38 @@ export const runStoreTck = (options: StoreTckOptions): void => {
         expect([...all.keys()].sort()).toEqual([sA, sB, sOther].sort());
       });
 
-      it("filter form — source and blocked apply via subscriptions", async () => {
+      it("compose with query_streams for subscription-level filters", async () => {
+        // `query_stats` only accepts event-stream selection. For
+        // "stats for blocked subscriptions" etc., compose with
+        // `query_streams` and pipe the names through. This test asserts
+        // that two-call pattern works end-to-end.
         const tag = uid();
-        // Two subscriptions, exercising the two filter branches
-        // independently: one with `source` (for the source filter test),
-        // one without (for the block test — claim()'s lagging-frontier
-        // semantics for source-based subscriptions varies across stores,
-        // so we use a no-source subscription to keep block + claim
-        // portable).
-        const sourced = `qsfs-${tag}-sourced`;
-        const blockable = `qsfs-${tag}-blockable`;
-        const src = `qsfs-${tag}-src`;
-        await store.subscribe([
-          { stream: sourced, source: src },
-          { stream: blockable },
-        ]);
-        await store.commit<CounterEvents>(
-          sourced,
-          [inc(1)],
-          makeMeta({ stream: sourced })
-        );
-        await store.commit<CounterEvents>(
-          blockable,
-          [inc(2)],
-          makeMeta({ stream: blockable })
-        );
+        const a = `qsc-${tag}-a`;
+        const b = `qsc-${tag}-b`;
+        await store.subscribe([{ stream: a }, { stream: b }]);
+        await store.commit<CounterEvents>(a, [inc(1)], makeMeta({ stream: a }));
+        await store.commit<CounterEvents>(b, [inc(2)], makeMeta({ stream: b }));
 
-        // source filter — only the sourced subscription matches.
-        const bySource = await store.query_stats<CounterEvents>({
-          stream: `^qsfs-${tag}-`,
-          source: src,
-          source_exact: true,
-        });
-        expect([...bySource.keys()]).toEqual([sourced]);
-
-        // Block `blockable` — its no-source subscription gets leased
-        // from its own events on every store, so block() reliably fires.
+        // Block stream `a` via the standard claim → block path.
         const leased = await store.claim(100, 0, `w-${uid()}`, 100_000);
-        const mine = leased.find((l) => l.stream === blockable);
+        const mine = leased.find((l) => l.stream === a);
         expect(mine).toBeDefined();
-        const others = leased.filter((l) => l.stream !== blockable);
+        const others = leased.filter((l) => l.stream !== a);
         await store.ack(others);
         await store.block([{ ...(mine as Lease), error: "boom" }]);
 
-        const onlyBlocked = await store.query_stats<CounterEvents>({
-          stream: `^qsfs-${tag}-`,
+        // Step 1: subscription-level filter via query_streams.
+        const blockedNames: string[] = [];
+        await store.query_streams((p) => blockedNames.push(p.stream), {
+          stream: `^qsc-${tag}-`,
           blocked: true,
         });
-        expect([...onlyBlocked.keys()]).toEqual([blockable]);
-      });
+        expect(blockedNames).toEqual([a]);
 
-      it("filter form — source regex, blocked false, no-stream filter, no-subscription", async () => {
-        const tag = uid();
-        // Three streams to exercise the remaining filter branches:
-        //   - `subSrc1` / `subSrc2`: subscribed with sources matching a regex
-        //   - `subBare`: subscribed without source — eligible for blocked-false
-        //   - `eventsOnly`: events committed but no subscription — must be
-        //     absent from source/blocked filter results
-        const subSrc1 = `qsfr-${tag}-1`;
-        const subSrc2 = `qsfr-${tag}-2`;
-        const subBare = `qsfr-${tag}-bare`;
-        const eventsOnly = `qsfr-${tag}-no-sub`;
-        const src1 = `qsfr-${tag}-src-1`;
-        const src2 = `qsfr-${tag}-src-2`;
-        await store.subscribe([
-          { stream: subSrc1, source: src1 },
-          { stream: subSrc2, source: src2 },
-          { stream: subBare },
-        ]);
-        await store.commit<CounterEvents>(
-          subSrc1,
-          [inc(1)],
-          makeMeta({ stream: subSrc1 })
-        );
-        await store.commit<CounterEvents>(
-          subSrc2,
-          [inc(2)],
-          makeMeta({ stream: subSrc2 })
-        );
-        await store.commit<CounterEvents>(
-          subBare,
-          [inc(3)],
-          makeMeta({ stream: subBare })
-        );
-        await store.commit<CounterEvents>(
-          eventsOnly,
-          [inc(99)],
-          makeMeta({ stream: eventsOnly })
-        );
-
-        // (1) source regex — matches both subscribed-source streams via
-        //     pattern, NOT the bare-subscribed or events-only streams.
-        const byRegex = await store.query_stats<CounterEvents>({
-          stream: `^qsfr-${tag}-`,
-          source: `^qsfr-${tag}-src-`,
-        });
-        expect([...byRegex.keys()].sort()).toEqual([subSrc1, subSrc2].sort());
-
-        // (2) blocked: false — every matched stream that has a non-blocked
-        //     subscription. `eventsOnly` is filtered out (no subscription
-        //     at all when source/blocked is set on the filter).
-        const notBlocked = await store.query_stats<CounterEvents>({
-          stream: `^qsfr-${tag}-`,
-          blocked: false,
-        });
-        expect([...notBlocked.keys()].sort()).toEqual(
-          [subSrc1, subSrc2, subBare].sort()
-        );
-        expect(notBlocked.has(eventsOnly)).toBe(false);
-
-        // (3) No-stream filter (only source) — exercises the filter form
-        //     when `stream` is undefined.
-        const sourceOnly = await store.query_stats<CounterEvents>({
-          source: `^qsfr-${tag}-src-`,
-        });
-        // Universe is global, but our regex narrows down to this tag's
-        // sources. Both subSrc1 and subSrc2 match.
-        expect([...sourceOnly.keys()].sort()).toEqual(
-          [subSrc1, subSrc2].sort()
-        );
+        // Step 2: event-level stats for those streams.
+        const stats = await store.query_stats<CounterEvents>(blockedNames);
+        expect(stats.get(a)?.head.name).toBe("Incremented");
+        expect(stats.has(b)).toBe(false);
       });
 
       it("empty filter {} — matches every event-bearing stream", async () => {

--- a/libs/act-tck/src/store-tck.ts
+++ b/libs/act-tck/src/store-tck.ts
@@ -225,6 +225,17 @@ export const runStoreTck = (options: StoreTckOptions): void => {
         expect(backward.map((e) => e.id)).toEqual(
           [...committed].reverse().map((c) => c.id)
         );
+
+        // Backward + limit — exercises the limit-break branch in the
+        // backward-traversal path. Latest event only.
+        const latest = await collect(store, {
+          stream: s,
+          stream_exact: true,
+          backward: true,
+          limit: 1,
+        });
+        expect(latest).toHaveLength(1);
+        expect(latest[0].id).toBe(committed.at(-1)!.id);
       });
 
       it("after/before bound the id range", async () => {
@@ -1280,15 +1291,135 @@ export const runStoreTck = (options: StoreTckOptions): void => {
         // from its own events on every store, so block() reliably fires.
         const leased = await store.claim(100, 0, `w-${uid()}`, 100_000);
         const mine = leased.find((l) => l.stream === blockable);
+        expect(mine).toBeDefined();
         const others = leased.filter((l) => l.stream !== blockable);
-        if (others.length) await store.ack(others);
-        if (mine) await store.block([{ ...(mine as Lease), error: "boom" }]);
+        await store.ack(others);
+        await store.block([{ ...(mine as Lease), error: "boom" }]);
 
         const onlyBlocked = await store.query_stats<CounterEvents>({
           stream: `^qsfs-${tag}-`,
           blocked: true,
         });
         expect([...onlyBlocked.keys()]).toEqual([blockable]);
+      });
+
+      it("filter form — source regex, blocked false, no-stream filter, no-subscription", async () => {
+        const tag = uid();
+        // Three streams to exercise the remaining filter branches:
+        //   - `subSrc1` / `subSrc2`: subscribed with sources matching a regex
+        //   - `subBare`: subscribed without source — eligible for blocked-false
+        //   - `eventsOnly`: events committed but no subscription — must be
+        //     absent from source/blocked filter results
+        const subSrc1 = `qsfr-${tag}-1`;
+        const subSrc2 = `qsfr-${tag}-2`;
+        const subBare = `qsfr-${tag}-bare`;
+        const eventsOnly = `qsfr-${tag}-no-sub`;
+        const src1 = `qsfr-${tag}-src-1`;
+        const src2 = `qsfr-${tag}-src-2`;
+        await store.subscribe([
+          { stream: subSrc1, source: src1 },
+          { stream: subSrc2, source: src2 },
+          { stream: subBare },
+        ]);
+        await store.commit<CounterEvents>(
+          subSrc1,
+          [inc(1)],
+          makeMeta({ stream: subSrc1 })
+        );
+        await store.commit<CounterEvents>(
+          subSrc2,
+          [inc(2)],
+          makeMeta({ stream: subSrc2 })
+        );
+        await store.commit<CounterEvents>(
+          subBare,
+          [inc(3)],
+          makeMeta({ stream: subBare })
+        );
+        await store.commit<CounterEvents>(
+          eventsOnly,
+          [inc(99)],
+          makeMeta({ stream: eventsOnly })
+        );
+
+        // (1) source regex — matches both subscribed-source streams via
+        //     pattern, NOT the bare-subscribed or events-only streams.
+        const byRegex = await store.query_stats<CounterEvents>({
+          stream: `^qsfr-${tag}-`,
+          source: `^qsfr-${tag}-src-`,
+        });
+        expect([...byRegex.keys()].sort()).toEqual([subSrc1, subSrc2].sort());
+
+        // (2) blocked: false — every matched stream that has a non-blocked
+        //     subscription. `eventsOnly` is filtered out (no subscription
+        //     at all when source/blocked is set on the filter).
+        const notBlocked = await store.query_stats<CounterEvents>({
+          stream: `^qsfr-${tag}-`,
+          blocked: false,
+        });
+        expect([...notBlocked.keys()].sort()).toEqual(
+          [subSrc1, subSrc2, subBare].sort()
+        );
+        expect(notBlocked.has(eventsOnly)).toBe(false);
+
+        // (3) No-stream filter (only source) — exercises the filter form
+        //     when `stream` is undefined.
+        const sourceOnly = await store.query_stats<CounterEvents>({
+          source: `^qsfr-${tag}-src-`,
+        });
+        // Universe is global, but our regex narrows down to this tag's
+        // sources. Both subSrc1 and subSrc2 match.
+        expect([...sourceOnly.keys()].sort()).toEqual(
+          [subSrc1, subSrc2].sort()
+        );
+      });
+
+      it("empty filter {} — matches every event-bearing stream", async () => {
+        const tag = uid();
+        const a = `qse-${tag}-a`;
+        const b = `qse-${tag}-b`;
+        await store.commit<CounterEvents>(a, [inc(1)], makeMeta({ stream: a }));
+        await store.commit<CounterEvents>(b, [dec(2)], makeMeta({ stream: b }));
+
+        // {} matches all event-bearing streams globally — the TCK runs
+        // against a shared store, so we only assert that this tag's
+        // streams are present (other tests' streams may also appear).
+        const all = await store.query_stats<CounterEvents>({});
+        expect(all.has(a)).toBe(true);
+        expect(all.has(b)).toBe(true);
+      });
+
+      it("stat-flag combinations — count-only, names-only, tail-only", async () => {
+        const tag = uid();
+        const s = `qsfl-${tag}`;
+        await store.commit<CounterEvents>(
+          s,
+          [inc(1), inc(2), dec(3)],
+          makeMeta({ stream: s })
+        );
+
+        // count only → no names, no tail in result.
+        const c = await store.query_stats<CounterEvents>([s], {
+          count: true,
+        });
+        expect(c.get(s)?.count).toBe(3);
+        expect(c.get(s)?.names).toBeUndefined();
+        expect(c.get(s)?.tail).toBeUndefined();
+
+        // names only → no count, no tail.
+        const n = await store.query_stats<CounterEvents>([s], {
+          names: true,
+        });
+        expect(n.get(s)?.names).toEqual({ Incremented: 2, Decremented: 1 });
+        expect(n.get(s)?.count).toBeUndefined();
+        expect(n.get(s)?.tail).toBeUndefined();
+
+        // tail only → no count, no names. Cheap path (no full scan).
+        const t = await store.query_stats<CounterEvents>([s], { tail: true });
+        expect(t.get(s)?.tail?.name).toBe("Incremented");
+        expect((t.get(s)?.tail?.data as { amount: number }).amount).toBe(1);
+        expect(t.get(s)?.count).toBeUndefined();
+        expect(t.get(s)?.names).toBeUndefined();
       });
     });
 

--- a/libs/act-tck/src/store-tck.ts
+++ b/libs/act-tck/src/store-tck.ts
@@ -1244,37 +1244,43 @@ export const runStoreTck = (options: StoreTckOptions): void => {
 
       it("filter form — source and blocked apply via subscriptions", async () => {
         const tag = uid();
-        const sub1 = `qsfs-${tag}-sub1`;
-        const sub2 = `qsfs-${tag}-sub2`;
+        // Two subscriptions, exercising the two filter branches
+        // independently: one with `source` (for the source filter test),
+        // one without (for the block test — claim()'s lagging-frontier
+        // semantics for source-based subscriptions varies across stores,
+        // so we use a no-source subscription to keep block + claim
+        // portable).
+        const sourced = `qsfs-${tag}-sourced`;
+        const blockable = `qsfs-${tag}-blockable`;
         const src = `qsfs-${tag}-src`;
-        // Commit events on each subscription stream + on the source stream
         await store.subscribe([
-          { stream: sub1, source: src },
-          { stream: sub2, source: src },
+          { stream: sourced, source: src },
+          { stream: blockable },
         ]);
         await store.commit<CounterEvents>(
-          sub1,
+          sourced,
           [inc(1)],
-          makeMeta({ stream: sub1 })
+          makeMeta({ stream: sourced })
         );
         await store.commit<CounterEvents>(
-          sub2,
+          blockable,
           [inc(2)],
-          makeMeta({ stream: sub2 })
+          makeMeta({ stream: blockable })
         );
 
-        // source filter — both subs share src
+        // source filter — only the sourced subscription matches.
         const bySource = await store.query_stats<CounterEvents>({
           stream: `^qsfs-${tag}-`,
           source: src,
           source_exact: true,
         });
-        expect([...bySource.keys()].sort()).toEqual([sub1, sub2].sort());
+        expect([...bySource.keys()]).toEqual([sourced]);
 
-        // Block sub1; blocked: true should match only it.
+        // Block `blockable` — its no-source subscription gets leased
+        // from its own events on every store, so block() reliably fires.
         const leased = await store.claim(100, 0, `w-${uid()}`, 100_000);
-        const mine = leased.find((l) => l.stream === sub1);
-        const others = leased.filter((l) => l.stream !== sub1);
+        const mine = leased.find((l) => l.stream === blockable);
+        const others = leased.filter((l) => l.stream !== blockable);
         if (others.length) await store.ack(others);
         if (mine) await store.block([{ ...(mine as Lease), error: "boom" }]);
 
@@ -1282,7 +1288,7 @@ export const runStoreTck = (options: StoreTckOptions): void => {
           stream: `^qsfs-${tag}-`,
           blocked: true,
         });
-        expect([...onlyBlocked.keys()]).toEqual([sub1]);
+        expect([...onlyBlocked.keys()]).toEqual([blockable]);
       });
     });
 

--- a/libs/act/bench/close-bulk.scenario.bench.ts
+++ b/libs/act/bench/close-bulk.scenario.bench.ts
@@ -1,0 +1,109 @@
+/**
+ * Scenario benchmark: bulk close-cycle scan via query_stats vs the
+ * pre-ACT-639 per-stream query() loop.
+ *
+ * Reproduces the close-cycle Phase 1 (scanStreamHeads) workload at
+ * realistic bulk-close sizes (10 → 1000 streams). Measures wall time
+ * for both shapes against an `InMemoryStore` so the comparison
+ * isolates framework + Map allocation overhead from disk I/O.
+ *
+ * **Regression bound (Shape C, per BENCH.md):**
+ * - At N=1000 streams, `query_stats` must be at least 2× faster than
+ *   the per-stream loop. In practice the microbench shows ~20-30× at
+ *   this N for InMemory; the 2× bound is intentionally loose so the
+ *   test stays green on slow CI hardware.
+ *
+ * On durable adapters (PG, SQLite) the win is structurally larger:
+ * the per-stream loop pays N transactions / N index lookups, vs one.
+ * Those numbers belong in the per-adapter benches.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { InMemoryStore } from "../src/adapters/in-memory-store.js";
+import type { Committed, Schemas } from "../src/types/index.js";
+
+const SIZES = [10, 100, 1000] as const;
+const EVENTS_PER_STREAM = 10;
+
+const store = new InMemoryStore();
+const seeded: { [N in (typeof SIZES)[number]]?: string[] } = {};
+
+beforeAll(async () => {
+  await store.seed();
+  for (const N of SIZES) {
+    const names: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const stream = `close-bench-${N}-${i}`;
+      names.push(stream);
+      const msgs = Array.from({ length: EVENTS_PER_STREAM }, (_, k) => ({
+        name: "Incremented",
+        data: { by: k + 1 },
+      }));
+      await store.commit(stream, msgs, {
+        correlation: "bench",
+        causation: {},
+      });
+    }
+    seeded[N] = names;
+  }
+});
+
+afterAll(async () => {
+  await store.dispose();
+});
+
+/** Hand-rolled equivalent of the pre-ACT-639 close-cycle scanStreamHeads. */
+async function perStreamHeads(streams: string[]) {
+  const out = new Map<string, Committed<Schemas, keyof Schemas>>();
+  await Promise.all(
+    streams.map(async (s) => {
+      let head: Committed<Schemas, keyof Schemas> | undefined;
+      await store.query<Schemas>(
+        (e) => {
+          if (!head) head = e;
+        },
+        { stream: s, stream_exact: true, backward: true, limit: 1 }
+      );
+      if (head) out.set(s, head);
+    })
+  );
+  return out;
+}
+
+describe("close-cycle bulk-scan benchmark", () => {
+  for (const N of SIZES) {
+    it(`N=${N} streams — query_stats vs per-stream loop`, async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      const streams = seeded[N]!;
+
+      // Warmup pass each — vitest's JIT may compile the first call.
+      await perStreamHeads(streams);
+      await store.query_stats(streams);
+
+      // --- Per-stream loop (pre-ACT-639) ---
+      const perStart = performance.now();
+      const perResult = await perStreamHeads(streams);
+      const perTime = performance.now() - perStart;
+
+      // --- query_stats (post-ACT-639) ---
+      const qsStart = performance.now();
+      const qsResult = await store.query_stats(streams);
+      const qsTime = performance.now() - qsStart;
+
+      const speedup = perTime / qsTime;
+
+      console.log(
+        `  N=${N.toString().padStart(4)} streams | per-stream loop: ${perTime.toFixed(2).padStart(8)}ms | query_stats: ${qsTime.toFixed(2).padStart(7)}ms | speedup: ${speedup.toFixed(1).padStart(5)}x`
+      );
+
+      // Both should return the same set of streams.
+      expect(qsResult.size).toBe(perResult.size);
+
+      // Regression bound: at N=1000, query_stats must be ≥2× faster.
+      // Smaller N: the constant overhead dominates, so we don't assert
+      // a multiplier — just record the timing for the PR writeup.
+      if (N >= 1000) {
+        expect(speedup).toBeGreaterThanOrEqual(2);
+      }
+    }, 10_000); // wall-time budget. // Per-stream loop at N=1000 is slow — give the test a generous
+  }
+});

--- a/libs/act/bench/query-stats.micro.bench.ts
+++ b/libs/act/bench/query-stats.micro.bench.ts
@@ -1,0 +1,94 @@
+/**
+ * Benchmark: Store.query_stats vs per-stream query() loop.
+ *
+ * Compares the three call shapes operators have available for fetching
+ * per-stream stats:
+ *
+ *   - **per-stream loop** — the pre-ACT-639 close-cycle pattern;
+ *     `Promise.all(streams.map(s => store.query(..., {stream: s})))`.
+ *     N round trips through the store interface.
+ *   - **query_stats (heads-only)** — one call, indexed cheap path on
+ *     durable stores; for InMemory this is a single forward scan.
+ *   - **query_stats (count+names)** — one call, full-scan path with
+ *     per-name aggregation.
+ *
+ * The InMemory adapter has no indexes, so the cost story here is
+ * "single pass vs N passes" (the per-stream loop scans the full event
+ * list N times). PG and SQLite get the additional index-only win which
+ * this microbench does not capture — for that, run the scenario bench
+ * `close-bulk.scenario.bench.ts` and the per-adapter benches when they
+ * land.
+ */
+import { afterAll, beforeAll, bench, describe } from "vitest";
+import { InMemoryStore } from "../src/adapters/in-memory-store.js";
+import type { Committed, Schemas } from "../src/types/index.js";
+
+const SWEEP_STREAMS = [10, 100, 1000] as const;
+const EVENTS_PER_STREAM = 10;
+
+const store = new InMemoryStore();
+
+const seeded: { [N in (typeof SWEEP_STREAMS)[number]]?: string[] } = {};
+
+beforeAll(async () => {
+  await store.seed();
+  for (const N of SWEEP_STREAMS) {
+    const names: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const stream = `bench-${N}-${i}`;
+      names.push(stream);
+      const msgs = Array.from({ length: EVENTS_PER_STREAM }, (_, k) => ({
+        name: "Incremented",
+        data: { by: k + 1 },
+      }));
+      await store.commit(stream, msgs, {
+        correlation: "bench",
+        causation: {},
+      });
+    }
+    seeded[N] = names;
+  }
+});
+
+afterAll(async () => {
+  await store.dispose();
+});
+
+/** Simulates the pre-ACT-639 close-cycle scanStreamHeads pattern. */
+async function perStreamHeads(
+  streams: string[]
+): Promise<Map<string, Committed<Schemas, keyof Schemas>>> {
+  const out = new Map<string, Committed<Schemas, keyof Schemas>>();
+  await Promise.all(
+    streams.map(async (s) => {
+      let head: Committed<Schemas, keyof Schemas> | undefined;
+      await store.query<Schemas>(
+        (e) => {
+          if (!head) head = e;
+        },
+        { stream: s, stream_exact: true, backward: true, limit: 1 }
+      );
+      if (head) out.set(s, head);
+    })
+  );
+  return out;
+}
+
+for (const N of SWEEP_STREAMS) {
+  describe(`query_stats N=${N} streams × ${EVENTS_PER_STREAM} events`, () => {
+    bench("per-stream query() loop (pre-ACT-639)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await perStreamHeads(seeded[N]!);
+    });
+
+    bench("query_stats — heads only", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await store.query_stats(seeded[N]!);
+    });
+
+    bench("query_stats — count + names (full scan)", async () => {
+      // biome-ignore lint/style/noNonNullAssertion: seeded in beforeAll
+      await store.query_stats(seeded[N]!, { count: true, names: true });
+    });
+  });
+}

--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -752,7 +752,7 @@ export class InMemoryStore implements Store {
    *   event-bearing stream.
    */
   async query_stats<E extends Schemas>(
-    input: string[] | StreamFilter,
+    input: string[] | Pick<StreamFilter, "stream" | "stream_exact">,
     options?: QueryStatsOptions<E>
   ): Promise<Map<string, StreamStats<E>>> {
     await sleep();
@@ -763,16 +763,12 @@ export class InMemoryStore implements Store {
     const before = options?.before;
 
     // Pre-compile per-stream scope predicate, cached as we go so each
-    // distinct stream evaluates the regex / subscription lookup once.
+    // distinct stream evaluates the regex once.
     const arrayTargets = Array.isArray(input) ? new Set(input) : null;
-    const filter: StreamFilter | null = Array.isArray(input) ? null : input;
+    const filter = Array.isArray(input) ? null : input;
     const streamRe =
       filter?.stream && !filter.stream_exact
         ? new RegExp(filter.stream)
-        : undefined;
-    const sourceRe =
-      filter?.source && !filter.source_exact
-        ? new RegExp(filter.source)
         : undefined;
 
     const scopeCache = new Map<string, boolean>();
@@ -782,41 +778,11 @@ export class InMemoryStore implements Store {
       let ok = true;
       if (arrayTargets) {
         ok = arrayTargets.has(stream);
-      } else {
-        // arrayTargets null ⇒ input was a StreamFilter ⇒ filter is set.
-        // biome-ignore lint/style/noNonNullAssertion: TS can't correlate arrayTargets and filter
-        const filter_ = filter!;
-        if (filter_.stream !== undefined) {
-          ok = filter_.stream_exact
-            ? stream === filter_.stream
-            : // biome-ignore lint/style/noNonNullAssertion: streamRe set when stream is regex
-              streamRe!.test(stream);
-        }
-        if (
-          ok &&
-          (filter_.source !== undefined || filter_.blocked !== undefined)
-        ) {
-          const sub = this._streams.get(stream);
-          if (!sub) {
-            ok = false;
-          } else {
-            if (filter_.source !== undefined) {
-              if (sub.source === undefined) ok = false;
-              else
-                ok = filter_.source_exact
-                  ? sub.source === filter_.source
-                  : // biome-ignore lint/style/noNonNullAssertion: sourceRe set when source is regex
-                    sourceRe!.test(sub.source);
-            }
-            if (
-              ok &&
-              filter_.blocked !== undefined &&
-              sub.blocked !== filter_.blocked
-            ) {
-              ok = false;
-            }
-          }
-        }
+      } else if (filter?.stream !== undefined) {
+        ok = filter.stream_exact
+          ? stream === filter.stream
+          : // biome-ignore lint/style/noNonNullAssertion: streamRe set when stream is regex
+            streamRe!.test(stream);
       }
       scopeCache.set(stream, ok);
       return ok;

--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -782,33 +782,36 @@ export class InMemoryStore implements Store {
       let ok = true;
       if (arrayTargets) {
         ok = arrayTargets.has(stream);
-      } else if (filter) {
-        if (filter.stream !== undefined) {
-          ok = filter.stream_exact
-            ? stream === filter.stream
+      } else {
+        // arrayTargets null ⇒ input was a StreamFilter ⇒ filter is set.
+        // biome-ignore lint/style/noNonNullAssertion: TS can't correlate arrayTargets and filter
+        const filter_ = filter!;
+        if (filter_.stream !== undefined) {
+          ok = filter_.stream_exact
+            ? stream === filter_.stream
             : // biome-ignore lint/style/noNonNullAssertion: streamRe set when stream is regex
               streamRe!.test(stream);
         }
         if (
           ok &&
-          (filter.source !== undefined || filter.blocked !== undefined)
+          (filter_.source !== undefined || filter_.blocked !== undefined)
         ) {
           const sub = this._streams.get(stream);
           if (!sub) {
             ok = false;
           } else {
-            if (filter.source !== undefined) {
+            if (filter_.source !== undefined) {
               if (sub.source === undefined) ok = false;
               else
-                ok = filter.source_exact
-                  ? sub.source === filter.source
+                ok = filter_.source_exact
+                  ? sub.source === filter_.source
                   : // biome-ignore lint/style/noNonNullAssertion: sourceRe set when source is regex
                     sourceRe!.test(sub.source);
             }
             if (
               ok &&
-              filter.blocked !== undefined &&
-              sub.blocked !== filter.blocked
+              filter_.blocked !== undefined &&
+              sub.blocked !== filter_.blocked
             ) {
               ok = false;
             }

--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -17,6 +17,7 @@ import type {
   Lease,
   Message,
   Query,
+  QueryStatsOptions,
   QueryStreams,
   QueryStreamsResult,
   Schema,
@@ -24,6 +25,7 @@ import type {
   Store,
   StreamFilter,
   StreamPosition,
+  StreamStats,
 } from "../types/index.js";
 import { sleep } from "../utils.js";
 
@@ -731,6 +733,133 @@ export class InMemoryStore implements Store {
       if (count >= limit) break;
     }
     return { maxEventId: this._events.length - 1, count };
+  }
+
+  /**
+   * Per-stream aggregated stats — see {@link Store.query_stats}.
+   *
+   * Single forward scan over the in-memory event list, accumulating per
+   * stream. The "cheap heads" cost tier from durable adapters doesn't
+   * apply here (InMemory has no indexes); correctness is the goal, perf
+   * is a non-issue.
+   *
+   * Scope rules:
+   * - Array `input` — explicit stream names, regardless of subscription.
+   * - Filter `input` — `stream`/`stream_exact` match against event-bearing
+   *   stream names; `source`/`source_exact`/`blocked` require a
+   *   corresponding subscription in `_streams` (those are subscription
+   *   concepts, not event concepts). Empty filter `{}` matches every
+   *   event-bearing stream.
+   */
+  async query_stats<E extends Schemas>(
+    input: string[] | StreamFilter,
+    options?: QueryStatsOptions<E>
+  ): Promise<Map<string, StreamStats<E>>> {
+    await sleep();
+    const exclude = new Set<string>(options?.exclude ?? []);
+    const wantTail = options?.tail ?? false;
+    const wantCount = options?.count ?? false;
+    const wantNames = options?.names ?? false;
+    const before = options?.before;
+
+    // Pre-compile per-stream scope predicate, cached as we go so each
+    // distinct stream evaluates the regex / subscription lookup once.
+    const arrayTargets = Array.isArray(input) ? new Set(input) : null;
+    const filter: StreamFilter | null = Array.isArray(input) ? null : input;
+    const streamRe =
+      filter?.stream && !filter.stream_exact
+        ? new RegExp(filter.stream)
+        : undefined;
+    const sourceRe =
+      filter?.source && !filter.source_exact
+        ? new RegExp(filter.source)
+        : undefined;
+
+    const scopeCache = new Map<string, boolean>();
+    const inScope = (stream: string): boolean => {
+      const cached = scopeCache.get(stream);
+      if (cached !== undefined) return cached;
+      let ok = true;
+      if (arrayTargets) {
+        ok = arrayTargets.has(stream);
+      } else if (filter) {
+        if (filter.stream !== undefined) {
+          ok = filter.stream_exact
+            ? stream === filter.stream
+            : // biome-ignore lint/style/noNonNullAssertion: streamRe set when stream is regex
+              streamRe!.test(stream);
+        }
+        if (
+          ok &&
+          (filter.source !== undefined || filter.blocked !== undefined)
+        ) {
+          const sub = this._streams.get(stream);
+          if (!sub) {
+            ok = false;
+          } else {
+            if (filter.source !== undefined) {
+              if (sub.source === undefined) ok = false;
+              else
+                ok = filter.source_exact
+                  ? sub.source === filter.source
+                  : // biome-ignore lint/style/noNonNullAssertion: sourceRe set when source is regex
+                    sourceRe!.test(sub.source);
+            }
+            if (
+              ok &&
+              filter.blocked !== undefined &&
+              sub.blocked !== filter.blocked
+            ) {
+              ok = false;
+            }
+          }
+        }
+      }
+      scopeCache.set(stream, ok);
+      return ok;
+    };
+
+    type Acc = {
+      head: Committed<Schemas, keyof Schemas>;
+      tail?: Committed<Schemas, keyof Schemas>;
+      count: number;
+      names?: Record<string, number>;
+    };
+    const acc = new Map<string, Acc>();
+    for (const e of this._events) {
+      if (before !== undefined && e.id >= before) continue;
+      if (!inScope(e.stream)) continue;
+      if (exclude.has(e.name as string)) continue;
+      let a = acc.get(e.stream);
+      if (!a) {
+        a = { head: e, count: 0 };
+        if (wantTail) a.tail = e;
+        if (wantNames) a.names = {};
+        acc.set(e.stream, a);
+      }
+      a.head = e;
+      a.count++;
+      if (wantNames) {
+        const n = String(e.name);
+        // biome-ignore lint/style/noNonNullAssertion: a.names initialized above when wantNames
+        a.names![n] = (a.names![n] ?? 0) + 1;
+      }
+    }
+
+    const out = new Map<string, StreamStats<E>>();
+    for (const [stream, a] of acc) {
+      const stats: {
+        head: Committed<Schemas, keyof Schemas>;
+        tail?: Committed<Schemas, keyof Schemas>;
+        count?: number;
+        names?: Record<string, number>;
+      } = { head: a.head };
+      if (wantTail) stats.tail = a.tail;
+      if (wantCount) stats.count = a.count;
+      if (wantNames) stats.names = a.names;
+      out.set(stream, stats as StreamStats<E>);
+    }
+    return out;
   }
 
   /**

--- a/libs/act/src/internal/close-cycle.ts
+++ b/libs/act/src/internal/close-cycle.ts
@@ -14,7 +14,7 @@
  * @internal
  */
 
-import { cache, store, TOMBSTONE_EVENT } from "../ports.js";
+import { cache, SNAP_EVENT, store, TOMBSTONE_EVENT } from "../ports.js";
 import type {
   CloseResult,
   CloseTarget,
@@ -127,26 +127,24 @@ export async function runCloseCycle(
 async function scanStreamHeads(
   streams: string[]
 ): Promise<Map<string, StreamHead>> {
+  // One round trip: query_stats returns the latest non-snap event per
+  // stream (heads-only cheap path, indexed). Streams whose latest non-snap
+  // event is a tombstone are filtered out in the loop — we don't want to
+  // re-tombstone an already-closed stream. Streams with no events (or
+  // only snap/tombstone events filtered out) are absent from the result
+  // map entirely.
+  const stats = await store().query_stats(streams, {
+    exclude: [SNAP_EVENT],
+  });
   const out = new Map<string, StreamHead>();
-  await Promise.all(
-    streams.map(async (s) => {
-      let maxId = -1;
-      let version = -1;
-      let lastEventName = "";
-      await store().query(
-        (e) => {
-          // backward iteration: first non-tombstone is the most recent
-          // domain event. snaps are filtered server-side (no with_snaps).
-          if (e.name === TOMBSTONE_EVENT || maxId !== -1) return;
-          maxId = e.id;
-          version = e.version;
-          lastEventName = e.name;
-        },
-        { stream: s, stream_exact: true, backward: true, limit: 1 }
-      );
-      if (maxId >= 0) out.set(s, { maxId, version, lastEventName });
-    })
-  );
+  for (const [stream, { head }] of stats) {
+    if (head.name === TOMBSTONE_EVENT) continue;
+    out.set(stream, {
+      maxId: head.id,
+      version: head.version,
+      lastEventName: head.name as string,
+    });
+  }
   return out;
 }
 

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -266,15 +266,18 @@ export type EventName<E extends Schemas = Schemas> =
  *   `options.tail` is true.
  * @property count - Total non-excluded event count for the stream, when
  *   `options.count` is true.
- * @property names - Map of event name → count of events with that name,
- *   when `options.names` is true. Empty object never returned — a stream
- *   with no matching events is absent from the result map entirely.
+ * @property names - Sparse map of event name → count of events with
+ *   that name, when `options.names` is true. Keys are typed as
+ *   {@link EventName | EventName<E>} so typos on lookup
+ *   (e.g. `stats.names?.["TicktOpened"]`) fail at compile time when the
+ *   caller narrows `E`. Empty object never returned — a stream with no
+ *   matching events is absent from the result map entirely.
  */
 export type StreamStats<E extends Schemas = Schemas> = {
   readonly head: Committed<E, keyof E>;
   readonly tail?: Committed<E, keyof E>;
   readonly count?: number;
-  readonly names?: Readonly<Record<string, number>>;
+  readonly names?: Readonly<Partial<Record<EventName<E>, number>>>;
 };
 
 /**

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -223,6 +223,99 @@ export type StreamFilter = Pick<
 export type PrioritizeFilter = StreamFilter;
 
 /**
+ * Framework-internal event names — written by the runtime, not by user
+ * code. Snapshots are seeded by `truncate()`; tombstones by `close()`.
+ *
+ * Kept as a literal-string union here (rather than re-exported from
+ * `../ports.js` where the runtime constants live) so {@link QueryStatsOptions.exclude}
+ * can be type-checked without inducing a `types/` → `ports.ts` cycle.
+ * The runtime constants {@link "../ports.js".SNAP_EVENT | SNAP_EVENT} and
+ * {@link "../ports.js".TOMBSTONE_EVENT | TOMBSTONE_EVENT} (exported from
+ * `@rotorsoft/act`) are the typed source of truth; this union mirrors
+ * them at the type level.
+ */
+export type FrameworkEventName = "__snapshot__" | "__tombstone__";
+
+/**
+ * Union of all event names valid for a given schema set: user-declared
+ * event names plus the framework-internal markers. Used by
+ * {@link QueryStatsOptions.exclude} so callers can mix domain events and
+ * framework markers in the same filter list without `as string` casts
+ * or stringly-typed mistakes (e.g. `"__tombsotne__"` typos fail at
+ * compile time).
+ *
+ * @template E - Event schemas; defaults to {@link Schemas}.
+ */
+export type EventName<E extends Schemas = Schemas> =
+  | (keyof E & string)
+  | FrameworkEventName;
+
+/**
+ * Per-stream aggregated stats returned by {@link Store.query_stats}.
+ *
+ * `head` and `tail` follow the **git-log convention**, not the Unix
+ * `head`/`tail` convention:
+ * - `head` — the **latest** event (highest id), always present.
+ * - `tail` — the **earliest** event (lowest id), opt-in via
+ *   {@link QueryStatsOptions.tail}.
+ *
+ * @template E - Event schemas; defaults to {@link Schemas} when the caller
+ *   does not narrow.
+ * @property head - Latest non-excluded event for the stream.
+ * @property tail - Earliest non-excluded event for the stream, when
+ *   `options.tail` is true.
+ * @property count - Total non-excluded event count for the stream, when
+ *   `options.count` is true.
+ * @property names - Map of event name → count of events with that name,
+ *   when `options.names` is true. Empty object never returned — a stream
+ *   with no matching events is absent from the result map entirely.
+ */
+export type StreamStats<E extends Schemas = Schemas> = {
+  readonly head: Committed<E, keyof E>;
+  readonly tail?: Committed<E, keyof E>;
+  readonly count?: number;
+  readonly names?: Readonly<Record<string, number>>;
+};
+
+/**
+ * Options for {@link Store.query_stats}. All stat fields default to
+ * `false` except `head`, which is always returned.
+ *
+ * **Cost model:** With no opt-in flags (or `tail` alone), each requested
+ * stat resolves via an index-backed lookup — O(K) cost where K is the
+ * number of matched streams. Setting `count` and/or `names` triggers a
+ * full event scan over the matched streams (O(N) where N is total events);
+ * both share the same scan and so requesting one is the same cost as
+ * requesting both.
+ *
+ * @template E - Event schemas; defaults to {@link Schemas}. When the caller
+ *   narrows `E`, `exclude` is type-checked against the schema's event names
+ *   — typos like `["TOMBSTON_EVENT"]` fail at compile time.
+ * @property tail - Include the earliest non-excluded event per stream.
+ *   Cheap when alone (indexed); free when `count`/`names` also set
+ *   (already scanning).
+ * @property count - Include the total non-excluded event count per stream.
+ *   Triggers full scan.
+ * @property names - Include a `name → count` map per stream. Triggers
+ *   full scan (shares cost with `count`).
+ * @property exclude - Event names to skip — e.g.
+ *   `[TOMBSTONE_EVENT, SNAP_EVENT]` to ignore framework markers. Applies
+ *   to all returned stats (head, tail, count, names) consistently.
+ * @property before - Time-travel cutoff: only consider events with
+ *   `id < before`. Omitted = current state. Useful for "what did this
+ *   stream look like at event N?" historical queries without changing
+ *   the call shape. Cheap on both code paths (cheap-heads path narrows
+ *   the index scan; full-scan path adds a `WHERE id < ?` predicate).
+ */
+export type QueryStatsOptions<E extends Schemas = Schemas> = {
+  readonly tail?: boolean;
+  readonly count?: boolean;
+  readonly names?: boolean;
+  readonly exclude?: ReadonlyArray<EventName<E>>;
+  readonly before?: number;
+};
+
+/**
  * Interface for event store implementations.
  *
  * The Store interface defines the contract for persistence adapters in Act.
@@ -688,6 +781,109 @@ export interface Store extends Disposable {
     callback: (position: StreamPosition) => void,
     query?: QueryStreams
   ) => Promise<QueryStreamsResult>;
+
+  /**
+   * Per-stream aggregated stats — single round trip per adapter.
+   *
+   * Returns the latest event (`head`) plus opt-in extras (`tail`, `count`,
+   * `names`) for each stream selected by `input`. Streams with no
+   * qualifying events are absent from the result map.
+   *
+   * **Cost model.** With no opt-in flags, the call uses an index-backed
+   * head lookup per stream — O(K) where K is the number of matched
+   * streams. `tail` alone stays in the cheap tier. Setting `count` and/or
+   * `names` triggers a full event scan over the matched streams (O(N)
+   * where N is total events); both stats share that scan, so requesting
+   * one or both is the same cost.
+   *
+   * **`input`.** Either an explicit `string[]` of stream names, or a
+   * {@link StreamFilter} for pattern / `blocked` selection — same shape
+   * as {@link Store.reset} and {@link Store.unblock}.
+   *
+   * **`head` vs `tail` naming.** Follows the git-log convention: `head`
+   * is the latest event (highest id), `tail` is the earliest (lowest id).
+   * This is the **opposite** of the Unix `head`/`tail` commands.
+   *
+   * **Framework markers.** Snapshots (`__snapshot__`) and tombstones
+   * (`__tombstone__`) are real events and are included by default —
+   * intentional, so schema-evolution tooling can count them. To exclude
+   * them, pass them in `options.exclude` (typed against {@link EventName})
+   * so typos are compile-time errors.
+   *
+   * **Snapshot counts come from `names`.** When `names: true` and snapshots
+   * are not in `exclude`, `result.names["__snapshot__"]` is the snapshot
+   * count for that stream — no separate field needed. Validates snapshot
+   * policy at scale: `names["__snapshot__"] / count` should match the
+   * configured snap predicate's expected ratio.
+   *
+   * **Time travel.** `options.before` narrows to events with `id < before`,
+   * answering "what did this stream look like at event N?" without
+   * special call shape.
+   *
+   * @example Cheap heads — close-cycle pattern (one round trip, no scan)
+   * ```typescript
+   * const stats = await store().query_stats(streams, {
+   *   exclude: [TOMBSTONE_EVENT],
+   * });
+   * for (const [stream, { head }] of stats) {
+   *   // head.id, head.version, head.name
+   * }
+   * ```
+   *
+   * @example Full stats — inspector / admin dashboard (one full scan)
+   * ```typescript
+   * const stats = await store().query_stats<MyEvents>(
+   *   { stream: "^orders-" },
+   *   { count: true, tail: true, names: true,
+   *     exclude: [TOMBSTONE_EVENT] }
+   * );
+   * for (const [stream, s] of stats) {
+   *   const snaps = s.names?.[SNAP_EVENT] ?? 0;
+   *   const domain = (s.count ?? 0) - snaps;
+   *   console.log(stream, { snaps, domain, tail: s.tail?.created });
+   * }
+   * ```
+   *
+   * @example Schema-evolution — surface deprecated events per stream
+   * ```typescript
+   * const stats = await store().query_stats<TicketEvents>(
+   *   { stream: "^ticket-" },
+   *   { names: true }
+   * );
+   * for (const [stream, { names = {} }] of stats) {
+   *   if ((names["TicketOpened"] ?? 0) > 0) {
+   *     console.log(`${stream}: ${names["TicketOpened"]} legacy events`);
+   *   }
+   * }
+   * ```
+   *
+   * @example Time travel — stream state at a historical cutoff
+   * ```typescript
+   * const stats = await store().query_stats(["order-42"], {
+   *   before: 100_000, // events up to (not including) id 100000
+   *   tail: true,
+   * });
+   * const { head, tail } = stats.get("order-42") ?? {};
+   * // head = latest event with id < 100_000; tail = earliest in range
+   * ```
+   *
+   * @template E - Event schemas. Narrow at the call site to type-check
+   *   `exclude` against your event names (typos fail at compile time).
+   *
+   * @param input - Stream names or a filter selecting the streams to stat.
+   * @param options - Opt-in stat fields, event-name exclusions, and
+   *   time-travel cutoff. See {@link QueryStatsOptions}.
+   * @returns Map keyed by stream name. Streams with no qualifying events
+   *   (after `exclude` and `before` are applied) are absent.
+   *
+   * @see {@link QueryStatsOptions} for the cost-aware option surface
+   * @see {@link StreamStats} for the per-stream result shape
+   * @see {@link EventName} for the typed exclude entries
+   */
+  query_stats: <E extends Schemas>(
+    input: string[] | StreamFilter,
+    options?: QueryStatsOptions<E>
+  ) => Promise<Map<string, StreamStats<E>>>;
 
   /**
    * Optional cross-process commit notifications.

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -797,8 +797,13 @@ export interface Store extends Disposable {
    * one or both is the same cost.
    *
    * **`input`.** Either an explicit `string[]` of stream names, or a
-   * {@link StreamFilter} for pattern / `blocked` selection — same shape
-   * as {@link Store.reset} and {@link Store.unblock}.
+   * narrow event-stream selector `{ stream?, stream_exact? }` for
+   * pattern-based or exact-name matching. **Subscription-level filters
+   * (`source`, `blocked`) are intentionally not accepted here** — they
+   * describe subscriptions, not events, and conflating the two would
+   * silently exclude unsubscribed event streams. For
+   * "stats for all blocked subscriptions" compose explicitly:
+   * `query_streams({blocked: true})` → collect names → `query_stats(names)`.
    *
    * **`head` vs `tail` naming.** Follows the git-log convention: `head`
    * is the latest event (highest id), `tail` is the earliest (lowest id).
@@ -881,7 +886,7 @@ export interface Store extends Disposable {
    * @see {@link EventName} for the typed exclude entries
    */
   query_stats: <E extends Schemas>(
-    input: string[] | StreamFilter,
+    input: string[] | Pick<StreamFilter, "stream" | "stream_exact">,
     options?: QueryStatsOptions<E>
   ) => Promise<Map<string, StreamStats<E>>>;
 

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -497,7 +497,18 @@ export const inspectorRouter = t.router({
     return [...names].sort();
   }),
 
-  /** Get distinct stream names for filter suggestions */
+  /** Get distinct stream names with per-stream metadata for the streams view.
+   *
+   * Backed by `Store.query_stats` (ACT-639): one round trip per adapter,
+   * returns per-stream aggregates instead of streaming every event row over
+   * the wire. For a store with 1M events / 10K streams this is ~100×
+   * less data transferred than the previous full-event-scan path.
+   *
+   * `names: true` is requested so the response also includes a per-stream
+   * event-name → count map, surfaced as `nameCounts` for future UI uses
+   * (schema-evolution view, drill-through to legacy-event filters).
+   * Sorting + limit stay client-side (the DB returns all matched streams).
+   */
   streams: t.procedure
     .input(
       z
@@ -508,41 +519,18 @@ export const inspectorRouter = t.router({
     )
     .query(async ({ input }) => {
       const s = getStore();
-
-      const events: AnyEvent[] = [];
-      await s.query<Schemas>(collect(events), { with_snaps: true });
-
-      const streamMap = new Map<
-        string,
-        {
-          count: number;
-          lastEvent: string;
-          lastVersion: number;
-          lastEventName: string;
-        }
-      >();
-
-      for (const e of events) {
-        const existing = streamMap.get(e.stream);
-        if (!existing || e.version > existing.lastVersion) {
-          streamMap.set(e.stream, {
-            count: (existing?.count ?? 0) + 1,
-            lastEvent: String(e.created),
-            lastVersion: e.version,
-            lastEventName: String(e.name),
-          });
-        } else {
-          existing.count++;
-        }
-      }
-
-      return [...streamMap.entries()]
-        .map(([stream, info]) => ({
+      const stats = await s.query_stats<Schemas>(
+        {},
+        { count: true, names: true }
+      );
+      return [...stats.entries()]
+        .map(([stream, { head, count, names }]) => ({
           stream,
-          eventCount: info.count,
-          lastEvent: info.lastEvent,
-          currentVersion: info.lastVersion,
-          isClosed: info.lastEventName === "__tombstone__",
+          eventCount: count ?? 0,
+          lastEvent: String(head.created),
+          currentVersion: head.version,
+          isClosed: head.name === "__tombstone__",
+          nameCounts: names ?? {},
         }))
         .sort((a, b) => b.eventCount - a.eventCount)
         .slice(0, input?.limit ?? 100);


### PR DESCRIPTION
Closes #639.

Adds `Store.query_stats(input, options)` — a single-round-trip per-stream aggregate primitive (head, optional tail/count/names, optional time-travel cutoff) — and migrates the two N-query callsites that motivated it: `close-cycle`'s `scanStreamHeads` and the inspector's `streams` tRPC procedure. Per-adapter benches confirm the architectural win: 6.55× faster on PG at N=1000 (round-trip amortization), 1.88× on SQLite (statement-prep), 27-37× on InMemory (single pass vs N passes). Branch is at 100% coverage on every metric.

Coverage: 100% statements / 100% branches / 100% functions / 100% lines.

## Port surface (`libs/act/src/types/ports.ts`)

```ts
interface Store {
  query_stats: <E extends Schemas>(
    input: string[] | Pick<StreamFilter, "stream" | "stream_exact">,
    options?: QueryStatsOptions<E>
  ) => Promise<Map<string, StreamStats<E>>>;
}

type StreamStats<E extends Schemas = Schemas> = {
  readonly head: Committed<E, keyof E>;                            // always — latest event
  readonly tail?: Committed<E, keyof E>;                           // opt-in — earliest event
  readonly count?: number;                                         // opt-in
  readonly names?: Readonly<Partial<Record<EventName<E>, number>>>; // opt-in — typed keys
};

type QueryStatsOptions<E extends Schemas = Schemas> = {
  readonly tail?: boolean;
  readonly count?: boolean;
  readonly names?: boolean;
  readonly exclude?: ReadonlyArray<EventName<E>>;
  readonly before?: number;
};

type FrameworkEventName = "__snapshot__" | "__tombstone__";
type EventName<E extends Schemas = Schemas> = (keyof E & string) | FrameworkEventName;
```

Design decisions worth flagging:

- **Cost model is in the API, not the docs.** Heads-only (default) is index-friendly on durable adapters; `count`/`names` trigger a full scan but share that scan. Callers see the cost differential by which options they request.
- **Filter form intentionally narrow** to event-stream selection (`stream` regex/exact only). Subscription-level filters (`source`, `blocked`) are **deliberately not accepted** — they describe subscriptions, not events, and conflating the two would silently exclude unsubscribed event streams. For "stats for blocked subscriptions" compose explicitly: `query_streams({blocked: true})` → collect names → `query_stats(names)`. One extra round trip; cleaner semantics. A TCK test locks the two-call pattern in.
- **`head` and `tail` follow git-log convention** (head = latest, tail = earliest), opposite of Unix `head`/`tail`. JSDoc is explicit about this.
- **`exclude` AND `names` keys are typed against `EventName<E>`** — typos like `["TOMBSTON_EVENT"]` or `stats.names?.["TicktOpened"]` fail at compile time when the caller narrows `E`. Framework markers (`__snapshot__`, `__tombstone__`) are in the type union so users can mix domain events and framework markers without `as` casts. The `names` map is `Partial<Record<...>>` since it's sparse — only event names that actually occurred get a count entry.
- **Snapshot count is derivable from `names[SNAP_EVENT]`** when `names: true`. No separate field.
- **`before` enables time-travel** without changing the call shape — `query_stats(streams, { before: id })` answers "what did this stream look like at event N?"

## Adapter implementations

Three adapters, two code paths each (cheap heads-only vs. full-scan), no JOINs (since filter form doesn't touch subscriptions):

| Adapter | Heads-only path | Full-scan path |
|---|---|---|
| `InMemoryStore` | single forward scan with per-stream scope-predicate cache | same scan with count/names accumulators |
| `PostgresStore` | `SELECT DISTINCT ON (stream) … ORDER BY stream, version DESC` (parallel head/tail via `Promise.all`) — uses the existing `(stream, version)` unique index | one CTE: `GROUP BY stream, name` → `jsonb_object_agg(name, n)`, `SUM(n)` joined back to `DISTINCT ON` heads/tails |
| `SqliteStore` | `ROW_NUMBER() OVER (PARTITION BY stream ORDER BY version DESC) = 1` | same CTE pattern with `json_group_object(name, n)` |

The narrow filter form simplified adapter SQL substantially — no conditional JOIN against the streams subscription table, no per-dialect source-regex translation (`~` on PG, `LIKE` on SQLite, `RegExp` on InMemory). The refactor that landed mid-PR removed ~150 lines from the adapters and 46 branches from the coverage matrix.

## Migrations

- **`libs/act/src/internal/close-cycle.ts`** — `scanStreamHeads` replaced its N-parallel `query()` loop with a single `query_stats(streams, { exclude: [SNAP_EVENT] })` call. Tombstone filtering moved to the consumer loop (so an already-closed stream — head is a tombstone — falls out of results without re-tombstoning).
- **`packages/inspector/src/server/router.ts`** — the `streams` tRPC procedure previously fetched every event in the store and folded them client-side. Now calls `query_stats({}, { count: true, names: true })` and returns the same shape plus a new `nameCounts` field (additive — ignored by current UI; lined up for #708's schema-evolution view).

## Benchmarks

Shape A (microbench) and Shape C (scenario) per BENCH.md.

| File | N=10 | N=100 | N=1000 |
|---|---|---|---|
| `libs/act/bench/query-stats.micro.bench.ts` (InMemory) | 1.49× | 3.89× | **27.29×** |
| `libs/act/bench/close-bulk.scenario.bench.ts` (InMemory, regression bound ≥2× at N=1000) | 1.1× | 6.7× | **36.9×** |
| `libs/act-pg/bench/query-stats.micro.bench.ts` (real PG) | 1.77× | 3.74× | **6.55×** |
| `libs/act-sqlite/bench/query-stats.micro.bench.ts` (libSQL) | 1.54× | 1.85× | **1.88×** |

Full-scan path (`count + names`) costs ~1.3–1.6× more than heads-only on durable adapters, demonstrating that the default-cheap path is the right ergonomic choice — operators pay only for what they request. BENCH.md inventory updated for all four files.

## CLAUDE.md — pre-handoff workflow rule

This PR almost shipped without running `/release-check` — per-slice `pnpm test` covers correctness but not the full matrix gate (workspace typecheck, lint across changed files, build, **100% coverage including new defensive branches**). Coverage regressed from master's 100% to 99.16% branches; only the `/release-check` run caught it.

Added a "Pre-handoff workflow" subsection under Development Workflow that makes `/release-check` mandatory before announcing ready-for-review. Defends against the same failure mode next time.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1622/1622 pass, **100% on every metric** (2572 branches after the narrowing refactor; 46 fewer than the original conflated design)
- [x] `pnpm lint` — 22 warnings, 0 errors
- [x] `pnpm build` — all packages build
- [x] TCK conformance: InMemoryStore, PostgresStore, SqliteStore — all green with the same query_stats describe block
- [x] All four benchmarks run; regression bound (≥2× at N=1000 on InMemory close-bulk) holds
- [x] Existing `libs/act/test/close.spec.ts` 24/24 — close-cycle migration is observably identical
- [x] TCK \`compose with query_streams for subscription-level filters\` test passes on all three adapters — locks in the two-call pattern for "stats for blocked subscriptions"
- [ ] CI green
- [ ] Reviewer accepts the additive charter change
- [ ] Deploy validation (not applicable for this PR; library-only change)

## Stability charter impact

**Additive only.** Charter-covered file changed: `libs/act/src/types/ports.ts`. All changes are net-new surface — no existing types renamed, narrowed, or semantically altered:

- New required method on `Store`: `query_stats` (forces custom-adapter implementers to add it — flagged but expected for a 1.0 release; the in-tree adapters all ship the impl in this PR).
- New types: `StreamStats<E>`, `QueryStatsOptions<E>`, `EventName<E>`, `FrameworkEventName`.

No `BREAKING CHANGE:` footer required.

## Follow-ups

- **#708** — inspector "schema evolution" tab. Already updated to consume `query_stats({names: true})` per this PR; the UI work is its own ticket.
- **\`PERFORMANCE.md\` entries** — captured the numbers in commit messages and BENCH.md; a dedicated narrative section in \`libs/act/PERFORMANCE.md\` can land in a follow-up doc PR if the per-optimization writeup is desired.
- **Optional \`limit\`/pagination on \`query_stats\`** — current design returns every matched stream. If a future caller (large inspector deployment, perhaps) needs paging, add \`limit\` + keyset \`after_stream\` matching \`query_streams\`. Not needed for the use cases here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
