### PR TITLE
fix(demos): unpin act/act-pg so stackblitz installs a lane-capable version

### DIFF
--- a/packages/calculator/package.json
+++ b/packages/calculator/package.json
@@ -12,7 +12,7 @@
     "dev:close": "tsx src/close-demo.ts"
   },
   "dependencies": {
-    "@rotorsoft/act": "^0.39.0",
+    "@rotorsoft/act": ">=0.45.0",
     "@trpc/server": "11.16.0",
     "zod": "^4.4.3"
   },

--- a/performance/act-performance/package.json
+++ b/performance/act-performance/package.json
@@ -11,8 +11,8 @@
     "throughput:parallel": "docker compose run --rm k6 run --out influxdb=http://influxdb:8086/k6 /scripts/throughput.js"
   },
   "dependencies": {
-    "@rotorsoft/act": "^0.39.0",
-    "@rotorsoft/act-pg": "^0.20.2",
+    "@rotorsoft/act": ">=0.45.0",
+    "@rotorsoft/act-pg": ">=0.25.0",
     "cli-table3": "^0.6.5",
     "express": "^5.2.1",
     "pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,8 +334,8 @@ importers:
   packages/calculator:
     dependencies:
       '@rotorsoft/act':
-        specifier: ^0.39.0
-        version: 0.39.0(zod@4.4.3)
+        specifier: '>=0.45.0'
+        version: link:../../libs/act
       '@trpc/server':
         specifier: 11.16.0
         version: 11.16.0(typescript@5.9.3)
@@ -540,11 +540,11 @@ importers:
   performance/act-performance:
     dependencies:
       '@rotorsoft/act':
-        specifier: ^0.39.0
-        version: 0.39.0(zod@4.4.3)
+        specifier: '>=0.45.0'
+        version: link:../../libs/act
       '@rotorsoft/act-pg':
-        specifier: ^0.20.2
-        version: 0.20.2(@rotorsoft/act@0.39.0(zod@4.4.3))(zod@4.4.3)
+        specifier: '>=0.25.0'
+        version: link:../../libs/act-pg
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
@@ -3185,23 +3185,6 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
-
-  '@rotorsoft/act-patch@1.2.2':
-    resolution: {integrity: sha512-qqFHW/1P7R0WNSXIDLmzGtNkJIFt967dc9AmcMqgiTlVBhrPgQQgO9Htdy9m5vf/29ZOZnyWSGnN7Yl74Ra9Og==}
-    engines: {node: '>=22.18.0'}
-
-  '@rotorsoft/act-pg@0.20.2':
-    resolution: {integrity: sha512-yDf5r7kbeFPBmUbI+OjdHG+WjtbcTRGYr8f7RYyJpdRQNo2Jc3gQLGqCmcQsgnNSaabvELR+q0ooI1/UbtFzcQ==}
-    engines: {node: '>=22.18.0'}
-    peerDependencies:
-      '@rotorsoft/act': '>=0.31.1'
-      zod: ^4.4.3
-
-  '@rotorsoft/act@0.39.0':
-    resolution: {integrity: sha512-FC/Z8YwOOaoapyd52PKq4DQIGq1L0AKSSyiG1hPPpIFmL+jeA4z91or7wxvaFEMcIjsKe+8jn/IY3JKWT+bopQ==}
-    engines: {node: '>=22.18.0'}
-    peerDependencies:
-      zod: ^4.4.3
 
   '@rspack/binding-darwin-arm64@1.7.11':
     resolution: {integrity: sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==}
@@ -12374,21 +12357,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
-
-  '@rotorsoft/act-patch@1.2.2': {}
-
-  '@rotorsoft/act-pg@0.20.2(@rotorsoft/act@0.39.0(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@rotorsoft/act': 0.39.0(zod@4.4.3)
-      pg: 8.20.0
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - pg-native
-
-  '@rotorsoft/act@0.39.0(zod@4.4.3)':
-    dependencies:
-      '@rotorsoft/act-patch': 1.2.2
-      zod: 4.4.3
 
   '@rspack/binding-darwin-arm64@1.7.11':
     optional: true


### PR DESCRIPTION
## Summary

Follow-up to PR #764. That PR landed only its first commit (the docs annotation that triggered CD) — this one didn't make the merge because it was pushed *after* the merge had already happened. CD published the libs successfully (v0.45.0 / 0.25.0 / 0.9.0 / 0.4.0 are all on npm now), but the StackBlitz demos still crash because their `package.json` files cap deps at `^0.39.0` and `^0.20.2`.

## The bug

Caret semver on 0.x acts like tilde:

```
^0.39.0 ⇒ >=0.39.0 <0.40.0
^0.20.2 ⇒ >=0.20.2 <0.21.0
```

So `npm install` in StackBlitz's WebContainer resolves to `@rotorsoft/act@0.39.0` and `@rotorsoft/act-pg@0.20.2` — neither has `.withLane(...)` or lane-aware `Drain`, so the demos die on first compile.

## The fix

Loosen to `>=0.45.0` and `>=0.25.0`. Matches the convention `libs/act-pg` etc. already use for their `@rotorsoft/act` peer dep. Local pnpm keeps using workspace symlinks (`linkWorkspacePackages: true`).

`packages/` and `performance/` aren't under the CI-CD `libs/**` path filter, so this PR adds nothing to the CD matrix — it just lets the live demos install the right versions on next StackBlitz pull.

## Test plan

- [ ] Merge, wait for docs deploy to rebuild
- [ ] Open the docs landing → click "Run live sandbox" on the calculator embed
- [ ] WebContainer installs `@rotorsoft/act@0.45.0`, `tsx watch` boots, terminal shows the per-cycle lane-tagged trace
- [ ] Same for perf — see the `(lane × frontier)` table populate

## Follow-ups

- If the terminal panel still isn't visible after this lands, that's a separate URL-params iteration on PR #763's territory — but the demos will at least be installing the right framework version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)