### PR TITLE
chore(release): act-901 pre-flight for the 1.0 cut

### DIFF
--- a/RELEASE_NOTES_1.0.md
+++ b/RELEASE_NOTES_1.0.md
@@ -1,6 +1,6 @@
 # Act 1.0 — Release Notes (Draft)
 
-> **Status:** Draft. This file stages the 1.0.0 release narrative for ACT-304
+> **Status:** Draft. This file stages the 1.0.0 release narrative for ACT-901
 > (#702) to consume when the release mechanics fire. semantic-release manages
 > the per-package `CHANGELOG.md` files automatically; this document is the
 > human-written framing that lands as the GitHub Release body when 1.0.0 is
@@ -28,8 +28,9 @@ See [STABILITY.md](./STABILITY.md) for the full text. The short version:
 - The builder API (`state`, `slice`, `projection`, `act` and their fluent
   surfaces).
 - The `IAct` runtime interface (`do`, `load`, `query`, `query_array`,
-  `drain`, `settle`, `correlate`, `reset`, `close`).
-- The `Store` and `Cache` adapter contracts — backed by the
+  `drain`, `settle`, `correlate`, `reset`, `close`, `unblock`,
+  `blocked_streams`, `audit`).
+- The `Store`, `Cache`, and `Logger` adapter contracts — backed by the
   [`@rotorsoft/act-tck`](./libs/act-tck) test compatibility kit, so the
   contract is executable and verifiable.
 - Lifecycle event names and payload shapes
@@ -44,29 +45,122 @@ See [STABILITY.md](./STABILITY.md) for the full text. The short version:
 - Adapter implementation details outside the contract.
 - Log formats and trace breadcrumb shapes.
 
-## How we got here — the 1.0 milestone in one paragraph
+## How we got here — the 1.0 milestone
 
-Three rounds of foundation work landed in the months leading to 1.0:
+Three phases of work landed in the months leading to 1.0. Each phase is a
+coherent slice of the architectural review that surfaced the weak points
+1.0 had to address: reaction latency, throughput ceilings, maturity, cross-slice
+contracts, singleton ports, and missing primitives for external integration.
 
-- **Scoped ports (ACT-501/502/503).** Per-Act `store`/`cache` injection via
-  `ActOptions.scoped`, threaded through internal modules via
+### Phase 1 — Foundations
+
+The point of Phase 1 was to make 1.0 a real line in the sand: stable API,
+instance-scoped ports for production isolation, and a TCK that lets third
+parties write stores with confidence.
+
+- **Stability charter (ACT-301).** [STABILITY.md](./STABILITY.md) explicitly
+  delineates what semver protects, what it doesn't, and how each category
+  evolves.
+- **Scoped ports (ACT-501 / 502 / 503).** Per-Act `store`/`cache` injection
+  via `ActOptions.scoped`, threaded through internal modules via
   AsyncLocalStorage. Multi-tenant deployments, parallel test workers, and
   hybrid-storage apps no longer fight the singleton port wiring.
-- **TCK (ACT-302).** The Store, Cache, and Logger ports become executable
-  contracts via `@rotorsoft/act-tck`. Every in-tree adapter is wired
-  through the kit; third-party adapter authors drop a single
-  `runStoreTck({ factory })` call into their suite and validate against
-  the same surface the framework itself depends on.
-- **Conformance matrix (ACT-303).** The TCK runs across PostgreSQL 14/15/16/17
-  and `@libsql/client` pinned + latest on every adapter-touching PR.
-  Dialect drift between PG majors and libSQL release jumps are caught
-  in CI, not in production.
+- **TCK (ACT-302).** The `Store`, `Cache`, and `Logger` ports become
+  executable contracts via `@rotorsoft/act-tck`. Every in-tree adapter is
+  wired through the kit; third-party adapter authors drop a single
+  `runStoreTck({ factory })` call into their suite and validate against the
+  same surface the framework itself depends on.
+- **Conformance matrix (ACT-303).** The TCK runs across PostgreSQL
+  14/15/16/17 and `@libsql/client` pinned + latest on every
+  adapter-touching PR. Dialect drift between PG majors and libSQL release
+  jumps surfaces in CI, not in production.
 
-Alongside the foundations, Phase 2 performance work (ACT-101 cross-process
-notify, ACT-102 priority lanes, ACT-103 latency benchmarks, ACT-203
-parallel lease dispatch) and Phase 3 contracts work (ACT-401 cross-slice
-event-schema agreement, ACT-403 versioned event-name deprecation) shipped
-over the same window. All of it is governed by the charter as of 1.0.
+### Phase 2 — Performance
+
+Phase 2 attacked the two performance questions architects ask first: how
+fast does a reaction fire, and how does this scale on Postgres?
+
+- **Cross-process notify (ACT-101).** A new optional `Store.notify(stream)`
+  hook lets adapters wake the local drain when a different process commits
+  to the same backing store. The `notified` lifecycle event surfaces the
+  wakeup to listeners.
+- **Per-event priority lanes (ACT-102).** Reactions can be assigned to
+  named lanes via `.withLane({ name, leaseMillis, streamLimit, cycleMs })`,
+  with each lane getting its own `DrainController`. Hot reactions don't
+  share a budget with slow ones.
+- **Worker-per-lane dispatch (ACT-1103).** Each declared lane runs its own
+  drain controller with its own `leaseMillis`, so a slow webhook reaction
+  can't pin a fast notification reaction's lease window. The same code runs
+  in three deployment shapes — single process running all lanes,
+  process-per-lane, or arbitrary partitioning — because lane filtering is
+  just a `WHERE` clause and `SKIP LOCKED` already gives competing-consumer
+  semantics.
+- **Parallel lease dispatch (ACT-203).** Drain dispatches leases in
+  parallel within a cycle rather than sequentially, lifting the
+  per-reaction latency floor for fan-out workloads.
+- **Latency benchmark scenarios (ACT-103).** Commit-to-reaction latency
+  scenarios live in the perf bench, so regressions in the drain hot path
+  surface as numbers, not as user reports.
+
+### Phase 3 — Integration & contracts
+
+Phase 3 closed the integration story and tightened the contract guarantees
+that grow in importance as Act apps scale to twenty-plus slices.
+
+- **Per-reaction retry backoff (ACT-601).** Configurable per-attempt
+  backoff between retries — exponential, constant, or custom — paced
+  per-worker on the local `DrainController`.
+- **`@rotorsoft/act-http` (ACT-602).** Umbrella package for HTTP-adjacent
+  integrations: a `webhook` helper for reaction-driven POST delivery, plus
+  an `sse` subpath that hosts the surface formerly published as
+  `@rotorsoft/act-sse`. The webhook helper classifies 4xx responses as
+  `NonRetryableWebhookError` so they block the stream on first failure
+  instead of consuming the full retry budget. With `act-http` landed,
+  `@rotorsoft/act-sse` is now deprecated — migration is a one-import
+  change from `@rotorsoft/act-sse` to `@rotorsoft/act-http/sse`; the
+  legacy package receives bug fixes only and will be removed in a future
+  release.
+- **External integration patterns + idempotency contract
+  doc (ACT-603).** A canonical write-up of inline `webhook` versus
+  forwarded bus, idempotency contracts, and recovery patterns.
+- **`NonRetryableError` (ACT-604).** Handlers signal permanent failures
+  (4xx responses, validation errors, "user deleted" 404s) and the drain
+  finalizer blocks the stream on first attempt instead of burning the
+  retry budget.
+- **Build-time cross-slice event-schema check (ACT-401).** Two same-name
+  state partials declaring the same event in `.emits({...})` must
+  reference the same Zod schema instance — `act().build()` throws if not.
+- **Generated event registry doc (ACT-402).** Build output drives a
+  registry doc that lists every event with its producer and consumer slices.
+- **Versioned event-name deprecation (ACT-403).** Adding `Foo_v2` to
+  `.emits({...})` auto-deprecates `Foo`; static emits targeting the legacy
+  version throw at build time, dynamic emits warn once per process.
+- **Configurable correlation id generator (ACT-404).** A `correlator`
+  delegate on `ActOptions` lets operators inject a project-specific id
+  scheme (the default produces a readable id).
+- **`Store.query_stats` primitive (#639).** Batched per-stream head with
+  opt-in count, tail, and event-name lists — replaces the per-stream
+  `query backward, limit:1` pattern across the framework.
+
+### Late additions — observability & operations
+
+Two surfaces landed late in the milestone that don't fit neatly into the
+phase narrative but were too foundational to defer.
+
+- **`app.audit()` (ACT-708.5).** An operator-driven multi-category store
+  audit on `IAct`, alongside `app.close()`, `app.reset()`, `app.unblock()`,
+  and `app.blocked_streams()`. One pass yields findings across nine
+  categories — `schema`, `close-candidate`, `restart-candidate`,
+  `deprecated-load`, `reaction-health`, `snapshot-drift`, `routing-health`,
+  `correlation-gaps`, `clock-anomalies` — each tagged with the
+  remediation it suggests. See
+  [auditing-a-store](./docs/docs/guides/auditing-a-store.md).
+- **Inspector UI for priority/lane + deprecated events (#698, #708).**
+  Priority/lane visualization plus a `prioritize()` mutation surface on
+  the Inspector, and a deprecated-event-count rollup so operators can spot
+  legacy event versions that are still being loaded in production.
+
+All of the above is governed by the charter as of 1.0.
 
 ## Versioning across the workspace
 
@@ -76,31 +170,48 @@ over the same window. All of it is governed by the charter as of 1.0.
 | `@rotorsoft/act-pg` | Yes | `Store` adapter, same contract |
 | `@rotorsoft/act-sqlite` | Yes | `Store` adapter, same contract |
 | `@rotorsoft/act-pino` | Yes | `Logger` adapter, narrow surface |
-| `@rotorsoft/act-sse` | Yes | Public broadcast surface, governed by charter |
+| `@rotorsoft/act-http` | Yes | Umbrella for HTTP integrations — `webhook` helper plus an `sse` subpath that hosts the surface formerly in `@rotorsoft/act-sse` |
 | `@rotorsoft/act-diagram` | Yes | Goes to 1.0 alongside core; diagram output shape (SVG structure, click-through anchors) is explicitly *not* part of the stability surface |
 | `@rotorsoft/act-patch` | Already past 1.0 | Stable utility, untouched |
-| `@rotorsoft/act-tck` | Stays at 0.x | TCK API itself (run* functions, capabilities flags, fixture helpers) is still stabilizing against third-party authors. The Store/Cache/Logger contracts it validates are covered by the charter; the kit's own surface is not yet |
+| `@rotorsoft/act-sse` | Already past 1.0, **deprecated** | Surface lives on as `@rotorsoft/act-http/sse`. Bug fixes only; will be removed in a future release. Migrate by changing the import path |
+| `@rotorsoft/act-tck` | Stays at 0.x | TCK API itself (`run*Tck` functions, capabilities flags, fixture helpers) is still stabilizing against third-party authors. The `Store`/`Cache`/`Logger` contracts it validates are covered by the charter; the kit's own surface is not yet |
 
 ## What's not in 1.0
 
-A few items moved to **1.1** so the milestone could close at a deliberate
-pace rather than a stretched one:
+A set of tickets moved to **1.1** so the milestone could close at a
+deliberate pace rather than a stretched one. They group into four themes:
+
+**Data-at-rest & long-tail storage.**
 
 - **GDPR crypto-shredding** (#566) — event encryption + per-subject key
   shredding. Defers to 1.1 so it can be designed against the now-stable
-  Store contract from day one.
+  `Store` contract from day one.
+- **Postgres partitioning strategy + migration script** (#675, ACT-1101) —
+  documented partitioning for stores that outgrow the unpartitioned
+  default, with a migration script.
+- **Framework-aware event import helper** (#676, ACT-1102) — schema-validated
+  bulk import for migrating events from external systems.
 
-A few items live in 1.0 as "ship-when-ready, not blocking":
+**Port mechanism cleanup.**
 
-- **Outbox builder + webhook adapter** (ACT-601 / 602 / 603) — at-least-once
-  external delivery on top of the event log.
-- **Generated event registry doc** (ACT-402) — build-output-driven docs.
-- **`Store.query_heads`** (#639) — batched per-stream latest-event lookup
-  primitive.
-- **Inspector UI updates** (#698 priority-lane viz, #708 deprecated event
-  counts) — observability surface.
+- **Collapse port-singleton Map + ALS overlay** (#710, ACT-510) — the
+  scoped-ports work landed two mechanisms in parallel; 1.1 collapses them
+  into one.
 
-All of these can land in 1.x point releases without breaking the charter.
+**`act-ops` helpers + idempotency (Phase 1.1 tracker, #748, ACT-1110).**
+
+- `withRetry` helper for `ConcurrencyError` (#739, ACT-1111).
+- `settleOnCommit` + `logBlocked` bootstrap helpers (#740, ACT-1112).
+- `replayUntilSettled` helper for projection rebuilds (#741, ACT-1113).
+- Extract `classifyHttpResponse` helper from `webhook` (#742, ACT-1114).
+- `extractIdempotencyKey` header parser (#743, ACT-1115).
+- Idempotency middleware — core + tRPC/Express/Fastify/Hono adapters (#744, ACT-1116).
+- Bootstrap `@rotorsoft/act-ops` workspace package (#745, ACT-1117).
+- `IdempotencyStore` port + `InMemoryIdempotencyStore` (#746, ACT-1118).
+- `computeMinSafeTtl` dedup window sizing helper (#747, ACT-1119).
+
+None of these block 1.0. They're 1.1 because they're additive 1.x
+work — the charter governs them as they land.
 
 ## Upgrading from 0.x
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -25,7 +25,8 @@ The runtime surface returned from `act(...).build()`:
 
 - `do`, `load`, `query`, `query_array`
 - `drain`, `settle`, `correlate`
-- `reset`, `close`
+- `reset`, `unblock`, `blocked_streams`, `close`
+- `audit`
 
 The signatures, return shapes, and behavioral contracts of these methods are stable. Additive new methods on `IAct` are not breaking. Changing the meaning of an existing call (e.g., what `settle()` guarantees) is.
 
@@ -84,8 +85,9 @@ These may change in **any** release, including patches. Don't depend on them in 
 | `@rotorsoft/act-pg` | Yes — `Store` adapter, same contract |
 | `@rotorsoft/act-sqlite` | Yes — `Store` adapter, same contract |
 | `@rotorsoft/act-patch` | Yes — stable utility, depended on by `act` reducers |
-| `@rotorsoft/act-sse` | Yes — public broadcast surface |
+| `@rotorsoft/act-http` | Yes — umbrella for HTTP integrations (`webhook` helper plus an `sse` subpath that hosts the surface formerly published as `@rotorsoft/act-sse`) |
 | `@rotorsoft/act-pino` | Yes — `Logger` adapter, narrow surface |
+| `@rotorsoft/act-sse` | **Deprecated** (already past 1.0). Surface moved to `@rotorsoft/act-http/sse`; bug fixes only, scheduled for removal in a future release. Migrate by changing the import path. |
 | `@rotorsoft/act-diagram` | Goes to 1.0 alongside core. Diagram output shape (SVG structure, click-through anchors) is *not* part of the stability surface and may evolve. |
 | `@rotorsoft/act-tck` | **Stays at 0.x.** The Store/Cache/Logger contracts the TCK validates are stable at 1.0; the TCK's own surface (`run*Tck` functions, `Capabilities` types, fixture helpers) keeps evolving until third-party adapter authors have shaken it out in practice. Joins the 1.x line once that settles. |
 

--- a/libs/act-diagram/.releaserc.json
+++ b/libs/act-diagram/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act-http/.releaserc.json
+++ b/libs/act-http/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act-patch/.releaserc.json
+++ b/libs/act-patch/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act-pg/.releaserc.json
+++ b/libs/act-pg/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act-pg/package.json
+++ b/libs/act-pg/package.json
@@ -51,7 +51,7 @@
     "pg": "^8.20.0"
   },
   "peerDependencies": {
-    "@rotorsoft/act": ">=0.45.0",
+    "@rotorsoft/act": "workspace:^",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/libs/act-pino/.releaserc.json
+++ b/libs/act-pino/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act-pino/package.json
+++ b/libs/act-pino/package.json
@@ -50,7 +50,7 @@
     "pino-pretty": "^13.1.3"
   },
   "peerDependencies": {
-    "@rotorsoft/act": ">=0.45.0"
+    "@rotorsoft/act": "workspace:^"
   },
   "devDependencies": {
     "@rotorsoft/act-tck": "workspace:^"

--- a/libs/act-sqlite/.releaserc.json
+++ b/libs/act-sqlite/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act-sqlite/package.json
+++ b/libs/act-sqlite/package.json
@@ -51,7 +51,7 @@
     "@libsql/client": "^0.17.3"
   },
   "peerDependencies": {
-    "@rotorsoft/act": ">=0.45.0",
+    "@rotorsoft/act": "workspace:^",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/libs/act-sse/.releaserc.json
+++ b/libs/act-sse/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/libs/act/.releaserc.json
+++ b/libs/act/.releaserc.json
@@ -7,7 +7,7 @@
       "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
-          { "breaking": true, "release": "minor" },
+          { "breaking": true, "release": "major" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ importers:
   libs/act-pg:
     dependencies:
       '@rotorsoft/act':
-        specifier: '>=0.45.0'
+        specifier: workspace:^
         version: link:../act
       pg:
         specifier: ^8.20.0
@@ -287,7 +287,7 @@ importers:
   libs/act-pino:
     dependencies:
       '@rotorsoft/act':
-        specifier: '>=0.45.0'
+        specifier: workspace:^
         version: link:../act
       pino:
         specifier: ^10.3.1
@@ -306,7 +306,7 @@ importers:
         specifier: ^0.17.3
         version: 0.17.3
       '@rotorsoft/act':
-        specifier: '>=0.45.0'
+        specifier: workspace:^
         version: link:../act
       zod:
         specifier: ^4.4.3


### PR DESCRIPTION
## Summary

Closes #702.

ACT-901 owns the release mechanics for the 1.0 cut. With every other ticket in milestone 1.0 now closed, this PR runs the pre-flight pass: reconcile the staged release narrative against what actually shipped, flip the semantic-release rules so `BREAKING CHANGE:` footers produce major bumps (not minor) under the 1.x line, and align peer-dep ranges so the post-cut adapter packages bind to `^1.0.0` on npm.

No charter-covered code changes. This is configuration + narrative, with the cut commits to follow in a separate PR.

## Reconcile the 1.0 release narrative

`RELEASE_NOTES_1.0.md` had drifted from the shipped state since ACT-301 staged it:

- **Restructured** the milestone narrative into explicit **Phase 1 (Foundations) / Phase 2 (Performance) / Phase 3 (Integration & contracts) / Late Additions** buckets matching what actually closed.
- **Added missing surfaces** that landed but weren't mentioned: `app.audit()` (ACT-708.5, #723), worker-per-lane drain dispatch (ACT-1103, #733), configurable correlation id generator (ACT-404, #725), `NonRetryableError` (ACT-604, #735), Inspector UI for priority lanes and deprecated event counts (#698, #708).
- **Corrected factual drift**: `Store.query_heads` → `Store.query_stats` (the real shipped name from #639); "outbox builder + webhook adapter" → `@rotorsoft/act-http` umbrella (`webhook` helper + `sse` subpath, the simplified design that actually shipped via #688).
- **Marked `@rotorsoft/act-sse` deprecated**: its surface lives on as `@rotorsoft/act-http/sse`; the legacy package receives bug fixes only and is scheduled for removal.
- **Expanded "What's not in 1.0"** to the full 1.1 backlog grouped by theme: data-at-rest (#566 GDPR, #675 partitioning, #676 event-import), port cleanup (#710), and the full helper-extraction batch (#748 / ACT-1110 + #739–#747).
- Added `@rotorsoft/act-http` to the per-library status table; moved `@rotorsoft/act-sse` to a deprecated row.

`STABILITY.md` also drifted:

- The `IAct` method list gains `unblock`, `blocked_streams`, and `audit` (all additive methods that landed under the charter).
- Per-library table gains `@rotorsoft/act-http`; `@rotorsoft/act-sse` moves to a deprecated row.

## Release-config flips

Every `.releaserc.json` in the workspace mapped `{ "breaking": true, "release": "minor" }` — appropriate for 0.x, wrong for 1.x. Flipped to `"major"` across every charter-covered package:

- `act`, `act-pg`, `act-sqlite`, `act-pino`, `act-diagram`, `act-http` — going to 1.0 in this release.
- `act-patch` (already at 1.2.2) and `act-sse` (already at 1.2.3, deprecated) — they were past 1.0 already but their config still mapped `breaking` to `minor`. Fixed in the same pass for consistency.
- `act-tck` left untouched — stays at 0.x per the charter's explicit carve-out.

## Peer-dep range bumps

`act-pg`, `act-sqlite`, and `act-pino` peer-depended on `"@rotorsoft/act": ">=0.45.0"`. Bumped to `"workspace:^"`, matching the pattern `act-http` and `act-tck` already use. At publish time semantic-release rewrites `workspace:^` to `^<published-version>`, so once the cut commit pushes `@rotorsoft/act` to `1.0.0`, the on-npm published adapter ends up with `"@rotorsoft/act": "^1.0.0"` exactly as ACT-901's body asks for.

The literal `^1.0.0` source representation doesn't work pre-publish: pnpm tries to resolve the peer against the registry, where `@rotorsoft/act@^1.0.0` doesn't exist yet. `workspace:^` is the same end-state via a representation pnpm can resolve through the workspace symlink.

Lockfile regenerated to match.

## Test plan

Verified locally with `/release-check`:

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1743/1743 passing across 112 files
- [x] Coverage: 100% statements / 100% branches / 100% functions / 100% lines (5884/5884, 2830/2830, 1036/1036, 5307/5307)
- [x] `pnpm lint` — 0 errors (23 warnings, 3 infos, all pre-existing)
- [x] `pnpm build` — every package builds clean
- [x] `pnpm install` resolves cleanly with the new peer ranges; lockfile is in sync
- [ ] CI green
- [ ] Reviewed by maintainer

## Stability charter impact

**No charter-covered code changed** — `git diff master --stat -- libs/act/src/builders/ libs/act/src/act.ts libs/act/src/types/ports.ts libs/act/src/types/index.ts libs/act/src/ports.ts` is empty.

This PR is the *implementation* of the charter's transition to 1.x, not a change to the charter-covered surface itself. The release-config flips activate semver-major behavior for any future `BREAKING CHANGE:` footer; the narrative updates and the STABILITY.md edits document what the charter now governs.

The actual 1.0.0 version bump happens in a follow-up PR via the cut commits (one `chore(<lib>)!:` per lib with a `BREAKING CHANGE:` footer), which is when semantic-release will consume the flipped release rules.

## Follow-ups

- **Cut commits + 1.0.0 publish** — a separate PR per ACT-901: one `chore(<lib>)!:` per charter-covered lib with `BREAKING CHANGE: This is the 1.0 release` footer. The sequential CD matrix (`max-parallel: 1`) consumes those and publishes 1.0.0 for each package via semantic-release.
- **Post-release tidy** — archive `RELEASE_NOTES_1.0.md` under `docs/`, add the one-line preamble to each lib's `CHANGELOG.md` 1.0.0 entry pointing at `STABILITY.md`, and close the umbrella tracking issue #690 once the cut completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>