### PR TITLE
docs: drop unprovable comparative claims from root + act READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,21 @@
   </tr>
 </table>
 
-## Event sourcing without the ceremony
+## What Act is
 
-Most event-sourcing frameworks ask you to learn five concepts before you can ship a feature: aggregates, commands, events, sagas, projections — and the glue between them. Act asks you to learn **three**: actions, state, reactions. The rest is plumbing the framework handles for you.
+Act is an event-sourcing framework for TypeScript. The domain is expressed through three composable primitives — **actions** (the changes you want to make), **state** (the data you care about), and **reactions** (what happens as a result) — all defined as Zod schemas with full TypeScript inference, all backed by an immutable event log.
 
-Your domain stays in TypeScript. Your schemas stay in Zod. Your events live in Postgres (or SQLite, or memory — same API). The framework wires the pipeline: validate input, append to the log, derive state, fan out reactions, drain them under back-pressure, recover blocked streams when something downstream breaks. No Kafka. No RabbitMQ. No saga DSL. No upcasting middleware. No code generators.
+Around those primitives, the framework provides the pipeline: input validation against the schemas, optimistic-concurrency commit, derived state via patch reducers, fan-out reactions over a polled drain loop with configurable backoff and stream-level dead-lettering, recovery primitives for blocked streams, snapshots and a cache layer for fast cold loads, time-travel queries against the same log. Pick a store at bootstrap — Postgres for production, SQLite for embedded, in-memory for tests — and the application code stays the same.
 
-If you've tried event sourcing before and bounced off the ceremony, **Act is the version where it clicks**.
+## What you get
 
-## Why teams pick Act
-
-- **Three primitives, not fifteen.** `Actions → {State} ← Reactions` is the whole mental model. The same shape covers commands, queries, projections, sagas, and integrations — without separate vocabularies for each.
+- **Three primitives organize the API.** Slices, projections, snapshots, the drain loop, lifecycle events — they all attach to `actions`, `state`, and `reactions`. One mental model for commands, queries, projections, and integrations.
 - **One schema, two purposes.** Zod schemas define your events at runtime *and* generate the TypeScript types at compile time. No drift, no duplication, no `unknown` escape hatches. Refactor an event, the compiler tells you everywhere it broke.
-- **Production-grade out of the box.** Atomic stream claiming via `FOR UPDATE SKIP LOCKED`. Optimistic concurrency on every commit. Automatic retries with configurable backoff. Stream-level dead-lettering with a real recovery API — not a TODO comment that says "wire up your DLQ here."
-- **Time-travel is just `load()`.** Reconstruct state at any historical event ID or timestamp with the same call you use for the current state. No separate read store, no "as-of" API to learn.
-- **Zero brokers required.** The event store IS the message bus. Postgres with `LISTEN`/`NOTIFY` for low-latency cross-process wakeups; SQLite for embedded; in-memory for tests. Same code, same semantics.
+- **Production-grade defaults.** Atomic stream claiming via `FOR UPDATE SKIP LOCKED`. Optimistic concurrency on every commit. Automatic retries with configurable backoff. Stream-level blocked-state with an explicit recovery API (`blocked_streams`, `unblock`).
+- **Time-travel via `load()`.** Reconstruct state at any historical event ID or timestamp with the same call you use for the current state. No separate read store, no "as-of" API to learn.
+- **No external broker.** The event store carries the message-bus role. Postgres with `LISTEN`/`NOTIFY` for low-latency cross-process wakeups; SQLite for embedded; in-memory for tests. The orchestrator works without notify too — it just adds polling lag.
 - **100% test coverage, perf-regression-gated.** Every PR runs the full suite at 100% statement/branch/function/line coverage. A separate CI bench fails the build when any scenario's p50 regresses past 1.5× the baseline. Numbers are public ([PERFORMANCE.md](./libs/act/PERFORMANCE.md)) and adapter conformance is enforced via a [Test Compatibility Kit](./libs/act-tck).
-- **AI scaffolding that actually works.** Drop a spec — event-modeling diagram, event-storming board, JSON config, or plain prose — into Claude Code with the included [scaffold skill](./.claude/skills/scaffold-act-app/), and get a working monorepo. Domain, API, client, tests.
+- **AI scaffolding.** Drop a spec — event-modeling diagram, event-storming board, JSON config, or plain prose — into Claude Code with the included [scaffold skill](./.claude/skills/scaffold-act-app/), and get a working monorepo. Domain, API, client, tests.
 
 ## 30-second demo
 

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -4,15 +4,15 @@
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act.svg)](https://www.npmjs.com/package/@rotorsoft/act)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-_Event sourcing without the ceremony — three primitives, Zod end to end, no broker required._
+_Event-sourcing framework for TypeScript — three primitives, Zod end to end, no broker required._
 
 ## Why this package
 
-Most event-sourcing frameworks ask you to learn five concepts before you can ship a feature: aggregates, commands, events, sagas, projections. Act asks you to learn three: **Actions → {State} ← Reactions**. Your domain stays in TypeScript, your schemas stay in Zod, your events live in an event store (in-memory by default; swap in Postgres or SQLite via the sibling adapters). The framework wires the pipeline — validation, append-only commit, derived state, fan-out reactions, drain under back-pressure, blocked-stream recovery.
+This is the framework core: the builders (`state`, `slice`, `projection`, `act`), the port interfaces (`Store`, `Cache`, `Logger`) with bundled in-memory implementations, the orchestrator that runs the correlate → drain loop, and the snapshot/cache layer that keeps `load()` fast on long streams. Around three primitives — **actions** (the changes you want to make), **state** (the data you care about), and **reactions** (what happens as a result) — it provides input validation against Zod schemas, optimistic-concurrency commit, derived state via patch reducers, fan-out reactions with backoff and dead-lettering, blocked-stream recovery, time-travel queries against the same log.
 
-This package is the framework itself: the builders (`state`, `slice`, `projection`, `act`), the port interfaces (`Store`, `Cache`, `Logger`) with bundled in-memory implementations, the orchestrator that runs the correlate → drain loop, and the snapshot/cache layer that keeps `load()` fast on long streams. The published surface is stable under [SemVer](../../STABILITY.md) at 1.0.
+Your domain stays in TypeScript; your schemas stay in Zod. Pick a store at bootstrap — Postgres (`@rotorsoft/act-pg`), SQLite (`@rotorsoft/act-sqlite`), or the bundled in-memory default — and the application code stays the same. The published surface is stable under [SemVer](../../STABILITY.md) at 1.0.
 
-For the marketing-shaped overview (what's cool about Act, who it's for, why teams pick it), see the [root README](../../README.md).
+For the project-level overview, see the [root README](../../README.md).
 
 ## Installation
 


### PR DESCRIPTION
Follow-up to #753 — that PR merged before this fix could land. Strictly a copy-edit on the marketing surface; no code, no tests touched.

## The issue

Several claims in the marketing copy lumped all event-sourcing frameworks into a single "five-concept ceremony" caricature and made assertions about Act that don't hold up under scrutiny.

Specifically:

- **"Most event-sourcing frameworks ask you to learn five concepts: aggregates, commands, events, sagas, projections."** — EventStoreDB, Marten, and plain event-log libraries don't fit this. The framing was punching at DDD/CQRS-style frameworks specifically (Axon, NestJS CQRS module, EventStorming-derived stacks) without naming them.
- **"Three primitives, not fifteen."** — Act itself surfaces slices, projections, snapshots, cache, drain, claim, settle, correlate, blocked streams, lifecycle events, the builder DSL... The "three primitives" framing is fair as a **mental-model** description, but the comparative count "not fifteen" implies Act has only three things to learn, which isn't true past hello-world.
- **"AI scaffolding that actually works."** — The "actually works" is a defensive tic that implies others don't, without naming or comparing. Unverifiable.
- **"If you've tried event sourcing before and bounced off the ceremony, Act is the version where it clicks."** — Emotional appeal, unverifiable.

Surfaced during PR #753 review after the merge.

## The fix

Replaced unprovable comparisons with descriptive copy that holds up:

| Before | After |
|---|---|
| `## Event sourcing without the ceremony` | `## What Act is` |
| `## Why teams pick Act` | `## What you get` |
| `Three primitives, not fifteen.` | `Three primitives organize the API.` |
| `Production-grade out of the box.` | `Production-grade defaults.` |
| `Zero brokers required.` | `No external broker.` |
| `AI scaffolding that actually works.` | `AI scaffolding.` |
| `_Event sourcing without the ceremony — three primitives…_` (act tagline) | `_Event-sourcing framework for TypeScript — three primitives…_` |

The "three primitives" framing stays — it's true at the mental-model level (slices, projections, snapshots all attach to actions/state/reactions). What's removed is the comparative count and the unverifiable absolute claims.

The "no broker required" claim stays across all surfaces because it's a factual statement about the architecture (the event store carries the message-bus role) and is qualified in context ("the orchestrator works without notify too — it just adds polling lag").

## GitHub repo About description

Updated separately via `gh repo edit` (outside git, so not in the diff):

```
before: Event sourcing without the ceremony. Three primitives, Zod end to end, no broker required. Postgres, SQLite, or in-memory.
after:  Event-sourcing framework for TypeScript. Three primitives (actions, state, reactions), Zod end to end, no broker required. Postgres, SQLite, or in-memory.
```

## Test plan

- [x] `pnpm check:readmes` — all 9 lib READMEs still pass the canonical-section check
- [x] `grep` for leftover overreach phrasings — none remain (`without the ceremony`, `asks you to learn`, `not fifteen`, `actually works`, `the version where it clicks`, `Most event-sourcing`)
- [ ] Reviewer sanity-check the new copy reads like a description, not a sales pitch

## Stability charter impact

**None.** Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>