### PR TITLE
feat(inspector): schema evolution view + time-travel (ACT-708)

### DIFF
--- a/book/act-708-schema-evolution.md
+++ b/book/act-708-schema-evolution.md
@@ -1,0 +1,41 @@
+# ACT-708 — Inspector schema-evolution view
+
+#708 ships the Schema Evolution tab in the inspector: workspace event-name rollup with deprecation status, drill-through modal listing streams that still hold a deprecated event, and a time-travel "as-of" toggle on the stream detail panel. Plus a deliberate non-feature: the inspector doesn't close streams directly. Notes for the tooling chapter.
+
+The thread worth pulling on isn't the UI. It's the question this view exists to answer — "ok, but how big is the legacy backlog?" — and the layered reasoning about *whose* problem that question is, and what the inspector is allowed to do about it.
+
+---
+
+### Threads to develop
+
+**1. The post-migration silence.**
+ACT-403's `_v<digits>` rule (#683) ends with a startup advisory: "your registry has deprecated events." It tells you the *shape* of the migration but not its *size*. After the operator ships `TicketOpened_v2`, they want to know: is the deprecated event 1% of the table or 84%? That answer needs a store query, and a store query at app startup is a footgun on large tables — easily 40 seconds on 4M-event stores. So the framework deliberately stops at the advisory. The Inspector is where it picks up: operator-driven, on-demand, cached until the operator says refresh. The book should treat "framework refuses to do the expensive thing automatically; tooling is allowed to" as a recurring pattern. Same shape as `app.close()` (operator-driven, never auto), `app.reset()` (operator-driven, never auto), the inspector's mutation gate. The framework's discipline is to never *surprise* the operator with cost; tooling's job is to make that cost easy to incur when wanted.
+
+**2. The convention is the contract.**
+Both the framework and the inspector apply the same `_v<digits>` rule independently — the framework against its in-memory registry at build time, the inspector against event names sitting in PG. They never share state. The shared thing is the *documented convention* in `docs/docs/architecture/event-schema-evolution.md`. The inspector inlines the regex (deliberately doesn't import the framework's `internal/event-versions.ts`) because the convention is the API, and copying the regex is honest about that. If the convention ever changes, both places update. Worth a callout: *the most stable contracts are the ones expressed as documentation about naming rules, not as exported functions*. Once a convention is published, downstream tooling can apply it without taking a dependency on framework internals.
+
+**3. "We surface data; the operator decides."**
+The drill-through modal lists streams holding the legacy event but doesn't close them. The original ticket asked for a bulk-close button. We dropped it. The reasoning needs to live in the book because it's a recurring shape: tooling that decides for operators is tooling that hides decisions, and hidden decisions get made wrong under pressure.
+
+The mechanics also matter. `app.close(targets)` orchestrates eight steps (correlate, safety-check, guard, load state, archive, truncate, cache invalidate, emit lifecycle). The orchestration needs the running app's registry and correlator. The inspector has neither — it's a standalone tool pointed at a PG schema. The choice was: (a) call a primitive that *isn't* `app.close()` (raw store tombstone, fewer steps, no archive), (b) RPC into the running app from the inspector (bigger design), or (c) generate a snippet the operator pastes into their own application code. We picked (c).
+
+The book should make the argument explicitly: option (a) violates the framework's safety story — `app.close()` exists *because* raw-tombstone-without-orchestration is the wrong default. Option (b) introduces deployment coupling between tool and target. Option (c) keeps the inspector standalone, the safety boundary intact, and surfaces the data the operator actually needs to make the call themselves. The "Copy app.close()" button is the framework's contract expressed as a clipboard payload — ready-to-paste shape that meets the operator where they are.
+
+**4. Time-travel as forensics, not browsing.**
+The "as-of" toggle on the stream detail panel doesn't render an event log frozen at id N. It re-fetches the **stats** — head, tail, name counts — over the prefix `id < N`. The use case is specifically schema-evolution forensics: "what did this stream look like right before we deprecated `TicketOpened`?" The head card answers immediately — if the stream's head at that time was `TicketOpened`, you've found the migration boundary. The book should distinguish *forensic time-travel* (asks a yes/no question about historical state) from *historical browsing* (scrolls through a frozen view). Different UX, different cost model. The inspector ships only the forensic one because that's what the operator actually asks for. The other is a different ticket.
+
+**5. The chip-as-filter pattern, again.**
+The drill-through modal renders lane chips in violet, priority chips in amber, and the operator can multi-select streams by lane visually. Same hue convention as the Streams view, the Monitor view, and the drain trace. By the time an operator lands on the schema-evolution drill-through, they've already learned what violet means everywhere else. *Color as a name* — the cross-tool affordance scales: every new view that adopts the convention costs the operator zero new vocabulary. Worth contrasting against dashboards where each pane reinvents its palette and the operator builds a mental color map per tool.
+
+**6. The summary cards are the actionable view.**
+Four numbers: total events, deprecated events, distinct names, deprecated names. Together they answer the migration triage question in two glances — "of 5.2M events, 4.2M are deprecated (81%)" tells the operator close-the-books would shrink the working set substantially, which is the whole point of asking. The table beneath is for the follow-up "which event names, which streams". The cards alone could ship as a Slack notification — the table is for the next click. The book should call out that "summary on top, drill on demand" is the right shape for operator dashboards: cheap-to-glance metrics that justify a deeper click, with the deeper click loading on demand rather than rendered eagerly.
+
+---
+
+### Pull-quotes
+
+- "Framework refuses to do the expensive thing automatically; tooling is allowed to."
+- "The most stable contracts are the ones expressed as documentation about naming rules, not as exported functions."
+- "Tooling that decides for operators is tooling that hides decisions."
+- "The 'Copy app.close()' button is the framework's contract expressed as a clipboard payload."
+- "Color as a name — every new view that adopts the convention costs the operator zero new vocabulary."

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -61,6 +61,15 @@ When **SSL** is enabled, the connection uses `ssl: { rejectUnauthorized: false }
   - Watermark histogram showing gap distribution across streams
   - Priority + lane chip filters — click a chip to drill blocked/lease lists to that priority value or drain lane (ACT-102 + ACT-1103). Default priority `p=0` and `default` lane dim; non-default values pop in amber (priority) and violet (lane). Same hue convention as the drain trace and the Streams view, so "this lane" reads the same everywhere.
   - Recent-mutations panel — last 10 inspector-driven mutations with timestamp, target priority, affected count, and the raw filter. Pill at the panel header shows whether the server is running in `write` or `read-only` mode.
+- **Schema Evolution** — answer the post-migration question "how big is the legacy event backlog on disk?":
+  - Four headline cards (total events, deprecated events, distinct names, deprecated names).
+  - Table of every event name on disk with status — `deprecated`, `current`, or `active`. Status derived from the `_v<digits>` convention (ACT-403): within a base group (`Foo`, `Foo_v2`, `Foo_v3`), the highest version is current, lower versions are deprecated, standalone groups are active. Deprecated rows pop with an amber-tinted background and point at their current-version sibling.
+  - Sortable name/status/count columns; filter by free-text name or status; manual refresh button (the workspace aggregation is lazy-loaded, never silently polled).
+  - Click any row → drill-through modal listing every stream that holds that event, with lane chip + priority chip + per-event count (sorted desc) + total events. Multi-select + two copy actions:
+    - "Copy names" — newline-separated stream names.
+    - "Copy app.close()" — ready-to-paste snippet you run from your own application code.
+  - The modal **does not** close streams directly; the inspector has no Act orchestrator (it's a standalone tool pointed at a Postgres store) and can't safely run `app.close()`. The copy affordance is the honest middle ground — inspector surfaces the data, your app runs the close.
+- **Time-travel stream detail** — every stream's detail panel has an "as-of" event-id input. Enter a value → head + tail + name counts re-fetch over the prefix slice (events with `id < beforeId`). A violet `as-of < <id>` chip badges the panel so historical data never reads as live. The forensic shape: "show me what `order-123` looked like before we deprecated `OrderPaid`" — head card reveals the legacy event, confirming the migration boundary.
 
 ### Mutations (write mode)
 
@@ -123,8 +132,11 @@ packages/inspector/
 | `stats` | query | Aggregate counts for current filters |
 | `eventNames` | query | Distinct event names for filter dropdown |
 | `streams` | query | Stream list with event counts, head + tail timestamps, and version |
+| `streamStats` | query | Per-stream head + tail + count + name counts. Optional `before: <id>` for time-travel ("as-of" the prefix with `id < before`) |
 | `streamMeta` | query | Subscription positions from the streams table — priority, lane, retry, lease holder |
 | `drainStatus` | query | Drain pipeline health: aggregates, blocked streams, leases, watermark histogram, priority + lane counts |
+| `schemaEvolution` | query | Workspace event-name rollup with deprecation status derived from the `_v<digits>` convention (ACT-403). Returns events + headline summary |
+| `streamsForEvent` | query | Streams that hold at least one event of the given name — feeds the Schema Evolution drill-through modal |
 | `writeMode` | query | `{ enabled, reason }` — reflects the `ACT_INSPECTOR_WRITE` env var |
 | `prioritize` | mutation | Bulk-update stream priority via `Store.prioritize(filter, n)`. Filter shape mirrors `query_streams` (stream/source/lane/blocked). Refuses when read-only. |
 | `audit` | query | Last 100 mutations performed via the inspector — in-memory ring buffer |

--- a/packages/inspector/src/client/App.tsx
+++ b/packages/inspector/src/client/App.tsx
@@ -7,6 +7,7 @@ import { queryClient, trpc, trpcClient } from "./trpc.js";
 import { Correlation } from "./views/Correlation.js";
 import { EventLog } from "./views/EventLog.js";
 import { Monitor } from "./views/Monitor.js";
+import { SchemaEvolution } from "./views/SchemaEvolution.js";
 import { Streams } from "./views/Streams.js";
 import { Timeline } from "./views/Timeline.js";
 
@@ -31,6 +32,7 @@ export function viewCaption(v: ViewState): string {
     streams: "Streams",
     correlation: "Correlation",
     monitor: "Monitor",
+    schema: "Schema Evolution",
   };
   return labels[v.tab];
 }
@@ -162,6 +164,7 @@ export default function App() {
                     onBlockedCount={setBlockedCount}
                   />
                 )}
+                {view.tab === "schema" && <SchemaEvolution />}
               </div>
             </>
           )}

--- a/packages/inspector/src/client/components/TabNav.tsx
+++ b/packages/inspector/src/client/components/TabNav.tsx
@@ -1,7 +1,20 @@
-import { Activity, Database, GanttChart, GitBranch, List } from "lucide-react";
+import {
+  Activity,
+  Database,
+  GanttChart,
+  GitBranch,
+  Layers,
+  List,
+} from "lucide-react";
 import type { ReactNode } from "react";
 
-export type Tab = "log" | "timeline" | "streams" | "correlation" | "monitor";
+export type Tab =
+  | "log"
+  | "timeline"
+  | "streams"
+  | "correlation"
+  | "monitor"
+  | "schema";
 
 type TabDef = { id: Tab; label: string; icon: ReactNode };
 
@@ -11,6 +24,7 @@ const tabs: TabDef[] = [
   { id: "streams", label: "Streams", icon: <Database size={14} /> },
   { id: "correlation", label: "Correlation", icon: <GitBranch size={14} /> },
   { id: "monitor", label: "Monitor", icon: <Activity size={14} /> },
+  { id: "schema", label: "Schema", icon: <Layers size={14} /> },
 ];
 
 type TabNavProps = {

--- a/packages/inspector/src/client/views/SchemaEvolution.tsx
+++ b/packages/inspector/src/client/views/SchemaEvolution.tsx
@@ -1,0 +1,267 @@
+import { ArrowRight, RefreshCw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { trpc } from "../trpc.js";
+
+type EventRow = {
+  name: string;
+  count: number;
+  status: "current" | "deprecated" | "active";
+  currentVersion: string | null;
+};
+
+type SortKey = "name" | "status" | "count";
+
+/**
+ * Schema Evolution view (#708).
+ *
+ * Renders the workspace event-name rollup with deprecation status —
+ * derived from the framework's `_v<digits>` convention. Operators
+ * land here to answer the post-migration question "how big is the
+ * legacy event backlog on disk?".
+ *
+ * Lazy-loaded: the query fires once on view-open and stays cached
+ * until the operator clicks Refresh. `query_stats({}, {names:true})`
+ * is cheap on durable adapters but not free; on-demand keeps it from
+ * running every time the page polls.
+ */
+export function SchemaEvolution() {
+  const [sortKey, setSortKey] = useState<SortKey>("status");
+  const [sortAsc, setSortAsc] = useState(false);
+  const [filter, setFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState<
+    "all" | "deprecated" | "current" | "active"
+  >("all");
+
+  const query = trpc.schemaEvolution.useQuery(undefined, {
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+  const utils = trpc.useUtils();
+
+  const rows: EventRow[] = (query.data?.events ?? []) as EventRow[];
+  const summary = query.data?.summary;
+
+  const filtered = useMemo(() => {
+    const dir = sortAsc ? 1 : -1;
+    // Stable status ordering for the "status" sort:
+    // deprecated (most operator-relevant) > current > active
+    const statusRank = (s: EventRow["status"]) =>
+      s === "deprecated" ? 0 : s === "current" ? 1 : 2;
+    return rows
+      .filter((r) => !filter || r.name.toLowerCase().includes(filter.toLowerCase()))
+      .filter((r) => statusFilter === "all" || r.status === statusFilter)
+      .sort((a, b) => {
+        switch (sortKey) {
+          case "name":
+            return dir * a.name.localeCompare(b.name);
+          case "status":
+            return dir * (statusRank(a.status) - statusRank(b.status));
+          case "count":
+            return dir * (a.count - b.count);
+        }
+      });
+  }, [rows, filter, statusFilter, sortKey, sortAsc]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) setSortAsc(!sortAsc);
+    else {
+      setSortKey(key);
+      // Sensible default: descending for count + status (highest impact
+      // first), ascending for name (alphabetical).
+      setSortAsc(key === "name");
+    }
+  };
+
+  const sortArrow = (key: SortKey) =>
+    sortKey === key ? (sortAsc ? " ▴" : " ▾") : "";
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      {/* Summary cards */}
+      {summary && (
+        <div className="grid grid-cols-4 gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-3">
+          <SummaryCard
+            label="Total events"
+            value={summary.totalEvents.toLocaleString()}
+            color="text-zinc-200"
+          />
+          <SummaryCard
+            label="Deprecated events"
+            value={summary.deprecatedEvents.toLocaleString()}
+            color={
+              summary.deprecatedEvents > 0 ? "text-amber-400" : "text-zinc-500"
+            }
+          />
+          <SummaryCard
+            label="Distinct names"
+            value={String(summary.distinctNames)}
+            color="text-zinc-200"
+          />
+          <SummaryCard
+            label="Deprecated names"
+            value={String(summary.deprecatedNames)}
+            color={
+              summary.deprecatedNames > 0 ? "text-amber-400" : "text-zinc-500"
+            }
+          />
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-2">
+        <span className="text-xs text-zinc-400">
+          <span className="font-medium text-zinc-200">{filtered.length}</span>
+          {filtered.length !== rows.length && (
+            <span className="text-zinc-500"> / {rows.length}</span>
+          )}{" "}
+          events
+        </span>
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by name..."
+          className="w-56 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-200 outline-none placeholder:text-zinc-600 focus:border-emerald-600"
+        />
+        <label className="flex items-center gap-1.5 text-[11px] text-zinc-400">
+          Status
+          <select
+            value={statusFilter}
+            onChange={(e) =>
+              setStatusFilter(
+                e.target.value as "all" | "deprecated" | "current" | "active"
+              )
+            }
+            className="rounded-md border border-zinc-700 bg-zinc-800 px-1.5 py-1 text-[11px] text-zinc-200 outline-none focus:border-emerald-600"
+          >
+            <option value="all">all</option>
+            <option value="deprecated">deprecated</option>
+            <option value="current">current</option>
+            <option value="active">active</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => void utils.schemaEvolution.invalidate()}
+          disabled={query.isFetching}
+          className="ml-auto flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-[11px] text-zinc-300 transition hover:border-emerald-600 hover:text-emerald-300 disabled:opacity-50"
+          title="Re-run the workspace event-name aggregation"
+        >
+          <RefreshCw
+            size={12}
+            className={query.isFetching ? "animate-spin" : ""}
+          />
+          {query.isFetching ? "Loading…" : "Refresh"}
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <div className="sticky top-0 flex items-center gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-1.5 text-[10px] uppercase tracking-wider text-zinc-500">
+          <button
+            onClick={() => handleSort("status")}
+            className="w-24 shrink-0 text-left hover:text-zinc-300"
+          >
+            Status{sortArrow("status")}
+          </button>
+          <button
+            onClick={() => handleSort("name")}
+            className="min-w-0 flex-1 text-left hover:text-zinc-300"
+          >
+            Event name{sortArrow("name")}
+          </button>
+          <span className="w-48 shrink-0 text-left">Current version</span>
+          <button
+            onClick={() => handleSort("count")}
+            className="w-32 shrink-0 text-right hover:text-zinc-300"
+          >
+            On-disk count{sortArrow("count")}
+          </button>
+        </div>
+
+        {query.isLoading ? (
+          <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+            Loading workspace event aggregation…
+          </div>
+        ) : query.isError ? (
+          <div className="flex h-48 items-center justify-center text-sm text-red-400">
+            Failed to load: {query.error?.message ?? "unknown error"}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+            {rows.length === 0
+              ? "No events in this store yet."
+              : "No events match the active filter."}
+          </div>
+        ) : (
+          filtered.map((row) => <EventNameRow key={row.name} row={row} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color: string;
+}) {
+  return (
+    <div className="rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+        {label}
+      </div>
+      <div className={`text-2xl font-semibold ${color}`}>{value}</div>
+    </div>
+  );
+}
+
+function EventNameRow({ row }: { row: EventRow }) {
+  return (
+    <div
+      className={`flex items-center gap-3 border-b border-zinc-800/50 px-4 py-2 text-xs ${
+        row.status === "deprecated" ? "bg-amber-950/10" : ""
+      }`}
+    >
+      <span className="w-24 shrink-0">
+        <StatusBadge status={row.status} />
+      </span>
+      <span className="min-w-0 flex-1 truncate font-mono text-zinc-200">
+        {row.name}
+      </span>
+      <span className="w-48 shrink-0 truncate font-mono text-zinc-500">
+        {row.currentVersion ? (
+          <span className="inline-flex items-center gap-1">
+            <ArrowRight size={10} className="text-zinc-600" />
+            <span className="text-emerald-400">{row.currentVersion}</span>
+          </span>
+        ) : (
+          <span className="text-zinc-700">—</span>
+        )}
+      </span>
+      <span className="w-32 shrink-0 text-right font-mono text-zinc-300">
+        {row.count.toLocaleString()}
+      </span>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: EventRow["status"] }) {
+  const className =
+    status === "deprecated"
+      ? "border-amber-700 bg-amber-950/50 text-amber-300"
+      : status === "current"
+        ? "border-violet-700 bg-violet-950/50 text-violet-300"
+        : "border-zinc-700 bg-zinc-900 text-zinc-500";
+  return (
+    <span
+      className={`inline-block rounded border px-1.5 py-0 text-[10px] font-mono ${className}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/packages/inspector/src/client/views/SchemaEvolution.tsx
+++ b/packages/inspector/src/client/views/SchemaEvolution.tsx
@@ -1,5 +1,5 @@
-import { ArrowRight, RefreshCw } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ArrowRight, Check, Copy, RefreshCw, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { trpc } from "../trpc.js";
 
 type EventRow = {
@@ -31,6 +31,12 @@ export function SchemaEvolution() {
   const [statusFilter, setStatusFilter] = useState<
     "all" | "deprecated" | "current" | "active"
   >("all");
+  // Open drill-through modal for the clicked event row. Operators only
+  // really want to drill into *deprecated* rows ("which streams still
+  // carry the legacy event?"), but every row supports it — `active`
+  // and `current` drill-through is useful for "which streams use this
+  // event" forensics too.
+  const [selectedEvent, setSelectedEvent] = useState<string | null>(null);
 
   const query = trpc.schemaEvolution.useQuery(undefined, {
     staleTime: Infinity,
@@ -194,9 +200,22 @@ export function SchemaEvolution() {
               : "No events match the active filter."}
           </div>
         ) : (
-          filtered.map((row) => <EventNameRow key={row.name} row={row} />)
+          filtered.map((row) => (
+            <EventNameRow
+              key={row.name}
+              row={row}
+              onSelect={() => setSelectedEvent(row.name)}
+            />
+          ))
         )}
       </div>
+
+      {selectedEvent && (
+        <StreamsForEventModal
+          eventName={selectedEvent}
+          onClose={() => setSelectedEvent(null)}
+        />
+      )}
     </div>
   );
 }
@@ -220,10 +239,19 @@ function SummaryCard({
   );
 }
 
-function EventNameRow({ row }: { row: EventRow }) {
+function EventNameRow({
+  row,
+  onSelect,
+}: {
+  row: EventRow;
+  onSelect: () => void;
+}) {
   return (
-    <div
-      className={`flex items-center gap-3 border-b border-zinc-800/50 px-4 py-2 text-xs ${
+    <button
+      type="button"
+      onClick={onSelect}
+      title="Drill into streams holding this event"
+      className={`flex w-full items-center gap-3 border-b border-zinc-800/50 px-4 py-2 text-left text-xs transition hover:bg-zinc-900/50 ${
         row.status === "deprecated" ? "bg-amber-950/10" : ""
       }`}
     >
@@ -246,6 +274,230 @@ function EventNameRow({ row }: { row: EventRow }) {
       <span className="w-32 shrink-0 text-right font-mono text-zinc-300">
         {row.count.toLocaleString()}
       </span>
+    </button>
+  );
+}
+
+/**
+ * Modal listing every stream that holds at least one event of the
+ * named type (#708 slice 4). Built from the `streamsForEvent` tRPC
+ * query — pure read, no destructive actions from the inspector.
+ *
+ * Operators select rows + copy stream names (or a ready-to-paste
+ * `app.close([...])` snippet) so they can run the actual close from
+ * their own application code. The inspector doesn't have an Act
+ * orchestrator to call `app.close()` itself; see slice-3 commit and
+ * the PR body for the rationale.
+ */
+function StreamsForEventModal({
+  eventName,
+  onClose,
+}: {
+  eventName: string;
+  onClose: () => void;
+}) {
+  const query = trpc.streamsForEvent.useQuery(
+    { name: eventName },
+    { staleTime: 30_000, refetchOnWindowFocus: false }
+  );
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [copied, setCopied] = useState<"names" | "snippet" | null>(null);
+
+  // Auto-dismiss the "copied" toast after a beat so repeated copies
+  // give visual feedback each time.
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(null), 1500);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  // Esc closes the modal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const rows = query.data?.streams ?? [];
+  const totalOfName = query.data?.totalEventsOfName ?? 0;
+
+  const toggle = (stream: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(stream)) next.delete(stream);
+      else next.add(stream);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelected((prev) =>
+      prev.size === rows.length ? new Set() : new Set(rows.map((r) => r.stream))
+    );
+  };
+
+  const selectedStreams = rows
+    .filter((r) => selected.has(r.stream))
+    .map((r) => r.stream);
+
+  const copyNames = () => {
+    void navigator.clipboard.writeText(selectedStreams.join("\n"));
+    setCopied("names");
+  };
+
+  const copySnippet = () => {
+    const targets = selectedStreams
+      .map((s) => `  { stream: ${JSON.stringify(s)} }`)
+      .join(",\n");
+    const snippet = `await app.close([\n${targets}\n]);`;
+    void navigator.clipboard.writeText(snippet);
+    setCopied("snippet");
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[80vh] w-[min(900px,90vw)] flex-col rounded-lg border border-zinc-700 bg-zinc-925 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between border-b border-zinc-800 px-4 py-3">
+          <div>
+            <h3 className="font-mono text-sm text-zinc-200">{eventName}</h3>
+            <p className="mt-0.5 text-[11px] text-zinc-500">
+              {rows.length === 0
+                ? "No streams hold this event."
+                : `${rows.length} streams hold ${totalOfName.toLocaleString()} ${eventName} events`}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-zinc-500 transition hover:text-zinc-300"
+            title="Close (Esc)"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Table */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <div className="sticky top-0 flex items-center gap-3 border-b border-zinc-800 bg-zinc-925 px-4 py-1.5 text-[10px] uppercase tracking-wider text-zinc-500">
+            <button
+              type="button"
+              onClick={toggleAll}
+              className="w-6 shrink-0 text-left hover:text-zinc-300"
+              title={
+                selected.size === rows.length && rows.length > 0
+                  ? "Clear selection"
+                  : "Select all"
+              }
+            >
+              {selected.size === rows.length && rows.length > 0 ? "☑" : "☐"}
+            </button>
+            <span className="w-20 shrink-0 truncate">Lane</span>
+            <span className="w-12 shrink-0 text-right">Pri</span>
+            <span className="min-w-0 flex-1">Stream</span>
+            <span className="w-24 shrink-0 text-right">
+              {eventName.length > 8 ? "Event #" : `${eventName}`}
+            </span>
+            <span className="w-24 shrink-0 text-right">Total events</span>
+          </div>
+          {query.isLoading ? (
+            <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+              Loading streams…
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="flex h-48 items-center justify-center text-sm text-zinc-600">
+              No streams currently hold this event.
+            </div>
+          ) : (
+            rows.map((r) => (
+              <button
+                key={r.stream}
+                type="button"
+                onClick={() => toggle(r.stream)}
+                className={`flex w-full items-center gap-3 border-b border-zinc-800/50 px-4 py-2 text-left text-xs transition hover:bg-zinc-900/50 ${
+                  selected.has(r.stream) ? "bg-emerald-950/30" : ""
+                }`}
+              >
+                <span className="w-6 shrink-0 font-mono text-zinc-400">
+                  {selected.has(r.stream) ? (
+                    <Check size={12} className="text-emerald-400" />
+                  ) : (
+                    <span className="text-zinc-700">☐</span>
+                  )}
+                </span>
+                <span
+                  className={`w-20 shrink-0 truncate font-mono text-[10px] ${r.lane ? "text-violet-300" : "text-zinc-700"}`}
+                  title={r.lane ? `lane: ${r.lane}` : "default lane"}
+                >
+                  {r.lane ?? "default"}
+                </span>
+                <span
+                  className={`w-12 shrink-0 text-right font-mono ${r.priority !== 0 ? "text-amber-400" : "text-zinc-700"}`}
+                >
+                  {r.priority}
+                </span>
+                <span className="min-w-0 flex-1 truncate font-mono text-zinc-200">
+                  {r.stream}
+                </span>
+                <span className="w-24 shrink-0 text-right font-mono text-amber-300">
+                  {r.eventCount.toLocaleString()}
+                </span>
+                <span className="w-24 shrink-0 text-right font-mono text-zinc-500">
+                  {r.totalEvents.toLocaleString()}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-zinc-800 px-4 py-2.5">
+          <div className="text-[11px] text-zinc-500">
+            <span className="font-mono text-zinc-300">
+              {selected.size}
+            </span>{" "}
+            selected
+            {copied && (
+              <span className="ml-3 inline-flex items-center gap-1 text-emerald-400">
+                <Check size={11} />
+                {copied === "names"
+                  ? "Stream names copied"
+                  : "app.close() snippet copied"}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={copyNames}
+              disabled={selected.size === 0}
+              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-[11px] text-zinc-300 transition hover:border-emerald-600 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-40"
+              title="Copy newline-separated stream names"
+            >
+              <Copy size={12} />
+              Copy names
+            </button>
+            <button
+              type="button"
+              onClick={copySnippet}
+              disabled={selected.size === 0}
+              className="flex items-center gap-1.5 rounded-md border border-emerald-700 bg-emerald-900/40 px-2 py-1 text-[11px] text-emerald-200 transition hover:border-emerald-600 hover:bg-emerald-900/60 disabled:cursor-not-allowed disabled:opacity-40"
+              title="Copy a ready-to-paste app.close([...]) snippet"
+            >
+              <Copy size={12} />
+              Copy app.close()
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/inspector/src/client/views/Streams.tsx
+++ b/packages/inspector/src/client/views/Streams.tsx
@@ -554,6 +554,14 @@ function StreamDetail({
   onStream?: (stream: string) => void;
   onClose: () => void;
 }) {
+  // Time-travel `before` — when non-null, stats are computed over the
+  // slice of the stream with `id < beforeId`. Lets the detail panel
+  // answer schema-evolution forensics like "what did this stream look
+  // like before we deprecated TicketOpened?". `null` = live view
+  // (#708 slice 5).
+  const [beforeId, setBeforeId] = useState<number | null>(null);
+  const [beforeInput, setBeforeInput] = useState("");
+
   const eventsQuery = trpc.query.useQuery(
     { stream, limit: 100, backward: true },
     { staleTime: 3_000 }
@@ -572,8 +580,10 @@ function StreamDetail({
   //   stale entry refetches via the `staleTime` window.
   // - 30s staleTime: long enough that closing and reopening the same
   //   stream re-uses the cached result instead of round-tripping.
+  // - `beforeId` is part of the query key, so toggling time-travel
+  //   fires a fresh query and the result caches independently.
   const statsQuery = trpc.streamStats.useQuery(
-    { stream },
+    { stream, before: beforeId ?? undefined },
     {
       staleTime: 30_000,
       refetchOnWindowFocus: false,
@@ -586,7 +596,7 @@ function StreamDetail({
     <div className="flex flex-1 flex-col overflow-y-auto">
       {/* Detail header */}
       <div className="sticky top-0 z-10 flex items-center justify-between border-b border-zinc-800 bg-zinc-925 px-4 py-2">
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <h3 className="truncate font-mono text-xs font-medium text-zinc-200">
             {stream}
           </h3>
@@ -596,8 +606,55 @@ function StreamDetail({
           >
             copy
           </button>
+          {beforeId !== null && (
+            <span
+              className="rounded border border-violet-700 bg-violet-950/60 px-1.5 py-0 font-mono text-[10px] text-violet-200"
+              title="Stats computed over events with id < beforeId. Click 'Live' to clear."
+            >
+              as-of &lt; {beforeId.toLocaleString()}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
+          {/* Time-travel control (#708 slice 5). Operator types an
+              event id and presses Enter to compute stats over the
+              prefix of the stream with `id < beforeId`. "Live"
+              clears the override. */}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const parsed = Number.parseInt(beforeInput, 10);
+              setBeforeId(Number.isFinite(parsed) && parsed > 0 ? parsed : null);
+            }}
+            className="flex items-center gap-1"
+          >
+            <label
+              className="text-[10px] uppercase tracking-wider text-zinc-500"
+              title="View stats as of the slice with id < this event"
+            >
+              as-of
+            </label>
+            <input
+              type="number"
+              value={beforeInput}
+              onChange={(e) => setBeforeInput(e.target.value)}
+              placeholder="event id"
+              className="w-24 rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-200 outline-none placeholder:text-zinc-600 focus:border-emerald-600"
+            />
+            {beforeId !== null && (
+              <button
+                type="button"
+                onClick={() => {
+                  setBeforeId(null);
+                  setBeforeInput("");
+                }}
+                className="rounded border border-emerald-700 bg-emerald-950/40 px-1.5 py-0.5 text-[10px] text-emerald-300 transition hover:bg-emerald-900/60"
+                title="Clear time-travel and return to the live view"
+              >
+                live
+              </button>
+            )}
+          </form>
           <button
             onClick={onClose}
             className="text-zinc-500 hover:text-zinc-300"

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -646,13 +646,23 @@ export const inspectorRouter = t.router({
    * total event count.
    */
   streamStats: t.procedure
-    .input(z.object({ stream: z.string().min(1) }))
+    .input(
+      z.object({
+        stream: z.string().min(1),
+        // Time-travel: include only events with `id < before` in the
+        // aggregation (#708 slice 5). Lets the detail panel answer
+        // "what did this stream look like before event N?". Default
+        // (omitted) returns live stats — the full stream.
+        before: z.number().int().positive().optional(),
+      })
+    )
     .query(async ({ input }) => {
       const s = getStore();
       const stats = await s.query_stats<Schemas>([input.stream], {
         count: true,
         names: true,
         tail: true,
+        before: input.before,
       });
       const entry = stats.get(input.stream);
       if (!entry) return null;
@@ -673,6 +683,9 @@ export const inspectorRouter = t.router({
         tail: project(tail),
         eventCount: count ?? 0,
         nameCounts: names ?? {},
+        // Echoed back so the UI doesn't have to thread state through
+        // its own cache key — `null` means "live, no time-travel".
+        asOf: input.before ?? null,
       };
     }),
 

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -45,6 +45,64 @@ const recordAudit = (entry: AuditEntry): void => {
 /** Loosely-typed committed event for inspector queries */
 type AnyEvent = Committed<Schemas, string>;
 
+/**
+ * Event-version classifier (ACT-403 mirror) — #708.
+ *
+ * The framework's `internal/event-versions.ts` owns the canonical
+ * `_v<digits>` rule. The inspector can't reach into internal, so this
+ * is a local copy of the same convention:
+ *
+ *   `Foo_v<n>` with `n >= 2` is "version n of Foo"; bare `Foo` is
+ *   implicit v1; `Foo_v1` is just a literal name. Within a base
+ *   group, the highest version is "current", lower versions are
+ *   "deprecated", standalone bases (no siblings) are "active".
+ *
+ * Kept inline so the inspector stays standalone — it queries a PG
+ * store directly and never needs to import the running app's
+ * registry. The convention is documented in
+ * `docs/docs/architecture/event-schema-evolution.md`, so duplicating
+ * the rule here doesn't widen any unstable surface.
+ */
+const VERSION_SUFFIX_RE = /^(.+?)_v(\d+)$/;
+type EventStatus = "current" | "deprecated" | "active";
+type Classification = {
+  status: EventStatus;
+  /** Defined when `status === "deprecated"` — points at the highest version. */
+  currentVersion: string | null;
+};
+
+function classifyEventVersions(
+  names: Iterable<string>
+): Map<string, Classification> {
+  const groups = new Map<string, Array<{ name: string; version: number }>>();
+  for (const name of names) {
+    const m = name.match(VERSION_SUFFIX_RE);
+    const v = m ? Number.parseInt(m[2], 10) : 1;
+    const base = m && v >= 2 ? m[1] : name;
+    const list = groups.get(base);
+    if (list) list.push({ name, version: v });
+    else groups.set(base, [{ name, version: v }]);
+  }
+  const out = new Map<string, Classification>();
+  for (const [, list] of groups) {
+    if (list.length < 2) {
+      // Standalone — "active".
+      out.set(list[0].name, { status: "active", currentVersion: null });
+      continue;
+    }
+    list.sort((a, b) => b.version - a.version);
+    const current = list[0];
+    out.set(current.name, { status: "current", currentVersion: null });
+    for (let i = 1; i < list.length; i++) {
+      out.set(list[i].name, {
+        status: "deprecated",
+        currentVersion: current.name,
+      });
+    }
+  }
+  return out;
+}
+
 /** Collect events into an array */
 const collect =
   (target: AnyEvent[]) =>
@@ -617,6 +675,69 @@ export const inspectorRouter = t.router({
         nameCounts: names ?? {},
       };
     }),
+
+  /**
+   * Workspace event-name rollup with deprecation status (#708).
+   *
+   * Aggregates per-stream event-name counts from
+   * `query_stats({}, {names: true})` into a single workspace-wide
+   * histogram, then applies the framework's `_v<digits>` deprecation
+   * rule (ACT-403) to label each name as `current` / `deprecated` /
+   * `active`. Returns one row per distinct event name, sorted with
+   * deprecated rows first (operator's main concern) then by count
+   * descending.
+   *
+   * Lazy-loaded — the Schema Evolution view opens this on demand,
+   * not on every page load. `query_stats({}, …)` is a single round
+   * trip on durable adapters (`SELECT … GROUP BY stream` with a CTE
+   * aggregation), so the cost scales with the events table size
+   * rather than fetching every row over the wire.
+   */
+  schemaEvolution: t.procedure.query(async () => {
+    const s = getStore();
+    const stats = await s.query_stats<Schemas>({}, { names: true });
+    const totals = new Map<string, number>();
+    for (const { names } of stats.values()) {
+      for (const [name, n] of Object.entries(names ?? {})) {
+        totals.set(name, (totals.get(name) ?? 0) + (n ?? 0));
+      }
+    }
+    const classification = classifyEventVersions(totals.keys());
+    return {
+      events: [...totals.entries()]
+        .map(([name, count]) => ({
+          name,
+          count,
+          ...(classification.get(name) ?? {
+            status: "active" as EventStatus,
+            currentVersion: null,
+          }),
+        }))
+        .sort((a, b) => {
+          // Deprecated first — that's the migration backlog operators
+          // want to see at a glance. Within each status, sort by count
+          // desc so the heaviest tables surface first.
+          if (a.status !== b.status) {
+            if (a.status === "deprecated") return -1;
+            if (b.status === "deprecated") return 1;
+          }
+          return b.count - a.count;
+        }),
+      // Headline totals — render above the table so an operator can
+      // see "of the 5.2M total events, 4.2M are deprecated" at a
+      // glance without summing rows mentally.
+      summary: {
+        totalEvents: [...totals.values()].reduce((s, n) => s + n, 0),
+        deprecatedEvents: [...totals.entries()]
+          .filter(([n]) => classification.get(n)?.status === "deprecated")
+          .reduce((s, [, n]) => s + n, 0),
+        distinctNames: totals.size,
+        deprecatedNames: [...classification.values()].filter(
+          (c) => c.status === "deprecated"
+        ).length,
+      },
+    };
+  }),
 
   /** Get stream processing metadata from the streams table */
   streamMeta: t.procedure.query(async () => {

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -739,6 +739,65 @@ export const inspectorRouter = t.router({
     };
   }),
 
+  /**
+   * Drill-through query: streams that still hold a given event name
+   * (#708). Used by the Schema Evolution view's modal — operator
+   * clicks a deprecated event row, sees every stream where
+   * `nameCounts[name] > 0`, sorted by per-stream count descending.
+   *
+   * The inspector itself doesn't close streams (no Act orchestrator
+   * available); the modal surfaces the list + a "copy stream names"
+   * affordance so the operator can run `app.close([...])` from their
+   * application. Pure read surface — gated only by `getStore()`.
+   *
+   * Joins `query_stats({}, {names: true})` (events table aggregation)
+   * with `loadAllStreamPositions` (streams table) so each row carries
+   * the lane + priority operators care about when deciding what to
+   * close.
+   */
+  streamsForEvent: t.procedure
+    .input(z.object({ name: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const s = getStore();
+      const [stats, { positions }] = await Promise.all([
+        s.query_stats<Schemas>({}, { count: true, names: true }),
+        loadAllStreamPositions().catch(() => ({ positions: [] })),
+      ]);
+      const metaByStream = new Map(
+        positions.map((p) => [
+          p.stream,
+          { lane: p.lane ?? null, priority: p.priority },
+        ])
+      );
+      const rows: Array<{
+        stream: string;
+        eventCount: number;
+        totalEvents: number;
+        lane: string | null;
+        priority: number;
+      }> = [];
+      let totalAcrossStreams = 0;
+      for (const [stream, { count, names }] of stats.entries()) {
+        const eventCount = names?.[input.name] ?? 0;
+        if (eventCount === 0) continue;
+        totalAcrossStreams += eventCount;
+        const meta = metaByStream.get(stream);
+        rows.push({
+          stream,
+          eventCount,
+          totalEvents: count ?? 0,
+          lane: meta?.lane ?? null,
+          priority: meta?.priority ?? 0,
+        });
+      }
+      rows.sort((a, b) => b.eventCount - a.eventCount);
+      return {
+        event: input.name,
+        streams: rows,
+        totalEventsOfName: totalAcrossStreams,
+      };
+    }),
+
   /** Get stream processing metadata from the streams table */
   streamMeta: t.procedure.query(async () => {
     try {


### PR DESCRIPTION
## Summary

Closes #708. Surfaces the post-migration question "how big is the legacy event backlog on disk?" in the inspector, plus on-demand time-travel forensics on stream detail.

Six commits, one slice each:

| # | Commit | Touches |
|---|---|---|
| 1 | `schemaEvolution` procedure | Server-side workspace event-name rollup; mirrors ACT-403's `_v<digits>` deprecation rule against names on disk |
| 2 | Schema Evolution view | New top-level tab; four summary cards + sortable/filterable table; deprecated rows tinted amber; manual refresh |
| 3 | `streamsForEvent` procedure | Drill-through query joining `query_stats({names:true})` with `loadAllStreamPositions()` for lane + priority |
| 4 | Drill-through modal | Click any event row → modal lists streams holding it; multi-select + two copy actions (newline-joined names; ready-to-paste `app.close([...])` snippet) |
| 5 | Time-travel "as-of" | `streamStats` gains optional `before` event-id; stream detail panel renders a violet `as-of < <id>` chip when active |
| 6 | Docs + book seed | Inspector README updates; tooling-chapter essay |

## Design call worth flagging — no close mutation

The original ticket called for a bulk-close button on the drill-through modal. **We dropped it.** The inspector is a standalone tRPC server pointed at a Postgres schema; it has no running Act orchestrator, no registry, no correlator. `app.close(targets)` orchestrates eight steps (correlate, safety-check, guard, load state, archive, truncate, cache invalidate, lifecycle) — running just the destructive subset of those would violate the framework's safety story.

The honest middle ground: the inspector surfaces the data (which streams hold the legacy event, with lane + priority context), and provides a **"Copy `app.close()`" button** that emits a ready-to-paste snippet. Operator runs the close from their own application code where the orchestrator is. Closing-from-inspector becomes its own ticket once the design path (run-as-app vs RPC-into-app vs raw-store-tombstone) is settled.

Documented in the slice-3 commit, slice-4 commit, README, and book seed.

## Release-check

| Gate | Status | Notes |
|---|---|---|
| Typecheck | ❌ pre-existing | **Not introduced by this branch.** Three errors in `docs/docusaurus.config.ts` + `docs/src/pages/index.tsx` from PR #768 (`@stackblitz/sdk` types + plugin signature). This PR touches zero `docs/` files; same errors reproduce on master tip. |
| Tests | ✅ | 1702 / 1702 passing |
| Coverage | ✅ | 100% / 100% / 100% / 100% |
| Lint | ✅ | clean |
| Build | ✅ | all packages built |
| Charter | ✅ | no charter files changed |
| Doc audit | ✅ | no renames / deletions to grep |

## Test plan

- [x] `pnpm test` — 1702/1702 green
- [x] Coverage at 100% on every metric
- [x] `pnpm build` clean
- [ ] Manual: connect inspector to a PG store with at least one versioned event family (`Foo` + `Foo_v2`) and confirm the Schema view shows `Foo` as deprecated with `→ Foo_v2`
- [ ] Manual: click a deprecated event row; verify the modal lists streams sorted by per-event count desc; verify lane / priority chips render
- [ ] Manual: multi-select streams + "Copy app.close()"; paste into a JS scratchpad and confirm syntax is valid
- [ ] Manual: on Streams detail, enter an event id in "as-of"; verify head + tail re-fetch over the prefix; verify violet `as-of < N` chip badges the panel; click "live" to clear

## Follow-ups

- **Pre-existing typecheck failure on master** (docs/ files from #768). Worth a tiny cleanup PR — add `@stackblitz/sdk` to docs/package.json deps, fix the plugin signature.
- **Inspector close mutation** — design path TBD. Captured in slice-3/4 commits as the open question.
- **Persistent audit log** for inspector mutations — current is in-memory; out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)