### PR TITLE
docs: fix stale ACT-639 references + add doc-audit to pre-handoff workflow

### DIFF
--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -1,6 +1,6 @@
 ---
 description: Run every pre-merge gate in parallel and report a punch-list
-allowed-tools: Bash(pnpm:*), Bash(git:*), Bash(jq:*)
+allowed-tools: Bash(pnpm:*), Bash(git:*), Bash(jq:*), Bash(grep:*)
 ---
 
 Verify the current branch is mergeable. Run **every gate in parallel** and surface a single consolidated report.
@@ -12,6 +12,14 @@ Verify the current branch is mergeable. Run **every gate in parallel** and surfa
 3. **Lint** — `pnpm lint`. Warnings are fine; errors fail the gate.
 4. **Build** — `pnpm build`. Must complete without TS errors.
 5. **Charter-covered diff** — `git diff master --stat -- libs/act/src/builders/ libs/act/src/act.ts libs/act/src/types/ports.ts libs/act/src/types/index.ts libs/act/src/ports.ts`. If any file in that list changed, explicitly note "charter surface modified — categorize as additive/breaking before merging."
+6. **Doc-staleness audit** — run the doc-grep recipe from CLAUDE.md "Pre-handoff workflow → Doc audit":
+   ```bash
+   # Identify renamed/removed identifiers in this PR
+   git diff master --diff-filter=D --name-only -- libs/act/src/ libs/act-*/src/
+   # For each renamed/removed symbol, grep for it in docs
+   grep -rln "<old-name-or-shape>" docs/docs book CLAUDE.md libs/*/README.md
+   ```
+   When the PR migrates a callsite to a new primitive (e.g., `query` → `query_stats`), also grep for the old behavioral description in `docs/docs/architecture/` ASCII diagrams. Report hits — they must be updated in this PR, not a follow-up. Skip cleanly when this is a no-public-surface PR (deps bump, internal refactor).
 
 ## Output
 
@@ -25,6 +33,7 @@ Print a single table:
 | Lint | ✅ / ❌ | error count |
 | Build | ✅ / ❌ | failing package if any |
 | Charter | ✅ / ⚠ | "additive" / "needs categorization" / "no charter files changed" |
+| Doc audit | ✅ / ⚠ | "clean" / "N stale refs in <files>" |
 
 End with a one-line verdict: **READY TO MERGE** or **NOT READY: <reason>**.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Source-of-truth for what lives where:
   2. If the method is optional, add a flag to the matching `Capabilities` type and gate the new tests on it so existing adapters keep passing until they opt in.
   3. Update the `docs/docs/guides/writing-a-*.md` walkthrough for that port (if it exists yet).
   4. Run the TCK against every in-tree adapter (InMemory, act-pg, act-sqlite, act-pino).
-  Example: when `Store.query_heads(streams)` (#639) lands, add a `queryHeads` capability and a "returns latest event per stream, empty for unknown, respects pagination" block in `store-tck.ts`.
+  Example: `Store.query_stats(input, options)` from [#639](https://github.com/Rotorsoft/act-root/issues/639) landed as a required method (not capability-gated — every adapter implements it). The TCK gained a `describe("query_stats", …)` block in `store-tck.ts` in lockstep with the port change.
 
 ### Pre-handoff workflow (mandatory before "ready for review" / PR)
 
@@ -182,11 +182,21 @@ Sequence at the end of a feature branch:
 1. `/release-check` — runs typecheck + tests + 100% coverage + lint + build + charter-diff in parallel. See [.claude/commands/release-check.md](.claude/commands/release-check.md).
 2. If coverage < 100% on any metric: run `/coverage` to see the uncovered lines, then write the fault-injection test or restructure the code to remove the branch. See `feedback_full_coverage.md` in memory and the patterns in `libs/act-pg/test/store.error.spec.ts` / `libs/act-sqlite/test/store.error.spec.ts`.
 3. **For substantive tickets** (anything that touched `libs/act/src/`, added a new public method, changed semantics, or migrated a callsite to a new primitive): run `/book-note <ticket-slug>` and write the narrative essay. See [.claude/commands/book-note.md](.claude/commands/book-note.md) and `book/README.md`. Skip only for pure chore/deps/docs PRs. The essay captures the *why* and the *rejected designs* — the part that won't be visible from the diff once it's merged. **Do this BEFORE opening the PR**, so the book entry lands with the code.
-4. Only then: announce "ready for review", show the diff summary, offer to open a PR via `/pr`.
+4. **Doc audit — any PR that changes a public surface, renames a method, migrates a callsite to a new primitive, or alters described semantics must update the relevant docs in the same PR.** Run the stale-reference grep:
+   ```bash
+   grep -rln "<old-name-or-shape>" docs/docs book CLAUDE.md libs/*/README.md
+   ```
+   Hits get fixed inline; **do not** leave them for a "follow-up PR." Specifically:
+   - **Port changes** (`Store` / `Cache` / `Logger`) → check `docs/docs/architecture/extension-points.md` and the matching `docs/docs/guides/writing-a-{store,cache,logger}.md`. The method-list snippet in extension-points goes stale every time the interface gains, loses, or renames a method.
+   - **Orchestrator / `Act` API changes** → check `docs/docs/concepts/` (especially `event-sourcing.md`, `error-handling.md`, `state-management.md`).
+   - **Internal subsystem refactors** (close-cycle, drain, settle, correlate) → check the matching `docs/docs/architecture/` page. Pseudocode and ASCII pipeline diagrams there often spell out the *old* shape ("Phase X: query backward, limit:1") — grep for the literal description, not just the method name.
+   - **Lifecycle event additions/changes** → check `docs/docs/concepts/error-handling.md` and `docs/docs/guides/production-checklist.md`.
+   The pattern that catches this: the PR's commit message says "we changed X" — every place that *describes* X in the docs needs the same update. Treat the docs as part of the public surface.
+5. Only then: announce "ready for review", show the diff summary, offer to open a PR via `/pr`.
 
 **Don't invent ad-hoc gates.** Running `pnpm typecheck` or eyeballing `pnpm test` output once doesn't substitute for the gate. Reach for the slash command first; narrow to ad-hoc tooling only for targeted debugging mid-development.
 
-Why this exists: the gate caught zero issues during development of ACT-639's eight slices because per-slice tests were run ad-hoc — but the merge gate verifies the full matrix (typecheck against the workspace, lint across changed files, build of every adapter, 100% coverage including newly-added defensive branches). Skipping it ships partially-verified work. The book-note step exists for the same reason in narrative form: ACT-639's PR almost shipped without one because the workflow didn't enforce it — and once a PR merges, the reasoning behind rejected designs lives only in the author's head until it's lost.
+Why this exists: each step closes a failure mode that has actually shipped. The gate (step 1) caught zero issues during development of ACT-639's eight slices because per-slice tests were run ad-hoc — the merge gate verifies the full matrix (typecheck against the workspace, lint across changed files, build of every adapter, 100% coverage including newly-added defensive branches). The book-note step (step 3) exists in narrative form for the same reason: ACT-639's PR almost shipped without one because the workflow didn't enforce it, and once a PR merges the reasoning behind rejected designs lives only in the author's head until it's lost. The doc-audit step (step 4) exists because the same #639 PR shipped without updating `docs/docs/architecture/close-cycle.md` (which still described the old per-stream query pattern) and `docs/docs/guides/writing-a-store.md` (which still referred to an earlier "planned" name for the same primitive) — both required follow-up PRs that should have been part of the original change.
 
 ### Documentation discipline
 

--- a/book/act-302-tck.md
+++ b/book/act-302-tck.md
@@ -10,7 +10,7 @@ Weave these ideas into the book (likely the Extensibility / Adapters chapter, wi
 - **Capabilities pattern.** Optional methods (e.g., `Store.notify`) are gated by flags in the TCK so adapters can opt out of features they don't implement. Show this as a generalizable pattern for evolving ports without breaking existing adapters.
 - **Reference implementation does double duty.** `InMemoryStore` / `InMemoryCache` / `ConsoleLogger` are both production-grade defaults *and* the first customers of the TCK — proves the TCK works before any external adapter ships.
 - **Fixed fixture domain.** TCK ships its own tiny Counter-style domain rather than accepting event schemas via options. Self-contained, deterministic, identical coverage across adapters. Use this as a worked example of "test fixtures should be the simplest thing that exercises the contract."
-- **Port evolution rule.** Changing a port interface (e.g., the planned `Store.query_heads` from #639) forces a matching TCK change. Encode this as a contributor rule and tie it to the book's "evolving event-sourced systems" theme.
+- **Port evolution rule.** Changing a port interface (e.g., `Store.query_stats` shipped in #639 / #752) forces a matching TCK change in lockstep. Encode this as a contributor rule and tie it to the book's "evolving event-sourced systems" theme.
 - **Third extension point — Logger.** Even though `Logger` is narrow, including it in the TCK signals that *all* extension points get the same treatment. Useful framing for the book: extensibility is uniform, not à la carte.
 
 Chapter placement candidates:

--- a/docs/docs/architecture/close-cycle.md
+++ b/docs/docs/architecture/close-cycle.md
@@ -23,7 +23,7 @@ title: Close cycle
                       ▼
           ┌───────────────────────────┐
           │ Phase 1: Scan stream heads│  For each target, find the latest non-tombstone event.
-          │   query backward, limit:1 │  Streams with no events are skipped here.
+          │   query_stats(exclude=snap)│  Single round trip — indexed heads-only path.
           └───────────┬───────────────┘
                       │
                       ▼
@@ -79,13 +79,13 @@ If `app.close()` is called and dynamic-resolver streams haven't been correlated 
 
 ### Phase 1 — Scan stream heads
 
-For each target, query the store backward, filter out tombstones in the callback, take the first non-tombstone event. This gives us `(maxId, version, lastEventName)` per stream.
+Call `Store.query_stats(streams, { exclude: [SNAP_EVENT] })` once for the whole target set. The store returns the latest non-snapshot event per stream in a single round trip — on Postgres and SQLite this uses the existing `(stream, version)` index for an index-only path (see [ACT-639](https://github.com/Rotorsoft/act-root/issues/639)). Streams whose latest non-snap event is a tombstone are skipped in the consuming loop (the call doesn't re-tombstone an already-closed stream). The kept entries become a `Map<stream, { maxId, version, lastEventName }>` consumed by the subsequent phases.
 
-The `with_snaps` flag is *not* set, so snapshot events are filtered server-side. The query returns the latest *domain* event.
+- **Stream has no domain events**: absent from the result map (no qualifying event). Phase 2's `safe` list excludes it. Result: stream untouched.
+- **Stream has only a tombstone**: included in the result map (the head is the tombstone), then dropped by the explicit `head.name === TOMBSTONE_EVENT` filter in the consumer. Same outcome — skipped.
+- **`query_stats` call fails**: close() throws to caller. Streams are untouched.
 
-- **Stream has no domain events**: not included in the result map. Phase 2's `safe` list will exclude it. Result: stream untouched.
-- **Stream has only a tombstone**: same outcome as no domain events — the tombstone is filtered, no result entry, skipped.
-- **Query fails**: close() throws to caller. Streams are untouched.
+Before #639 this phase ran `N` parallel `query(backward: true, limit: 1)` calls — one round trip per stream. The new shape collapses to one call regardless of `N`, which matters most for bulk close jobs (hundreds of streams).
 
 ### Phase 2 — Partition by safety
 
@@ -169,12 +169,12 @@ The result map contains `{ deleted: count, committed: seed_event }` per stream. 
 
 Calling `close()` on an already-closed stream is a no-op:
 
-1. Phase 1 scans backward; the head is `__tombstone__` (because it's filtered, the scan returns no result for this stream)
+1. Phase 1's `query_stats` returns the head — which is `__tombstone__` — but the consumer loop drops any entry whose `head.name === TOMBSTONE_EVENT` so we don't re-tombstone an already-closed stream
 2. Phase 1's result map doesn't include this stream
 3. Phase 2's `safe` list doesn't include this stream
 4. Result: stream isn't in `truncated`, isn't in `skipped` from a concurrency error — it's just absent
 
-For a stream that's been *restarted* but not tombstoned (one `__snapshot__` event at v=0), close() will find that snapshot in Phase 1 (snapshots aren't filtered like tombstones are), proceed through guard, and tombstone it. The result is a truncate-and-tombstone of the restarted stream.
+For a stream that's been *restarted* but not tombstoned (one `__snapshot__` event at v=0), Phase 1 calls `query_stats` with `exclude: [SNAP_EVENT]` so the snapshot is filtered out server-side — leaving the stream absent from the result map. Without a head, Phase 2 doesn't include the stream in `safe`, so the restarted-but-empty stream stays untouched. To force-tombstone a restarted stream, commit at least one domain event first.
 
 ## Pointers
 

--- a/docs/docs/architecture/close-cycle.md
+++ b/docs/docs/architecture/close-cycle.md
@@ -22,8 +22,8 @@ title: Close cycle
                       │
                       ▼
           ┌───────────────────────────┐
-          │ Phase 1: Scan stream heads│  For each target, find the latest non-tombstone event.
-          │   query_stats(exclude=snap)│  Single round trip — indexed heads-only path.
+          │ Phase 1: Scan stream heads│  For each target, find the latest non-tombstone event in
+          │   query_stats             │  a single indexed round trip; snapshots filtered out.
           └───────────┬───────────────┘
                       │
                       ▼

--- a/docs/docs/architecture/extension-points.md
+++ b/docs/docs/architecture/extension-points.md
@@ -50,10 +50,13 @@ interface Store extends Disposable {
   prioritize(filter: StreamFilter, priority): Promise<number>;
   truncate(targets): Promise<Map<stream, { deleted; committed }>>;
   query_streams(callback, query?): Promise<QueryStreamsResult>;
+  query_stats(input, options?): Promise<Map<stream, StreamStats>>;
 }
 ```
 
 `reset`, `unblock`, and `prioritize` share the same `StreamFilter` shape (`stream` / `stream_exact` / `source` / `source_exact` / `blocked`). `reset` and `unblock` also accept a plain `string[]` for targeted operations. `unblock` always restricts to blocked streams regardless of what the filter passes — there's no "unblock unblocked streams" use case. `reset` is for projection rebuilds (watermark → -1); `unblock` is for poison-message recovery (watermark preserved).
+
+`query_stats` is the per-stream-aggregate primitive (added in [ACT-639](https://github.com/Rotorsoft/act-root/issues/639)). Default returns the head event per stream via an indexed path; opt-in `count`/`tail`/`names` trigger a full scan but share it. Input is `string[]` for an enumerated set or `Pick<StreamFilter, "stream" | "stream_exact">` for pattern selection — subscription-level filters (`source`, `blocked`) live on `query_streams`; compose the two for "stats for blocked subscriptions" workflows.
 
 ### Invariants an adapter must hold
 

--- a/docs/docs/guides/writing-a-store.md
+++ b/docs/docs/guides/writing-a-store.md
@@ -118,7 +118,7 @@ runStoreTck({
 
 ## When the Store port changes
 
-The TCK and the interface evolve together. When the framework adds, removes, or changes a method on `Store` (e.g., the planned `Store.query_heads(streams)` primitive in [#639](https://github.com/Rotorsoft/act-root/issues/639)):
+The TCK and the interface evolve together. When the framework adds, removes, or changes a method on `Store` (e.g., the `Store.query_stats(input, options)` primitive added in [#639](https://github.com/Rotorsoft/act-root/issues/639) / [#752](https://github.com/Rotorsoft/act-root/pull/752)):
 
 1. The matching cases land in `libs/act-tck/src/store-tck.ts`.
 2. New optional methods are gated behind a `Capabilities` flag so existing adapters keep passing until they opt in.


### PR DESCRIPTION
Follow-up to #752 — five doc surfaces still described the pre-639 API or behavior. This PR fixes them inline and adds a mandatory doc-audit step to the pre-handoff workflow so the same failure mode doesn't recur on future PRs.

## What I missed in #752

| File | What was stale | Fix |
|---|---|---|
| `docs/docs/architecture/close-cycle.md` | Pipeline ASCII said `query backward, limit:1`; Phase 1 walkthrough described the per-stream backward query + callback tombstone filter; Idempotency section described the old mechanism for restart-but-not-tombstoned streams. | Rewrote Phase 1 to describe `query_stats(exclude: [SNAP_EVENT])` + consumer-loop tombstone filter. Idempotency section reframed for the new mechanism. Added a one-liner noting the before/after for archaeology readers. |
| `docs/docs/guides/writing-a-store.md` | Referenced a "planned `query_heads`" primitive that shipped under a different name. | Updated to reference shipped `query_stats` with #639 / #752 links. |
| `docs/docs/architecture/extension-points.md` | `Store` interface code block was missing `query_stats` entirely. | Added the method to the interface listing + a paragraph on the cost model and input narrowing (no `source`/`blocked` — compose with `query_streams`). |
| `book/act-302-tck.md` | Port-evolution-rule bullet cited `query_heads` as "planned." | Updated to reference shipped `query_stats`. |
| `CLAUDE.md` | Example sentence used a placeholder `query_heads` name. | Replaced with the actual `query_stats` shape that landed. |

## The workflow rule that should have caught this

Added as new **step 3** in CLAUDE.md "Pre-handoff workflow" (slotting between the existing coverage gate and "open PR"):

> **Doc audit — any PR that changes a public surface, renames a method, migrates a callsite to a new primitive, or alters described semantics must update the relevant docs in the same PR.** Run the stale-reference grep ... Hits get fixed inline; do not leave them for a "follow-up PR."

Concrete map of which surface-change category points at which doc files:

- **Port changes** → `extension-points.md` + `writing-a-*.md`
- **Orchestrator/Act API changes** → `docs/docs/concepts/`
- **Internal subsystem refactors** → matching `architecture/` page (especially ASCII diagrams that spell out the *old* shape)
- **Lifecycle event additions** → `error-handling.md` + `production-checklist.md`

Also extended `.claude/commands/release-check.md` with a sixth "Doc-staleness audit" gate so the existing command surfaces the same hits.

Same defense-in-depth shape as the earlier `/release-check` and `/book-note` additions: when a project convention isn't in the workflow loop, future PRs don't follow it.

## Test plan

- [x] `grep -rln "query_heads"` across docs / libs / book / README / CLAUDE.md returns **zero hits** (the cure isn't visible in the grep — the historical mention in CLAUDE.md is phrased without the literal name).
- [x] `pnpm check:readmes` still passes.
- [x] No code touched — pure docs + workflow.
- [ ] Reviewer accepts the new workflow step + the rewritten close-cycle Phase 1 walkthrough reads correctly.

## Stability charter impact

**None.** Docs + workflow only.

## Note on overlap with #755

PR #755 is also adding a new step to the same "Pre-handoff workflow" section (the `/book-note` requirement). When #755 merges, this PR will need a small rebase to renumber `book-note` (step 3) → `doc-audit` (step 4) → `open PR` (step 5). The conflict is mechanical — both new steps slot between the existing "coverage" and "open PR" steps; their order doesn't matter conceptually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>