### PR TITLE
fix(docs): make stackblitz embeds show the terminal panel

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -424,16 +424,16 @@ function Sandboxes() {
             <Sandbox
               title="Event Sourcing + Lanes"
               blurb="Calculator demo — random keypresses commit events, a digit-board projection drains on the “board” lane, a per-stream result projection drains on the “result” lane. Watch lane names tag every drain cycle in the trace."
-              src="https://stackblitz.com/github/rotorsoft/act-root/tree/master/packages/calculator?embed=1&view=editor&terminal=1&file=src/main.ts&hideNavigation=1&showSidebar=0&showExplorer=0&showPreview=0&startScript=dev%3Astackblitz"
-              open="https://stackblitz.com/github/rotorsoft/act-root/tree/master/packages/calculator?file=src/main.ts&embed=1&view=editor&terminal=1&hideNavigation=1&showSidebar=0&showExplorer=0&showPreview=0&startScript=dev%3Astackblitz"
+              src="https://stackblitz.com/github/rotorsoft/act-root/tree/master/packages/calculator?embed=1&file=src/main.ts&hideNavigation=1&hideExplorer=1&terminalHeight=55&startScript=dev%3Astackblitz"
+              open="https://stackblitz.com/github/rotorsoft/act-root/tree/master/packages/calculator?file=src/main.ts&embed=1&hideNavigation=1&hideExplorer=1&terminalHeight=55&startScript=dev%3Astackblitz"
               source="https://github.com/rotorsoft/act-root/tree/master/packages/calculator/src"
             />
 
             <Sandbox
               title="Lanes × Adaptive Dual-Frontier Drain"
               blurb="Todo load test split across two lanes — “writes” (creates + updates, tight lease, hot path) and “mutations” (deletes, longer lease, can tolerate lag). Each drain cycle prints a lane × frontier table so you can see Act adapt the leading/lagging budget independently per lane until everything converges."
-              src="https://stackblitz.com/github/rotorsoft/act-root/tree/master/performance/act-performance?embed=1&view=editor&terminal=1&file=src/index.ts&hideNavigation=1&showSidebar=0&showExplorer=0&showPreview=0&startScript=start%3Astackblitz"
-              open="https://stackblitz.com/github/rotorsoft/act-root/tree/master/performance/act-performance?file=src/index.ts&embed=1&view=editor&terminal=1&hideNavigation=1&showSidebar=0&showExplorer=0&showPreview=0&startScript=start%3Astackblitz"
+              src="https://stackblitz.com/github/rotorsoft/act-root/tree/master/performance/act-performance?embed=1&file=src/index.ts&hideNavigation=1&hideExplorer=1&terminalHeight=55&startScript=start%3Astackblitz"
+              open="https://stackblitz.com/github/rotorsoft/act-root/tree/master/performance/act-performance?file=src/index.ts&embed=1&hideNavigation=1&hideExplorer=1&terminalHeight=55&startScript=start%3Astackblitz"
               source="https://github.com/rotorsoft/act-root/tree/master/performance/act-performance/src"
             />
           </section>


### PR DESCRIPTION
## Summary

Post-merge fix to PR #762. The lane-PR shipped two StackBlitz embeds whose URL params *looked* like they'd surface a running terminal but didn't — operators landed on a static editor view with no console output, which is exactly what the demos are *for*.

Root cause: four params either don't exist as URL params, are legacy, or actively suppressed the panel that was supposed to show the trace:

| Old | Problem |
|---|---|
| `terminal=1` | `terminal` is SDK-only, not a URL param. The value was discarded. |
| `view=editor` + `showPreview=0` | Collapses the right pane and leaves no bottom panel mounted because `terminalHeight` is unset. |
| `showSidebar=0` / `showExplorer=0` / `showPreview=0` | Legacy / ignored. WebContainer embeds use `hide*=1`. |

Verified against the published StackBlitz iframe embed parameter list — `terminal` does not appear; `terminalHeight` (0–100) is the documented control for bottom-panel size on WebContainers.

## Fix

Replace with the minimum documented set for a Node WebContainer embed that auto-runs a script and surfaces its output:

\`\`\`
embed=1
file=src/main.ts
hideNavigation=1
hideExplorer=1
terminalHeight=55
startScript=<scriptName>
\`\`\`

Both packages already define `dev:stackblitz` / `start:stackblitz` scripts that do `npm install && tsx watch …`, so `startScript=` boots the demo and `terminalHeight=55` keeps the trace visible.

## Test plan

- [ ] Open the deployed docs landing
- [ ] Click "Run live sandbox" on the Calculator embed → editor on top, terminal below running `dev:stackblitz`, trace output streaming
- [ ] Same for the Lanes × Adaptive Dual-Frontier Drain embed → `start:stackblitz`, lane × frontier table updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)