### PR TITLE
docs: re-trigger CD to publish lane v0.45.0/0.25.0/0.9.0/0.4.0

### DIFF
--- a/libs/act-pg/README.md
+++ b/libs/act-pg/README.md
@@ -4,7 +4,7 @@
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-pg.svg)](https://www.npmjs.com/package/@rotorsoft/act-pg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-_PostgreSQL event store for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act). ACID, connection-pooled, multi-process — production default for Act deployments._
+_PostgreSQL event store for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act). ACID, connection-pooled, multi-process — production default for Act deployments. Lane-aware claim/ack via `streams.lane` + `streams_lane_ix` since v0.25.0 ([ACT-1103](https://github.com/Rotorsoft/act-root/issues/733))._
 
 ## Why this package
 

--- a/libs/act-sqlite/README.md
+++ b/libs/act-sqlite/README.md
@@ -4,7 +4,7 @@
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-sqlite.svg)](https://www.npmjs.com/package/@rotorsoft/act-sqlite)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-_SQLite event store for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act) via [`@libsql/client`](https://github.com/tursodatabase/libsql-client-ts). File-based, edge-ready, ACID — for single-node deployments._
+_SQLite event store for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act) via [`@libsql/client`](https://github.com/tursodatabase/libsql-client-ts). File-based, edge-ready, ACID — for single-node deployments. Lane-aware claim/ack via `streams.lane` + `streams_lane_ix` since v0.9.0 ([ACT-1103](https://github.com/Rotorsoft/act-root/issues/733))._
 
 ## Why this package
 

--- a/libs/act-tck/README.md
+++ b/libs/act-tck/README.md
@@ -4,7 +4,7 @@
 [![NPM Downloads](https://img.shields.io/npm/dm/@rotorsoft/act-tck.svg)](https://www.npmjs.com/package/@rotorsoft/act-tck)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-_Test Compatibility Kit for the `Store`, `Cache`, and `Logger` ports of [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act)._
+_Test Compatibility Kit for the `Store`, `Cache`, and `Logger` ports of [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act). Lane conformance suite (claim filter, subscribe UPSERT, ack/block round-trip) added in v0.4.0 ([ACT-1103](https://github.com/Rotorsoft/act-root/issues/733))._
 
 ## Why this package
 

--- a/libs/act/PERFORMANCE.md
+++ b/libs/act/PERFORMANCE.md
@@ -556,6 +556,8 @@ Same reasoning as ACT-403: the cost is below measurement noise, so a baseline wo
 
 ## Lane Fan-out (ACT-1103)
 
+> Shipped in `@rotorsoft/act@0.45.0` (May 2026). See [#733](https://github.com/Rotorsoft/act-root/issues/733).
+
 The orchestrator builds one `DrainController` per active lane (implicit `default` + every `.withLane(...)`). `Act._drainAll` runs every controller's `drain()` in parallel via `Promise.all` and aggregates `fetched`/`leased`/`acked`/`blocked`. Per-lane `cycleMs` autostarts a `setTimeout` chain that calls the controller's `drain()` at the lane's cadence — independent of the Act-level settle loop.
 
 Three perf questions:


### PR DESCRIPTION
## Summary

Three things in one PR — together they unblock the StackBlitz demos:

### 1. Re-trigger CI-CD to publish v0.45.0 / 0.25.0 / 0.9.0 / 0.4.0

PR #762's publish step 404'd on all four libs (NPM_TOKEN now rotated). Tags were deleted so semantic-release re-derives from v0.44.0/0.24.0/0.8.0/0.3.0. CI-CD's `paths: libs/**` filter requires libs/ touched, so each adapter gets a one-line annotation:

- `libs/act/PERFORMANCE.md` — Lane Fan-out section gains a "shipped in v0.45.0" pointer.
- `libs/act-pg/README.md` — tagline notes lane-aware claim/ack via `streams.lane`.
- `libs/act-sqlite/README.md` — same.
- `libs/act-tck/README.md` — tagline notes the lane conformance suite.

`docs:` doesn't trigger semantic-release rules on its own — the feat: lane commits already in master since each adapter's last tag drive the bumps.

### 2. Unpin demo deps so StackBlitz can install lane-capable versions

Even after publish, `npm install` in WebContainer would resolve `^0.39.0` to **0.39.0 only** (caret on 0.x acts like tilde — `>=0.39.0 <0.40.0`). Every lane-PR feature crashed on first compile because the installed lib pre-dated the API.

Loosened to `>=0.45.0` / `>=0.25.0` — matches `libs/act-pg`'s peer-dep convention. Local pnpm keeps using workspace symlinks.

### 3. Workflow ordering

When this PR merges:
- CI runs typecheck + tests on libs/* (existing gates)
- CD matrix runs on each of the four libs, publishes 0.45.0/0.25.0/0.9.0/0.4.0 to npm
- Docs deploy rebuilds with the loosened demo deps
- StackBlitz on next "Run live sandbox" click pulls master + installs the actual lane-capable libs

## Test plan

- [ ] CI typecheck + tests green
- [ ] CD matrix: all 4 jobs (`act`, `act-tck`, `act-pg`, `act-sqlite`) succeed
- [ ] `npm view @rotorsoft/act version` → `0.45.0`
- [ ] `npm view @rotorsoft/act-pg version` → `0.25.0`
- [ ] `npm view @rotorsoft/act-sqlite version` → `0.9.0`
- [ ] `npm view @rotorsoft/act-tck version` → `0.4.0`
- [ ] StackBlitz calculator embed boots, terminal shows the per-cycle lane-tagged trace
- [ ] StackBlitz perf embed boots, terminal shows the `(lane × frontier)` table

## Follow-ups

- If the terminal panel itself still doesn't surface after the demos can compile, that's a separate URL-params iteration on top of PR #763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)