### PR TITLE
fix(act-performance): route per lane, drive via lifecycle, settle to exit

### DIFF
--- a/performance/act-performance/src/index.ts
+++ b/performance/act-performance/src/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   act,
   type Committed,
+  type Drain,
   type Schemas,
   sleep,
   store,
@@ -19,13 +20,16 @@ function target(stream: string, N: number) {
   return first % N;
 }
 
-// Three-lane split. Each event type drains on its own lane with a
-// distinct lease budget — creates are the hottest path (tight lease,
-// high stream limit), updates are medium-cadence, deletes can tolerate
-// the longest lag. Each lane runs an independent DrainController so a
-// slow handler in one never stalls the others. The leading/lagging
-// frontier mechanic operates *within* each lane, so both dimensions
-// are visible in the per-cycle stats.
+// Three-lane split. Each event type drains on *its own* set of target
+// streams, on its own lane, with its own lease budget. Keeping the
+// target streams disjoint per lane is load-bearing: `subscribe()`
+// UPSERTs the lane every call, so if all three event types resolved
+// to the same `stream-X`, the lane field would be overwritten on
+// each subscribe and only the last writer's lane would actually hold
+// — the other two lanes would end up with zero streams assigned.
+//
+// Naming convention: `<lane>-<bucket>` (e.g. `creates-0`, `updates-3`,
+// `deletes-7`). 25 buckets per lane via UUID hash.
 const LANES = ["creates", "updates", "deletes"] as const;
 type Lane = (typeof LANES)[number];
 const lane_for = (eventName: string): Lane => {
@@ -34,27 +38,46 @@ const lane_for = (eventName: string): Lane => {
   return "updates";
 };
 
-// serialize projection leases to one key or
-// one projection lease per stream?
-const projection_resolver =
-  process.env.SERIAL_PROJECTION === "true"
-    ? // serial projection (only one projection stream)
-      (committed: Committed<Schemas, keyof Schemas>) => ({
-        target: "serial_projection",
-        lane: lane_for(String(committed.name)),
-      })
-    : // parallel projection (custom resolver to N projection streams)
-      (committed: Committed<Schemas, keyof Schemas>) => ({
-        target: `stream-${target(committed.stream, 25)}`, // use N > streamLimit to avoid conflicts
-        source: "todo.*", // incluce all todos
-        lane: lane_for(String(committed.name)),
-      });
-// // parallel projection (default resolver is one-stream-to-one-projection)
-// : (committed: Committed<Schemas, keyof Schemas>) => ({
-//   target: committed.stream,
-//   source: committed.stream,
-//   lane: lane_for(String(committed.name)),
-// });
+const resolveTarget = (committed: Committed<Schemas, keyof Schemas>) => {
+  const lane = lane_for(String(committed.name));
+  return {
+    target:
+      process.env.SERIAL_PROJECTION === "true"
+        ? `${lane}-serial`
+        : `${lane}-${target(committed.stream, 25)}`,
+    source: "todo.*",
+    lane,
+  };
+};
+
+// Lane-shaped artificial latency. Tuned to make the contrast obvious
+// in the rendered table — creates run at full speed; updates pay a
+// small tax; the slow lane (deletes) pays enough that an operator
+// watching the table sees its frontier lag behind creates and
+// updates have already settled.
+const LANE_DELAY_MS: Record<Lane, number> = {
+  creates: 0,
+  updates: 25,
+  deletes: 150,
+};
+
+// Wrap a projector callback with the lane-specific delay. Returns a
+// *named* function — Act's `.do()` rejects anonymous handlers because
+// the name shows up in traces.
+function withDelay<H extends (...args: never[]) => Promise<unknown>>(
+  name: string,
+  lane: Lane,
+  handler: H
+): H {
+  const delay = LANE_DELAY_MS[lane];
+  const wrapped = {
+    async [name](...args: Parameters<H>) {
+      if (delay > 0) await sleep(delay);
+      return handler(...args);
+    },
+  }[name];
+  return wrapped as H;
+}
 
 // Don't use PG option in browser
 const usePg = process.env.USE_PG === "true";
@@ -74,71 +97,96 @@ const projector = usePg
   ? pgProjector("postgres://postgres:postgres@localhost:5431/postgres")
   : memProjector();
 
-// Composed "Todo" app with state and reactions. Three lanes give each
-// event type its own lease budget so the per-cycle table shows three
-// independent leading/lagging frontiers converging at different rates.
+// Composed "Todo" app — three lanes give each event type its own
+// lease budget so the per-cycle table shows three independent
+// leading/lagging frontiers converging at different rates.
 export const app = act()
   .withState(Todo)
   .withLane({ name: "creates", leaseMillis: 2_000, streamLimit: 20 })
   .withLane({ name: "updates", leaseMillis: 5_000, streamLimit: 15 })
   .withLane({ name: "deletes", leaseMillis: 30_000, streamLimit: 5 })
   .on("TodoCreated")
-  .do(projector.projectTodoCreated)
-  .to(projection_resolver)
+  .do(withDelay("projectTodoCreated", "creates", projector.projectTodoCreated))
+  .to(resolveTarget)
   .on("TodoUpdated")
-  .do(projector.projectTodoUpdated)
-  .to(projection_resolver)
+  .do(withDelay("projectTodoUpdated", "updates", projector.projectTodoUpdated))
+  .to(resolveTarget)
   .on("TodoDeleted")
-  .do(projector.projectTodoDeleted)
-  .to(projection_resolver)
+  .do(withDelay("projectTodoDeleted", "deletes", projector.projectTodoDeleted))
+  .to(resolveTarget)
   .build();
 
-// load test variables
-let drainInterval: ReturnType<typeof setInterval> | undefined;
-let lastDrain = Date.now();
-let eventCount = 0;
-let drainCount = 0;
-const streams = new Set<string>();
+// === Observability via lifecycle events ===
+//
+// Best-practice Act apps don't poll for drain results — the framework
+// emits lifecycle events as work happens, and listeners read those.
+// Two channels feed the dashboard:
+//
+//   `committed` — increments the "committed" headline counter.
+//   `acked`     — appended to a recent-acks ring; the render timer
+//                 below snapshots and clears the ring each tick to
+//                 build the per-cycle table.
+//   `blocked`   — surfaced as a warning line.
+//
+// The orchestrator auto-schedules a settle pass on every commit, so
+// there's no manual `setInterval(drain)` driving work — load just
+// commits and the framework drives the drain to completion. The
+// `setInterval` below is *render only*: it doesn't trigger drain, it
+// just paints accumulated lifecycle data.
+//
+// (Why not the `settled` event? Settle is debounced + loops to
+// completion per pass, so under sustained load it fires once at the
+// very end. That'd give us one final table, not a running view.
+// Rendering off `acked` decouples display cadence from drain cadence.)
+import type { BlockedLease, Lease } from "@rotorsoft/act";
+
+let totalCommitted = 0;
+let renderCount = 0;
+let loadFinished = false;
+const ackedSinceLastRender: Lease[] = [];
+const blockedSeen: BlockedLease[] = [];
+
+app.on("committed", (snapshots) => {
+  totalCommitted += snapshots.length;
+});
+
+app.on("acked", (acked) => {
+  ackedSinceLastRender.push(...acked);
+});
+
+app.on("blocked", (blocked) => {
+  blockedSeen.push(...blocked);
+  for (const b of blocked) console.error(`⚠ blocked: ${b.stream} ${b.error}`);
+});
 
 /**
- * Debounced drain for convergence testing.
+ * Wait until the orchestrator has nothing left to drain.
  *
- * Drains the store every FREQ ms.
+ * Listens for a `settled` event whose `acked` + `leased` are both
+ * empty — that's the operational definition of "fully caught up".
+ * Schedules an immediate settle pass to kick things in case nothing
+ * recent has fired one.
  *
- * Logs the lag and lead of the drain.
+ * Returns true when settlement was observed; false on timeout.
  */
-export async function drain() {
-  const now = Date.now();
-  if (now - lastDrain > drainFrequency) {
-    lastDrain = now;
-
-    const drain = await app.drain(drainOptions);
-    drainCount++;
-
-    const [lagging, leading] = updateStats(
-      drainCount,
-      eventCount,
-      drain,
-      LANES
-    );
-
-    if (lagging.convergedAt && leading.convergedAt) {
-      clearInterval(drainInterval);
-      drainInterval = undefined;
-
-      console.log("\nConverged! Load test complete.");
-      const stats = await projector.getStats();
-      console.table({
-        ...stats,
-        lagging: `Converged @${lagging.convergedAt} in ${lagging.convergedTime! / 1000} seconds`,
-        leading: `Converged @${leading.convergedAt} in ${leading.convergedTime! / 1000} seconds`,
-      });
-      process.exit(0);
-    }
-  }
+function waitForCaughtUp(timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      app.off("settled", onSettled);
+      resolve(false);
+    }, timeoutMs);
+    const onSettled = (drain: Drain<Schemas>) => {
+      if (drain.acked.length === 0 && drain.leased.length === 0) {
+        clearTimeout(timer);
+        app.off("settled", onSettled);
+        resolve(true);
+      }
+    };
+    app.on("settled", onSettled);
+    app.settle({ debounceMs: 0 });
+  });
 }
 
-// Main event generation loop
 async function main(
   { maxEvents, createMax, eventFrequency }: LoadTestOptions = {
     maxEvents: 300,
@@ -150,26 +198,47 @@ async function main(
   await store().seed();
   await projector.init();
 
-  drainInterval = setInterval(drain, drainFrequency);
-  // app.on("committed", debouncedDrain);
+  // Render the dashboard at a steady cadence, snapshotting whatever
+  // lifecycle events have accumulated since the last paint. This is
+  // separate from drain — Act runs that internally on every commit.
+  const renderTimer = setInterval(() => {
+    renderCount++;
+    const acked = ackedSinceLastRender.splice(0);
+    // Synthesize a minimal Drain-shaped payload from the accumulated
+    // acks. updateStats only reads `acked`, `leased`, `fetched`, so
+    // empty arrays for the latter two are fine — they'd be the same
+    // from the framework's perspective at the moment we render.
+    const drainSnapshot = {
+      acked,
+      leased: [],
+      fetched: [],
+      blocked: blockedSeen,
+    };
+    updateStats(
+      renderCount,
+      totalCommitted,
+      drainSnapshot,
+      LANES,
+      loadFinished
+    );
+  }, 500);
 
   const actorId = "local";
+  const streams = new Set<string>();
+  let eventCount = 0;
+  const startTime = Date.now();
+
   while (eventCount < maxEvents) {
     eventCount++;
     await sleep(eventFrequency);
     const op = Math.random();
     if (eventCount < createMax && (op < 0.4 || streams.size === 0)) {
       const stream = "todo-" + randomUUID();
-      const [snap] = await app.do(
+      await app.do(
         "create",
         { stream, actor: { id: actorId, name: actorId } },
         { text: "created @ " + new Date().toISOString() }
       );
-      // correlate right after creation
-      await app.correlate({
-        stream,
-        after: snap.event!.id - 1,
-      });
       streams.add(stream);
     } else if (op < 0.8 && streams.size > 0) {
       const idx = Math.floor(Math.random() * streams.size);
@@ -190,14 +259,29 @@ async function main(
       streams.delete(stream);
     }
   }
+  loadFinished = true;
+
+  console.log("\nLoad complete. Waiting for drain to catch up…");
+  const caughtUp = await waitForCaughtUp(120_000);
+  clearInterval(renderTimer);
+  if (!caughtUp) {
+    console.error("Timed out waiting for drain to settle.");
+    process.exit(1);
+  }
+
+  const elapsed = (Date.now() - startTime) / 1000;
+  console.log(
+    `\n✓ Converged after ${renderCount} render cycles, ${elapsed.toFixed(2)}s.`
+  );
+  console.table({
+    ...(await projector.getStats()),
+    committed: totalCommitted,
+    blocked: blockedSeen.length,
+    durationSec: elapsed.toFixed(2),
+  });
+  process.exit(0);
 }
 
-// 👉 Change drain options to evaluate performance at different load levels
-const drainFrequency = 500;
-const drainOptions = {
-  streamLimit: 15,
-  eventLimit: 20,
-};
 // 👉 Change app options to evaluate performance at different load levels
 void main({
   maxEvents: 350,

--- a/performance/act-performance/src/stats.ts
+++ b/performance/act-performance/src/stats.ts
@@ -37,10 +37,25 @@ const leading: ConvergenceState = {
   consecutiveMatches: 0,
 };
 
-// Per-stream watermark tracking. The honest convergence signal: every
-// known projection stream has watermark == maxWatermarkObserved for
-// CONVERGENCE_STABLE_CYCLES drains in a row.
+// Per-stream watermark tracking — used for the "watermark range"
+// rendering in the table, not for convergence detection (see below).
 const watermarks = new Map<string, number>();
+
+// Convergence detection — "no progress for N cycles in a row".
+//
+// Earlier this checked `streamsConverged === streamsKnown && maxWatermark
+// >= eventCount`, which assumed every stream lives in the same global
+// id space. With the multi-lane setup each lane processes a different
+// event type into a disjoint set of target streams, so per-stream
+// watermarks naturally diverge — `creates-X` streams plateau at the
+// last TodoCreated event id, `updates-X` plateau later, etc. The old
+// rule would never fire even when everything is genuinely done.
+//
+// "No acks, no leases, no fetches for CONVERGENCE_STABLE_CYCLES" is
+// lane-config-independent: it directly observes the drain returning
+// empty, which only happens when no work is left to do across any
+// controller. Cheap, correct, and renders well as a "stable cycles"
+// counter the operator can watch tick up.
 const CONVERGENCE_STABLE_CYCLES = 5;
 let stableCycles = 0;
 let convergedDrainCount = 0;
@@ -132,7 +147,8 @@ export function updateStats<E extends Schemas>(
   drainCount: number,
   eventCount: number,
   drain: Drain<E>,
-  declaredLanes: readonly string[] = []
+  declaredLanes: readonly string[] = [],
+  loadFinished = false
 ): [ConvergenceState, ConvergenceState] {
   // --- This cycle's frontier split (what claim() actually pulled) ---
   const leasedLagging = drain.leased.filter((l) => l.lagging).length;
@@ -155,25 +171,37 @@ export function updateStats<E extends Schemas>(
       SPLIT_EMA_ALPHA * cycleSplit + (1 - SPLIT_EMA_ALPHA) * observedSplit;
   }
 
-  // --- Per-stream watermark map (honest convergence) ---
+  // --- Per-stream watermark map (used only for the table's
+  // "watermarks" range column) ---
   for (const acked of drain.acked) {
     const prev = watermarks.get(acked.stream) ?? -1;
     if (acked.at > prev) watermarks.set(acked.stream, acked.at);
   }
   const allWms = [...watermarks.values()];
   const maxWatermark = allWms.length > 0 ? Math.max(...allWms) : 0;
-  const streamsConverged = allWms.filter((w) => w === maxWatermark).length;
   const streamsKnown = watermarks.size;
+  const streamsConverged = allWms.filter((w) => w === maxWatermark).length;
 
-  // Real convergence: every known stream at max for N cycles in a row.
-  // We additionally require the maxWatermark to have caught up to
-  // eventCount — otherwise we'd declare convergence mid-load.
-  const allAtMax =
-    streamsKnown > 0 &&
-    streamsConverged === streamsKnown &&
-    maxWatermark >= eventCount;
+  // Convergence: no progress for N consecutive cycles AFTER the load
+  // generator has finished issuing operations.
+  //
+  // "No progress" = no claims, no fetched events, no acks this cycle.
+  // Gating on `loadFinished` instead of `maxWatermark >= eventCount`
+  // avoids the off-by-one between "ops requested by main loop" and
+  // "events present in the store" — projection events and reaction
+  // round-trips can push the actual event id space well past
+  // `eventCount`, and trying to predict that count from the load loop
+  // is brittle (it depends on which reactions emit further events,
+  // which adapters write extras, etc.). The gate "main loop done"
+  // captures the operator's actual intent: the workload is over,
+  // tell me when the drain catches up.
+  const emptyCycle =
+    drain.leased.length === 0 &&
+    drain.acked.length === 0 &&
+    drain.fetched.reduce((s, f) => s + f.events.length, 0) === 0;
+  const drainFinished = emptyCycle && loadFinished;
 
-  if (allAtMax) {
+  if (drainFinished) {
     stableCycles++;
     if (stableCycles >= CONVERGENCE_STABLE_CYCLES && !convergedDrainCount) {
       convergedDrainCount = drainCount;


### PR DESCRIPTION
## Summary

Three bugs surfaced once the demo went multi-lane after #770:

1. **Only one lane showed activity.** The resolver returned the same `stream-X` target for all three event types and just varied `lane`. `subscribe()` UPSERTs the lane every call, so the last writer's lane held for every bucket and the other two lanes ended up with zero streams. Now each event type routes to its own target prefix (`creates-X` / `updates-X` / `deletes-X`).
2. **The demo never stopped.** The old convergence check required every stream's watermark to equal a global max — assumed a single id space. With three lanes processing different event types into disjoint streams, watermarks naturally diverge. Switched to "no progress for N cycles after the load loop is done" — lane-config-independent.
3. **The drain mechanics didn't follow Act best practices.** The old pattern (setInterval + manual drain + correlate-after-create) predated `start_correlations`/`settle()`. The orchestrator was doing the work via auto-settle on every commit, so the manual `app.drain()` calls found nothing to do — the per-cycle table read empty even while the demo was making progress.

Rewrite drives everything off lifecycle events:

- `committed` → headline counter
- `acked` → ring-buffered and snapshotted by a render timer for per-cycle stats
- `blocked` → logged as warnings
- After the load loop, `waitForCaughtUp` listens for a `settled` event with `acked.length === 0 && leased.length === 0` (the operational "fully caught up" signal). 120s timeout.

Also wraps each projector handler with a lane-specific artificial delay (creates: 0ms, updates: 25ms, deletes: 150ms) so the slow lane's frontier visibly lags while creates have already settled — the educational payoff of three lanes.

## Verification

Ran the demo locally with the in-memory store. All three lanes show real activity (sample taken from a 28.9s run):

```
creates  lagging  0 evts /  32 streams   watermarks  21..48   gap=27
updates  lagging  0 evts /  20 streams   watermarks   7..19   gap=12
deletes  lagging  0 evts /   7 streams   watermarks   1..9    gap=8
…
✓ Converged after 57 render cycles, 28.91s.
```

(`claimed` and `evts` columns now read 0 across the board — they don't carry meaning when rendering off `acked` events. Stream count + watermark range carry the useful signal.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Demo runs to completion, all three lanes populated, exit code 0
- [ ] Same with `USE_PG=true` against a local Postgres instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)