### PR TITLE
chore(release): cut 1.0.0 for the six charter packages

### DIFF
--- a/libs/act-diagram/README.md
+++ b/libs/act-diagram/README.md
@@ -185,7 +185,7 @@ Bottom-up: inventory scan → per-state validation → per-slice composition (wi
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md). The diagram's **output shape** (SVG structure, click-through anchors) is *not* part of the stability surface and may evolve. Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+Public API governed by the [Act Stability Charter](../../STABILITY.md). The diagram's **output shape** (SVG structure, click-through anchors) is *not* part of the stability surface and may evolve. Charter is **in effect as of 1.0.0**; the milestone tracker is [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1).
 
 ## Related packages
 

--- a/libs/act-http/README.md
+++ b/libs/act-http/README.md
@@ -186,7 +186,7 @@ For the recommended receiver-side idempotency contract that pairs with `webhook`
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+Public API governed by the [Act Stability Charter](../../STABILITY.md). Both subpaths (`@rotorsoft/act-http/webhook` and `@rotorsoft/act-http/sse`) are covered by the charter. The `sse` subpath hosts the surface formerly published as `@rotorsoft/act-sse`, now deprecated. Charter is **in effect as of 1.0.0**; the milestone tracker is [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1).
 
 ## Related packages
 

--- a/libs/act-pg/README.md
+++ b/libs/act-pg/README.md
@@ -159,7 +159,7 @@ Both adapters pass the same conformance suite — your application code doesn't 
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+Public API governed by the [Act Stability Charter](../../STABILITY.md). `PostgresStore` implements the `Store` contract from `@rotorsoft/act` and is validated against `@rotorsoft/act-tck` across PostgreSQL 14/15/16/17 in CI. Charter is **in effect as of 1.0.0**; the milestone tracker is [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1).
 
 ## Related packages
 

--- a/libs/act-pino/README.md
+++ b/libs/act-pino/README.md
@@ -119,7 +119,7 @@ Pair with `dispose()` from `@rotorsoft/act` to wire pino flush into the framewor
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+Public API governed by the [Act Stability Charter](../../STABILITY.md). `PinoLogger` implements the `Logger` contract from `@rotorsoft/act` and is validated against `@rotorsoft/act-tck`. Charter is **in effect as of 1.0.0**; the milestone tracker is [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1).
 
 ## Related packages
 

--- a/libs/act-sqlite/README.md
+++ b/libs/act-sqlite/README.md
@@ -126,7 +126,7 @@ Both adapters pass the same `runStoreTck` suite. Application code doesn't change
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md). Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+Public API governed by the [Act Stability Charter](../../STABILITY.md). `SqliteStore` implements the `Store` contract from `@rotorsoft/act` and is validated against `@rotorsoft/act-tck` on `@libsql/client` pinned + latest in CI. Charter is **in effect as of 1.0.0**; the milestone tracker is [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1).
 
 ## Related packages
 

--- a/libs/act/README.md
+++ b/libs/act/README.md
@@ -10,7 +10,7 @@ _Event-sourcing framework for TypeScript — three primitives, Zod end to end, n
 
 This is the framework core: the builders (`state`, `slice`, `projection`, `act`), the port interfaces (`Store`, `Cache`, `Logger`) with bundled in-memory implementations, the orchestrator that runs the correlate → drain loop, and the snapshot/cache layer that keeps `load()` fast on long streams. Around three primitives — **actions** (the changes you want to make), **state** (the data you care about), and **reactions** (what happens as a result) — it provides input validation against Zod schemas, optimistic-concurrency commit, derived state via patch reducers, fan-out reactions with backoff and dead-lettering, blocked-stream recovery, time-travel queries against the same log.
 
-Your domain stays in TypeScript; your schemas stay in Zod. Pick a store at bootstrap — Postgres (`@rotorsoft/act-pg`), SQLite (`@rotorsoft/act-sqlite`), or the bundled in-memory default — and the application code stays the same. The published surface is stable under [SemVer](../../STABILITY.md) at 1.0.
+Your domain stays in TypeScript; your schemas stay in Zod. Pick a store at bootstrap — Postgres (`@rotorsoft/act-pg`), SQLite (`@rotorsoft/act-sqlite`), or the bundled in-memory default — and the application code stays the same. The published surface is stable under [SemVer](../../STABILITY.md) as of 1.0.0.
 
 For the project-level overview, see the [root README](../../README.md).
 
@@ -136,7 +136,7 @@ await app.unblock({ stream: "^webhooks-out-" }); // bulk
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md). The charter names exactly which surfaces are protected by SemVer (builders, `Act` interface, port interfaces, lifecycle event shapes, public type exports) and what's free to evolve (internal modules, performance characteristics, log formats). Breaking changes require a `BREAKING CHANGE:` commit footer and a written migration note. Charter takes effect at 1.0 (gated on [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1)).
+Public API governed by the [Act Stability Charter](../../STABILITY.md). The charter names exactly which surfaces are protected by SemVer (builders, `Act` interface, port interfaces, lifecycle event shapes, public type exports) and what's free to evolve (internal modules, performance characteristics, log formats). Breaking changes require a `BREAKING CHANGE:` commit footer and a written migration note. Charter is **in effect as of 1.0.0**; the milestone tracker is [milestone 1.0](https://github.com/Rotorsoft/act-root/milestone/1).
 
 ## Related packages
 


### PR DESCRIPTION
## Summary

Closes #702. Final step of ACT-901: the cut commits that drive semantic-release to publish `1.0.0` for every package going to 1.0 in this milestone.

Six commits, one per charter-covered library entering 1.0 fresh. Each commit is `chore(<lib>)!:` with a tailored `BREAKING CHANGE:` footer and touches exactly that lib's `README.md` — updating the Stability section from "Charter takes effect at 1.0 (gated on milestone 1.0)" to "Charter is in effect as of 1.0.0." Semantic-release-monorepo uses the touched files to attribute each commit to its package; the `BREAKING CHANGE:` footer combined with the release-rule flip from PR #774 drives a major bump.

This is configuration-driven, not a code change. The previous PR put `RELEASE_NOTES_1.0.md`, `STABILITY.md`, the `.releaserc.json` rules, and the peer-dep ranges in place; this PR provides the trigger that consumes them.

## What ships when this merges

The sequential CD matrix (`max-parallel: 1`) processes the six commits in dependency order:

| Package | Cut from | Cut to | Notes |
|---|---|---|---|
| `@rotorsoft/act` | 0.46.0 | **1.0.0** | Defines the charter |
| `@rotorsoft/act-pg` | 0.25.0 | **1.0.0** | Store adapter, PG 14/15/16/17 conformance |
| `@rotorsoft/act-sqlite` | 0.9.0 | **1.0.0** | Store adapter, libSQL pinned + latest conformance |
| `@rotorsoft/act-pino` | 0.5.0 | **1.0.0** | Logger adapter |
| `@rotorsoft/act-diagram` | 0.4.0 | **1.0.0** | Public exports covered; diagram output shape explicitly NOT |
| `@rotorsoft/act-http` | 0.2.0 | **1.0.0** | Webhook helper + SSE subpath (hosts former `act-sse` API) |

`act-patch` (already at 1.2.2) and `act-sse` (already at 1.2.3, deprecated) get no cut commit in this PR — adding a `BREAKING CHANGE:` footer to them would push them to 2.0.0 with no actual behavior change to justify a major bump. Their `.releaserc.json` was still flipped to `breaking → major` in #774 so the next genuine breaking change does the right thing.

`act-tck` stays at 0.x per the charter's explicit carve-out.

## Why the per-lib commits

Semantic-release-monorepo decides which package each commit touches based on the files it modifies. A single multi-lib commit would either be ambiguous (no clean attribution) or get attributed to whichever lib appears first. Splitting into six commits, each touching only the relevant lib's README, gives each package its own clean release event with its own changelog entry and its own published version bump.

The README change in each commit is meaningful on its own — rewriting "gated on milestone 1.0" to "in effect as of 1.0.0" — not a no-op chosen just to drive the commit.

## Test plan

- [x] All six commits are `chore(<lib>)!:` with `BREAKING CHANGE:` footer (commitlint validated locally)
- [x] Each commit touches exactly one lib's README, nothing else
- [x] `git log master..HEAD --oneline` confirms six commits, one per charter-covered lib
- [ ] CI green (typecheck / test / lint / build — no functional code changed, should be a no-op pass)
- [ ] Reviewed by maintainer
- [ ] After merge: CD matrix completes successfully and publishes 1.0.0 for all six packages

## Stability charter impact

**This is the charter taking effect.** No charter-covered code surface changed — only the README's Stability section per lib. The `BREAKING CHANGE:` footers are the formal "stability commitment activates" event; from this point forward, anything covered by `STABILITY.md` requires a major bump to alter.

## Follow-ups (post-merge, post-publish)

- Verify each lib hits 1.0.0 on npm via the CD matrix.
- Add the one-line preamble to each lib's `CHANGELOG.md` 1.0.0 entry pointing at `STABILITY.md` (the full narrative lives in `RELEASE_NOTES_1.0.md`, not duplicated per-package).
- Use `RELEASE_NOTES_1.0.md` content as the GitHub Release body for `@rotorsoft/act@1.0.0`.
- Archive `RELEASE_NOTES_1.0.md` under `docs/` so the repo root stays tidy for future major releases.
- Close umbrella issue #690 (mark Phase 1 complete), close milestone 1.0, close this issue (#702).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>