### PR TITLE
refactor(act-inspector): discriminated AdapterConfig union (ACT-1121)

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -226,7 +226,7 @@ function Hero() {
       <div className={styles.heroInner}>
         <div className={styles.heroBadge}>
           <span className={styles.heroBadgeDot} />
-          v0.x &middot; TypeScript-first event sourcing
+          v1.x &middot; TypeScript-first event sourcing
         </div>
 
         <div className={styles.heroBrand}>

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -114,9 +114,18 @@ const collect =
 const toDate = (iso: string | undefined): Date | undefined =>
   iso ? new Date(iso) : undefined;
 
-/** Managed store instance — not the singleton, so we can reconnect */
-let currentStore: Store | null = null;
-let currentConfig: {
+/**
+ * Per-adapter shape of the currently-connected store's configuration.
+ *
+ * Today only the `pg` member is reachable — `connect` always constructs a
+ * `PostgresStore`. The `sqlite` member is reserved so #781 (discovery) and
+ * #782 (SQLite `connect` branch) land as additive changes against a stable
+ * union, rather than churning this declaration a second time.
+ *
+ * Read-only-after-connect: mutated exclusively by `connect` / `disconnect`.
+ */
+type PgConfig = {
+  adapter: "pg";
   host: string;
   port: number;
   database: string;
@@ -124,7 +133,19 @@ let currentConfig: {
   password: string;
   schema: string;
   table: string;
-} | null = null;
+};
+
+type SqliteConfig = {
+  adapter: "sqlite";
+  file: string;
+  table: string;
+};
+
+type AdapterConfig = PgConfig | SqliteConfig;
+
+/** Managed store instance — not the singleton, so we can reconnect */
+let currentStore: Store | null = null;
+let currentConfig: AdapterConfig | null = null;
 
 function getStore(): Store {
   if (!currentStore) throw new Error("Not connected to a store");
@@ -412,9 +433,19 @@ function csvParseLine(line: string): string[] {
   return fields;
 }
 
-/** Get a raw pg client for direct queries */
-async function getRawClient(): Promise<pg.Client> {
+/**
+ * Get a raw pg client for direct queries.
+ *
+ * PG-only by design — narrows the {@link AdapterConfig} discriminator and
+ * throws on any non-PG adapter. The guard is a noop today (only PG can
+ * connect) but makes #782 safe to add the SQLite branch without inventing
+ * a fake `pg.Client`. The whole helper goes away in #786 once `restore`
+ * rides `Store.restore`.
+ */
+async function getRawPgClient(): Promise<pg.Client> {
   if (!currentConfig) throw new Error("Not connected to a store");
+  if (currentConfig.adapter !== "pg")
+    throw new Error("Raw PG client requires a PG-backed inspector connection");
   const client = new pg.Client({
     host: currentConfig.host,
     port: currentConfig.port,
@@ -477,7 +508,7 @@ export const inspectorRouter = t.router({
         // Test the connection
         await newStore.query<Schemas>(() => {}, { limit: 1 });
         currentStore = newStore;
-        currentConfig = input;
+        currentConfig = { adapter: "pg", ...pgConfig };
         return { ok: true as const, config: { ...input, password: "***" } };
       } catch (err) {
         currentStore = null;
@@ -1080,6 +1111,10 @@ export const inspectorRouter = t.router({
     .input(z.object({ csv: z.string() }))
     .mutation(async ({ input }) => {
       if (!currentConfig) throw new Error("Not connected to a store");
+      if (currentConfig.adapter !== "pg")
+        throw new Error(
+          "Restore currently requires a PG-backed inspector connection"
+        );
       const fqt = `"${currentConfig.schema}"."${currentConfig.table}"`;
       const fqs = `"${currentConfig.schema}"."${currentConfig.table}_streams"`;
 
@@ -1110,7 +1145,7 @@ export const inspectorRouter = t.router({
       });
 
       // Drop existing data and re-seed
-      const client = await getRawClient();
+      const client = await getRawPgClient();
       try {
         await client.query("BEGIN");
 


### PR DESCRIPTION
Closes #780.

First slice of the ACT-1120 saga (#790). The inspector router already runs almost entirely against the `Store` interface — every read procedure (`query`, `stats`, `eventNames`, `streams`, `streamStats`, `schemaEvolution`, `streamsForEvent`, `streamMeta`, `drainStatus`, `backup`, `prioritize`) flows through `getStore()` and only touches the port. The PG-specific surface was concentrated in three spots: `connect`, the `getRawClient` helper, and `restore`. This change introduces a discriminated `AdapterConfig` union now — with the `sqlite` variant reserved as type-only — so subsequent slices (#781 discovery, #782 SQLite connect, #786 restore-on-port) land as additive changes against a stable shape rather than churning the declaration twice.

Behavior is identical: only `pg` is reachable, and the `PostgresStore` constructor receives bit-for-bit the same input it did before.

## Inspector router

- `currentConfig` becomes `AdapterConfig | null` — a `PgConfig | SqliteConfig` union keyed by `adapter`. The `sqlite` member has no callers yet; it exists so #782 doesn't reshape this declaration when it wires `SqliteStore` into `connect`.
- `getRawClient` → `getRawPgClient`, with a discriminator guard that throws on any non-PG adapter. The guard is a noop today but prevents #782 from accidentally falling into raw `pg.Client` construction against a SQLite-backed config.
- `connect` wraps the destructured input (`pgConfig`, minus `ssl`) with `{ adapter: "pg", ...pgConfig }`. Using `pgConfig` instead of `input` avoids dragging the `ssl: boolean` field into the union (it's a connection-only flag and not part of the persisted config shape).
- `restore` narrows on the discriminator before reading `.schema`/`.table`. Stays PG-only until #786 rewrites it onto `Store.restore`.

## Docs landing page

- Hero badge `v0.x` → `v1.x` on `docs/src/pages/index.tsx` — picked up in the same PR because it was the only visible "you're using a 0.x project" cue left and didn't earn a separate PR.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1743 passed / 1743 (112 files)
- [x] Coverage: 100% statements / 100% branches / 100% functions / 100% lines
- [x] `pnpm lint` — 0 errors (23 pre-existing warnings, none introduced)
- [x] `pnpm build` — all packages built
- [x] Doc audit — no stale references to renamed/removed identifiers (`getRawClient` grep returns 0 across `docs/docs`, `book`, `CLAUDE.md`, READMEs)
- [ ] Manual smoke: connect inspector to a local PG store, exercise read views — gated on CI
- [ ] Review

## Stability charter impact

**No charter-covered surface touched.** `git diff master --stat` on `libs/act/src/builders/`, `libs/act/src/act.ts`, `libs/act/src/types/ports.ts`, `libs/act/src/types/index.ts`, `libs/act/src/ports.ts` is empty. The change lives entirely in `packages/inspector` and a docs page.

## Follow-ups

Tracked under the saga master #790:

- #795 — ACT-1131: bootstrap inspector unit test infrastructure (soft-gates #781/#782/#787/#788)
- #781 — ACT-1122: adapter-pluggable discovery (PG port scan + SQLite file scan factory)
- #782 — ACT-1123: add SQLite adapter to the inspector
- #786 — ACT-1127: rewrite inspector restore onto `Store.restore` — at which point `getRawPgClient` and the PG-only `restore` guard go away

No book note for this slice — refactor with no rejected designs or new primitives. The saga's substantive narrative lands with #783 (`Store.restore` port method) and the wrap-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>