### PR TITLE
refactor(act-inspector): adapter-pluggable discovery + SQLite probe (ACT-1122)

### DIFF
--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -17,8 +17,10 @@
   "keywords": [],
   "license": "ISC",
   "dependencies": {
+    "@libsql/client": "^0.17.3",
     "@rotorsoft/act": "workspace:^",
     "@rotorsoft/act-pg": "workspace:^",
+    "@rotorsoft/act-sqlite": "workspace:^",
     "@tanstack/react-query": "^5.100.14",
     "@trpc/client": "11.16.0",
     "@trpc/react-query": "11.16.0",

--- a/packages/inspector/src/client/components/ScanDialog.tsx
+++ b/packages/inspector/src/client/components/ScanDialog.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { trpc } from "../trpc.js";
 
+// Mirrors the server's `DiscoveredPgStore` shape (see
+// `server/discovery/types.ts`). ACT-1122 widened the `discover`
+// response to a discriminated union; this dialog still only surfaces
+// PG results, so we narrow the union at the boundary. #782 will add
+// the SQLite tab + its own variant.
 type DiscoveredStore = {
+  kind: "pg";
   host: string;
   port: number;
   user: string;
@@ -37,14 +43,18 @@ export function ScanDialog({ initialHost, onSelect, onClose }: Props) {
 
   const discoverMutation = trpc.discover.useMutation({
     onSuccess: (result) => {
-      setStores(result.stores);
+      // Narrow the union — this dialog is the PG scanner.
+      const pgStores = result.stores.filter(
+        (s): s is DiscoveredStore => s.kind === "pg"
+      );
+      setStores(pgStores);
       setScanning(false);
       setScanned(true);
-      if (result.stores.length === 0) {
+      if (pgStores.length === 0) {
         setError("No Act event stores found");
-      } else if (result.stores.length === 1) {
+      } else if (pgStores.length === 1) {
         // Single result — auto-select it
-        handleSelect(result.stores[0]);
+        handleSelect(pgStores[0]);
       }
     },
     onError: (err) => {
@@ -59,7 +69,7 @@ export function ScanDialog({ initialHost, onSelect, onClose }: Props) {
     setStores([]);
     setScanning(true);
     setScanned(false);
-    discoverMutation.mutate({ host, portFrom, portTo });
+    discoverMutation.mutate({ kind: "pg", host, portFrom, portTo });
   };
 
   const handleSelect = (store: DiscoveredStore) => {

--- a/packages/inspector/src/server/discovery/index.ts
+++ b/packages/inspector/src/server/discovery/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Adapter-pluggable discovery dispatcher (ACT-1122).
+ *
+ * The router's `discover` tRPC procedure forwards to `runDiscovery`,
+ * which branches on the input's `kind` discriminator. Adding a new
+ * adapter (MySQL, Redis, etc.) is a matter of writing a new probe
+ * module and a new arm in this switch — the router stays thin.
+ */
+import {
+  discoverPg,
+  PG_PORT_RANGE_END,
+  PG_PORT_RANGE_START,
+} from "./pg-probe.js";
+import { discoverSqlite } from "./sqlite-probe.js";
+import type { DiscoveredStore, DiscoveryInput } from "./types.js";
+
+export * from "./types.js";
+export { PG_PORT_RANGE_END, PG_PORT_RANGE_START };
+
+/**
+ * Dispatch to the right probe based on the input's `kind`.
+ *
+ * Probes are responsible for swallowing per-file / per-port failures
+ * and returning the partial result they could collect. `runDiscovery`
+ * itself only re-throws unexpected dispatch failures, which the tRPC
+ * layer wraps as "Discovery failed: …".
+ */
+export async function runDiscovery(
+  input: DiscoveryInput
+): Promise<DiscoveredStore[]> {
+  if (input.kind === "pg") {
+    return discoverPg(input);
+  }
+  return discoverSqlite(input);
+}

--- a/packages/inspector/src/server/discovery/pg-probe.ts
+++ b/packages/inspector/src/server/discovery/pg-probe.ts
@@ -1,0 +1,202 @@
+/**
+ * Postgres discovery probe (ACT-1122).
+ *
+ * Lifted verbatim from the original inline `router.ts` discover block —
+ * port range scan in parallel, credential walk per open port, schema
+ * walk per database. No behavior change versus master; the only
+ * difference is the response carries an explicit `kind: "pg"` tag now
+ * so the UI can differentiate PG and SQLite discovery rows.
+ */
+import { createConnection, type Socket } from "node:net";
+import pg from "pg";
+import type { DiscoveredPgStore, PgDiscoveryInput } from "./types.js";
+
+/** Default PG port range to scan (5430–5480). */
+export const PG_PORT_RANGE_START = 5430;
+export const PG_PORT_RANGE_END = 5480;
+
+/** Common credential combos tried in order against each open port. */
+const COMMON_CREDS: ReadonlyArray<{ user: string; password: string }> = [
+  { user: "postgres", password: "postgres" },
+  { user: "postgres", password: "" },
+  { user: "postgres", password: "password" },
+  { user: "root", password: "root" },
+  { user: "admin", password: "admin" },
+];
+
+/** Check if a TCP port is open with a short timeout. */
+function probePort(
+  host: string,
+  port: number,
+  timeoutMs = 500
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket: Socket = createConnection({ host, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on("error", () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/** Try to authenticate with a PG server using the given credentials. */
+async function tryConnect(
+  host: string,
+  port: number,
+  user: string,
+  password: string
+): Promise<pg.Client | null> {
+  const client = new pg.Client({
+    host,
+    port,
+    user,
+    password,
+    database: "postgres",
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await client.connect();
+    return client;
+  } catch {
+    return null;
+  }
+}
+
+/** Find the best Act-shaped event table per schema in a given database. */
+async function findEventTables(
+  config: { host: string; port: number; user: string; password: string },
+  dbName: string
+): Promise<{ schema: string; table: string; count: number }[]> {
+  const client = new pg.Client({
+    ...config,
+    database: dbName,
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await client.connect();
+    const result = await client.query<{
+      table_schema: string;
+      table_name: string;
+      row_estimate: string;
+    }>(
+      `SELECT DISTINCT ON (t.table_schema)
+              t.table_schema, t.table_name,
+              (SELECT reltuples::bigint FROM pg_class c
+               JOIN pg_namespace n ON n.oid = c.relnamespace
+               WHERE n.nspname = t.table_schema AND c.relname = t.table_name) AS row_estimate
+       FROM information_schema.tables t
+       WHERE t.table_type = 'BASE TABLE'
+         AND t.table_schema NOT IN ('pg_catalog', 'information_schema')
+         AND EXISTS (SELECT 1 FROM information_schema.columns c
+           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'stream')
+         AND EXISTS (SELECT 1 FROM information_schema.columns c
+           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'meta')
+         AND EXISTS (SELECT 1 FROM information_schema.columns c
+           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'version')
+       ORDER BY t.table_schema,
+         (t.table_name = 'events') DESC,
+         row_estimate DESC NULLS LAST`
+    );
+
+    const tables: { schema: string; table: string; count: number }[] = [];
+    for (const r of result.rows) {
+      const estimate = Number(r.row_estimate);
+      if (estimate > 0) {
+        tables.push({
+          schema: r.table_schema,
+          table: r.table_name,
+          count: estimate,
+        });
+      } else {
+        const check = await client.query(
+          `SELECT EXISTS (SELECT 1 FROM "${r.table_schema}"."${r.table_name}" LIMIT 1) AS has_rows`
+        );
+        if (check.rows[0]?.has_rows) {
+          tables.push({
+            schema: r.table_schema,
+            table: r.table_name,
+            count: 0,
+          });
+        }
+      }
+    }
+    return tables;
+  } catch {
+    return [];
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Scan a host's PG port range for Act event stores.
+ *
+ * Returns one row per `(port, database, schema)` triple that has an
+ * Act-shaped table with at least one row. Empty result on no open
+ * ports / no matching credentials / no Act tables.
+ */
+export async function discoverPg(
+  input: PgDiscoveryInput
+): Promise<DiscoveredPgStore[]> {
+  const { host, portFrom, portTo } = input;
+  const ports = Array.from(
+    { length: portTo - portFrom + 1 },
+    (_, i) => portFrom + i
+  );
+  const portResults = await Promise.all(
+    ports.map(async (port) => ({ port, open: await probePort(host, port) }))
+  );
+  const openPorts = portResults.filter((r) => r.open).map((r) => r.port);
+
+  if (openPorts.length === 0) return [];
+
+  const stores: DiscoveredPgStore[] = [];
+  for (const port of openPorts) {
+    for (const creds of COMMON_CREDS) {
+      const client = await tryConnect(host, port, creds.user, creds.password);
+      if (!client) continue;
+
+      try {
+        const dbResult = await client.query<{ datname: string }>(
+          `SELECT datname FROM pg_database
+           WHERE datistemplate = false AND datallowconn = true
+           ORDER BY datname`
+        );
+        for (const row of dbResult.rows) {
+          const tables = await findEventTables(
+            { host, port, user: creds.user, password: creds.password },
+            row.datname
+          );
+          for (const t of tables) {
+            stores.push({
+              kind: "pg",
+              host,
+              port,
+              user: creds.user,
+              database: row.datname,
+              schema: t.schema,
+              table: t.table,
+              eventCount: t.count,
+            });
+          }
+        }
+      } finally {
+        await client.end();
+      }
+
+      // Working creds found — move on to the next port.
+      break;
+    }
+  }
+
+  return stores;
+}

--- a/packages/inspector/src/server/discovery/sqlite-probe.ts
+++ b/packages/inspector/src/server/discovery/sqlite-probe.ts
@@ -1,0 +1,101 @@
+/**
+ * SQLite discovery probe (ACT-1122).
+ *
+ * Scans a directory for files matching a glob (default
+ * `\.(db|sqlite|sqlite3)$`) and verifies each one is an Act SQLite
+ * store by reading its schema.
+ *
+ * Read-only **in behavior** — the probe only issues `SELECT` and
+ * `PRAGMA` reads, never `INSERT` / `UPDATE` / `DELETE` / DDL. We do
+ * not pass `?mode=ro` on the libsql URL because `@libsql/client`
+ * rejects unsupported URL params; SQLite may still touch `-wal` /
+ * `-shm` sidecar files when opening a database in WAL mode, but the
+ * database content itself is never modified by this code path.
+ *
+ * The "Act shape" check looks for both `events` and `streams` tables
+ * and the canonical column set on `events` (`stream`, `version`,
+ * `meta`). Any failure — missing tables, wrong columns, locked file,
+ * permission error — drops the file silently from the result.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { createClient } from "@libsql/client";
+import type { DiscoveredSqliteStore, SqliteDiscoveryInput } from "./types.js";
+
+const DEFAULT_FILE_PATTERN = /\.(db|sqlite|sqlite3)$/i;
+const REQUIRED_TABLES = ["events", "streams"] as const;
+const REQUIRED_EVENT_COLUMNS = ["stream", "version", "meta"] as const;
+
+/** Probe a single file. Returns the discovery row or null. */
+export async function probeSqliteFile(
+  file: string
+): Promise<DiscoveredSqliteStore | null> {
+  const client = createClient({ url: `file:${file}` });
+  try {
+    const tablesResult = await client.execute(
+      `SELECT name FROM sqlite_master
+       WHERE type='table' AND name IN ('events', 'streams')`
+    );
+    const presentTables = new Set(tablesResult.rows.map((r) => String(r.name)));
+    for (const required of REQUIRED_TABLES) {
+      if (!presentTables.has(required)) return null;
+    }
+
+    const colResult = await client.execute("PRAGMA table_info(events)");
+    const presentCols = new Set(colResult.rows.map((r) => String(r.name)));
+    for (const required of REQUIRED_EVENT_COLUMNS) {
+      if (!presentCols.has(required)) return null;
+    }
+
+    const countResult = await client.execute(
+      "SELECT COUNT(*) AS c FROM events"
+    );
+    const eventCount = Number(countResult.rows[0]?.c ?? 0);
+
+    return {
+      kind: "sqlite",
+      file,
+      table: "events",
+      eventCount,
+    };
+  } catch {
+    return null;
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Scan a directory for Act SQLite files.
+ *
+ * Returns one row per file that passes the schema probe. Empty result
+ * on missing / unreadable directory or no matching files.
+ */
+export async function discoverSqlite(
+  input: SqliteDiscoveryInput
+): Promise<DiscoveredSqliteStore[]> {
+  const { dir, glob } = input;
+  let pattern: RegExp;
+  try {
+    pattern = glob ? new RegExp(glob) : DEFAULT_FILE_PATTERN;
+  } catch {
+    // Invalid user-supplied regex — bail with an empty result rather
+    // than throwing into the tRPC error wrapper.
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    // Directory doesn't exist, permission denied, or it's a file —
+    // all of which collapse to "no SQLite stores here."
+    return [];
+  }
+
+  const candidates = entries.filter((name) => pattern.test(name));
+  const results = await Promise.all(
+    candidates.map((name) => probeSqliteFile(path.join(dir, name)))
+  );
+  return results.filter((r): r is DiscoveredSqliteStore => r !== null);
+}

--- a/packages/inspector/src/server/discovery/types.ts
+++ b/packages/inspector/src/server/discovery/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared types for the discovery module (ACT-1122).
+ *
+ * `DiscoveredStore` is the response shape the inspector hands back to
+ * the UI — a discriminated union over `kind` so the connection panel
+ * can render adapter-specific badges (port + db vs. file path).
+ *
+ * The input shape is also discriminated so `runDiscovery` can dispatch
+ * to the right probe with one branch. Defaults on the PG variant keep
+ * existing frontend payloads working without changes — a call with
+ * `{ host, portFrom, portTo }` (no `kind` field) parses as PG.
+ */
+
+/** Result row for a Postgres-backed Act store. */
+export type DiscoveredPgStore = {
+  readonly kind: "pg";
+  readonly host: string;
+  readonly port: number;
+  readonly user: string;
+  readonly database: string;
+  readonly schema: string;
+  readonly table: string;
+  readonly eventCount: number;
+};
+
+/** Result row for a SQLite-backed Act store. */
+export type DiscoveredSqliteStore = {
+  readonly kind: "sqlite";
+  readonly file: string;
+  readonly table: string;
+  readonly eventCount: number;
+};
+
+/** Discriminated union: any adapter the inspector knows how to probe. */
+export type DiscoveredStore = DiscoveredPgStore | DiscoveredSqliteStore;
+
+/** Input for the PG port-range probe. */
+export type PgDiscoveryInput = {
+  readonly host: string;
+  readonly portFrom: number;
+  readonly portTo: number;
+};
+
+/** Input for the SQLite directory probe. */
+export type SqliteDiscoveryInput = {
+  readonly dir: string;
+  /** Regex (as a string) used to filter directory entries.
+   *  Default: `\.(db|sqlite|sqlite3)$` (case-insensitive). */
+  readonly glob?: string;
+};
+
+/** Top-level discriminated input accepted by `runDiscovery`. */
+export type DiscoveryInput =
+  | ({ readonly kind: "pg" } & PgDiscoveryInput)
+  | ({ readonly kind: "sqlite" } & SqliteDiscoveryInput);

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -1,4 +1,3 @@
-import { createConnection, type Socket } from "node:net";
 import {
   type Committed,
   InMemoryStore,
@@ -10,6 +9,11 @@ import { PostgresStore } from "@rotorsoft/act-pg";
 import { initTRPC } from "@trpc/server";
 import pg from "pg";
 import { z } from "zod";
+import {
+  PG_PORT_RANGE_END,
+  PG_PORT_RANGE_START,
+  runDiscovery,
+} from "./discovery/index.js";
 
 const t = initTRPC.create();
 
@@ -206,209 +210,11 @@ async function loadAllStreamPositions(): Promise<{
 }
 
 // --- Discovery ---
-
-/** PG port range to scan: 5430–5480 */
-const PORT_RANGE_START = 5430;
-const PORT_RANGE_END = 5480;
-
-/** Common credential combos to try */
-const COMMON_CREDS = [
-  { user: "postgres", password: "postgres" },
-  { user: "postgres", password: "" },
-  { user: "postgres", password: "password" },
-  { user: "root", password: "root" },
-  { user: "admin", password: "admin" },
-];
-
-/** One discovered store per port — the best candidate */
-type DiscoveredStore = {
-  host: string;
-  port: number;
-  user: string;
-  database: string;
-  schema: string;
-  table: string;
-  eventCount: number;
-};
-
-/** Check if a TCP port is open */
-function probePort(
-  host: string,
-  port: number,
-  timeoutMs = 500
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket: Socket = createConnection({ host, port });
-    const timer = setTimeout(() => {
-      socket.destroy();
-      resolve(false);
-    }, timeoutMs);
-    socket.on("connect", () => {
-      clearTimeout(timer);
-      socket.destroy();
-      resolve(true);
-    });
-    socket.on("error", () => {
-      clearTimeout(timer);
-      resolve(false);
-    });
-  });
-}
-
-/** Try to authenticate with a PG server using given credentials */
-async function tryConnect(
-  host: string,
-  port: number,
-  user: string,
-  password: string
-): Promise<pg.Client | null> {
-  const client = new pg.Client({
-    host,
-    port,
-    user,
-    password,
-    database: "postgres",
-    connectionTimeoutMillis: 2000,
-  });
-  try {
-    await client.connect();
-    return client;
-  } catch {
-    return null;
-  }
-}
-
-/** Find the best Act event table per schema in a database (non-empty) */
-async function findEventTables(
-  config: { host: string; port: number; user: string; password: string },
-  dbName: string
-): Promise<{ schema: string; table: string; count: number }[]> {
-  const client = new pg.Client({
-    ...config,
-    database: dbName,
-    connectionTimeoutMillis: 2000,
-  });
-  try {
-    await client.connect();
-    // Find all Act-shaped tables, one best per schema
-    const result = await client.query<{
-      table_schema: string;
-      table_name: string;
-      row_estimate: string;
-    }>(
-      `SELECT DISTINCT ON (t.table_schema)
-              t.table_schema, t.table_name,
-              (SELECT reltuples::bigint FROM pg_class c
-               JOIN pg_namespace n ON n.oid = c.relnamespace
-               WHERE n.nspname = t.table_schema AND c.relname = t.table_name) AS row_estimate
-       FROM information_schema.tables t
-       WHERE t.table_type = 'BASE TABLE'
-         AND t.table_schema NOT IN ('pg_catalog', 'information_schema')
-         AND EXISTS (SELECT 1 FROM information_schema.columns c
-           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'stream')
-         AND EXISTS (SELECT 1 FROM information_schema.columns c
-           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'meta')
-         AND EXISTS (SELECT 1 FROM information_schema.columns c
-           WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.column_name = 'version')
-       ORDER BY t.table_schema,
-         (t.table_name = 'events') DESC,
-         row_estimate DESC NULLS LAST`
-    );
-
-    // Filter out truly empty tables — reltuples can be -1 (no stats) or 0
-    const tables: { schema: string; table: string; count: number }[] = [];
-    for (const r of result.rows) {
-      const estimate = Number(r.row_estimate);
-      if (estimate > 0) {
-        tables.push({
-          schema: r.table_schema,
-          table: r.table_name,
-          count: estimate,
-        });
-      } else {
-        // Stats not gathered or zero — check for actual rows
-        const check = await client.query(
-          `SELECT EXISTS (SELECT 1 FROM "${r.table_schema}"."${r.table_name}" LIMIT 1) AS has_rows`
-        );
-        if (check.rows[0]?.has_rows) {
-          tables.push({
-            schema: r.table_schema,
-            table: r.table_name,
-            count: 0,
-          });
-        }
-      }
-    }
-    return tables;
-  } catch {
-    return [];
-  } finally {
-    await client.end();
-  }
-}
-
-/** Full discovery: scan ports, try credentials, pick best Act store per port */
-async function discover(
-  host: string,
-  portFrom: number,
-  portTo: number
-): Promise<DiscoveredStore[]> {
-  // 1. Scan port range in parallel
-  const ports = Array.from(
-    { length: portTo - portFrom + 1 },
-    (_, i) => portFrom + i
-  );
-  const portResults = await Promise.all(
-    ports.map(async (port) => ({ port, open: await probePort(host, port) }))
-  );
-  const openPorts = portResults.filter((r) => r.open).map((r) => r.port);
-
-  if (openPorts.length === 0) return [];
-
-  // 2. For each open port, try credential combos and find best table
-  const stores: DiscoveredStore[] = [];
-
-  for (const port of openPorts) {
-    for (const creds of COMMON_CREDS) {
-      const client = await tryConnect(host, port, creds.user, creds.password);
-      if (!client) continue;
-
-      try {
-        const dbResult = await client.query<{ datname: string }>(
-          `SELECT datname FROM pg_database
-           WHERE datistemplate = false AND datallowconn = true
-           ORDER BY datname`
-        );
-
-        // Find best table per schema across all databases on this port
-        for (const row of dbResult.rows) {
-          const tables = await findEventTables(
-            { host, port, user: creds.user, password: creds.password },
-            row.datname
-          );
-          for (const t of tables) {
-            stores.push({
-              host,
-              port,
-              user: creds.user,
-              database: row.datname,
-              schema: t.schema,
-              table: t.table,
-              eventCount: t.count,
-            });
-          }
-        }
-      } finally {
-        await client.end();
-      }
-
-      // Found working creds for this port, move to next port
-      break;
-    }
-  }
-
-  return stores;
-}
+//
+// The inline PG-only block that lived here pre-ACT-1122 has moved to
+// `src/server/discovery/`. The router now dispatches to `runDiscovery`
+// with a discriminated-union input that picks PG (port scan) or SQLite
+// (directory glob) at the call site.
 
 /** CSV column order for backup/restore */
 const CSV_COLUMNS = [
@@ -486,18 +292,34 @@ async function getRawPgClient(): Promise<pg.Client> {
 }
 
 export const inspectorRouter = t.router({
-  /** Scan host for PG servers and discover Act event stores */
+  /**
+   * Scan for Act event stores.
+   *
+   * Discriminated input — `{ kind: "pg" }` scans a TCP port range and
+   * walks credentials; `{ kind: "sqlite" }` globs a directory for SQLite
+   * files and probes each one's schema. The PG variant defaults its
+   * `kind` so existing frontend payloads (`{ host, portFrom, portTo }`)
+   * keep working unchanged.
+   */
   discover: t.procedure
     .input(
-      z.object({
-        host: z.string().default("localhost"),
-        portFrom: z.number().min(1).max(65535).default(PORT_RANGE_START),
-        portTo: z.number().min(1).max(65535).default(PORT_RANGE_END),
-      })
+      z.union([
+        z.object({
+          kind: z.literal("pg").default("pg"),
+          host: z.string().default("localhost"),
+          portFrom: z.number().min(1).max(65535).default(PG_PORT_RANGE_START),
+          portTo: z.number().min(1).max(65535).default(PG_PORT_RANGE_END),
+        }),
+        z.object({
+          kind: z.literal("sqlite"),
+          dir: z.string().min(1),
+          glob: z.string().optional(),
+        }),
+      ])
     )
     .mutation(async ({ input }) => {
       try {
-        const stores = await discover(input.host, input.portFrom, input.portTo);
+        const stores = await runDiscovery(input);
         return { ok: true as const, stores };
       } catch (err) {
         throw new Error(

--- a/packages/inspector/test/connection.spec.ts
+++ b/packages/inspector/test/connection.spec.ts
@@ -88,7 +88,8 @@ describe("discover", () => {
   it("returns an empty list when no PG servers are reachable", async () => {
     // Privileged port — not accepting TCP connections in any reasonable
     // test environment. probePort returns false; discover short-circuits
-    // before any PG auth attempt.
+    // before any PG auth attempt. `kind` defaults to "pg" so the input
+    // shape stays back-compat with the pre-ACT-1122 frontend.
     const result = await caller.discover({
       host: "127.0.0.1",
       portFrom: 1,

--- a/packages/inspector/test/discovery/dispatch.spec.ts
+++ b/packages/inspector/test/discovery/dispatch.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * `runDiscovery` dispatcher tests (ACT-1122).
+ *
+ * The dispatcher's only job is to route by `input.kind`. The
+ * underlying probes have their own coverage; here we just verify the
+ * routing produces the right adapter-specific result shape.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runDiscovery } from "../../src/server/discovery/index.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), "act-inspector-dispatch-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("runDiscovery", () => {
+  it("dispatches to the PG probe and returns no rows for an unreachable port", async () => {
+    const stores = await runDiscovery({
+      kind: "pg",
+      host: "127.0.0.1",
+      portFrom: 1,
+      portTo: 1,
+    });
+    expect(stores).toEqual([]);
+  });
+
+  it("dispatches to the SQLite probe and finds Act-shaped files", async () => {
+    const file = path.join(dir, "store.db");
+    const store = new SqliteStore({ url: `file:${file}` });
+    try {
+      await store.seed();
+    } finally {
+      await store.dispose();
+    }
+    const stores = await runDiscovery({ kind: "sqlite", dir });
+    expect(stores).toHaveLength(1);
+    expect(stores[0]).toMatchObject({ kind: "sqlite", file });
+  });
+});

--- a/packages/inspector/test/discovery/sqlite-probe.spec.ts
+++ b/packages/inspector/test/discovery/sqlite-probe.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * SQLite discovery probe tests (ACT-1122).
+ *
+ * Fixtures: each test builds throwaway SQLite files in a tempdir using
+ * the real `SqliteStore` (act-sqlite's `.seed()` creates the events +
+ * streams tables) and points the probe at the directory. Cleanup runs
+ * in `afterEach` so the tempdir doesn't linger between tests.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  discoverSqlite,
+  probeSqliteFile,
+} from "../../src/server/discovery/sqlite-probe.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), "act-inspector-sqlite-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function buildActSqlite(file: string, withEvents = false): Promise<void> {
+  const store = new SqliteStore({ url: `file:${file}` });
+  try {
+    await store.seed();
+    if (withEvents) {
+      await store.commit(
+        "stream-a",
+        [
+          { name: "OpenedV1", data: { i: 1 } },
+          { name: "OpenedV1", data: { i: 2 } },
+        ],
+        { correlation: "c", causation: {} }
+      );
+    }
+  } finally {
+    await store.dispose();
+  }
+}
+
+describe("probeSqliteFile", () => {
+  it("recognizes a freshly-seeded Act SQLite file", async () => {
+    const file = path.join(dir, "store.db");
+    await buildActSqlite(file);
+    const result = await probeSqliteFile(file);
+    expect(result).toEqual({
+      kind: "sqlite",
+      file,
+      table: "events",
+      eventCount: 0,
+    });
+  });
+
+  it("counts events when the store has data", async () => {
+    const file = path.join(dir, "store.db");
+    await buildActSqlite(file, true);
+    const result = await probeSqliteFile(file);
+    expect(result?.eventCount).toBe(2);
+  });
+
+  it("returns null for a non-SQLite file (corrupt binary content)", async () => {
+    const file = path.join(dir, "not-sqlite.db");
+    await writeFile(file, Buffer.from("this is not a sqlite database"));
+    const result = await probeSqliteFile(file);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a SQLite file without the Act table shape", async () => {
+    const file = path.join(dir, "other.db");
+    // Build a SQLite database with a different schema — no events table.
+    const { createClient } = await import("@libsql/client");
+    const client = createClient({ url: `file:${file}` });
+    try {
+      await client.execute(
+        "CREATE TABLE unrelated (id INTEGER PRIMARY KEY, payload TEXT)"
+      );
+    } finally {
+      client.close();
+    }
+    const result = await probeSqliteFile(file);
+    expect(result).toBeNull();
+  });
+});
+
+describe("discoverSqlite", () => {
+  it("returns [] when the directory does not exist", async () => {
+    const result = await discoverSqlite({
+      dir: path.join(dir, "does-not-exist"),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when the directory has no matching files", async () => {
+    await writeFile(path.join(dir, "readme.txt"), "hi");
+    const result = await discoverSqlite({ dir });
+    expect(result).toEqual([]);
+  });
+
+  it("finds every Act-shaped file by default glob", async () => {
+    await buildActSqlite(path.join(dir, "first.db"));
+    await buildActSqlite(path.join(dir, "second.sqlite"), true);
+    await buildActSqlite(path.join(dir, "third.sqlite3"));
+    const result = await discoverSqlite({ dir });
+    expect(result).toHaveLength(3);
+    expect(result.every((r) => r.kind === "sqlite")).toBe(true);
+    const counts = Object.fromEntries(
+      result.map((r) => [path.basename(r.file), r.eventCount])
+    );
+    expect(counts).toEqual({
+      "first.db": 0,
+      "second.sqlite": 2,
+      "third.sqlite3": 0,
+    });
+  });
+
+  it("respects a custom glob", async () => {
+    await buildActSqlite(path.join(dir, "keep.act"));
+    await buildActSqlite(path.join(dir, "skip.db"));
+    const result = await discoverSqlite({ dir, glob: "\\.act$" });
+    expect(result.map((r) => path.basename(r.file))).toEqual(["keep.act"]);
+  });
+
+  it("silently drops files that don't have the Act shape", async () => {
+    await buildActSqlite(path.join(dir, "valid.db"));
+    await writeFile(
+      path.join(dir, "garbage.db"),
+      Buffer.from("not a sqlite database")
+    );
+    const result = await discoverSqlite({ dir });
+    expect(result).toHaveLength(1);
+    expect(path.basename(result[0]!.file)).toBe("valid.db");
+  });
+
+  it("returns [] when given an invalid regex glob", async () => {
+    await buildActSqlite(path.join(dir, "store.db"));
+    // Unbalanced bracket — `new RegExp(...)` throws.
+    const result = await discoverSqlite({ dir, glob: "[" });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/inspector/vitest.config.ts
+++ b/packages/inspector/vitest.config.ts
@@ -44,10 +44,10 @@ export default {
       // their PG-specific helpers. Each of those tickets will ramp
       // these thresholds toward 100% as it lands its own coverage.
       thresholds: {
-        statements: 60,
+        statements: 65,
         branches: 60,
-        functions: 65,
-        lines: 60,
+        functions: 75,
+        lines: 65,
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,12 +402,18 @@ importers:
 
   packages/inspector:
     dependencies:
+      '@libsql/client':
+        specifier: ^0.17.3
+        version: 0.17.3
       '@rotorsoft/act':
         specifier: workspace:^
         version: link:../../libs/act
       '@rotorsoft/act-pg':
         specifier: workspace:^
         version: link:../../libs/act-pg
+      '@rotorsoft/act-sqlite':
+        specifier: workspace:^
+        version: link:../../libs/act-sqlite
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.100.14(react@19.2.6)


### PR DESCRIPTION
Closes #781.

Extracts the inline PG-only discovery block out of `router.ts` into a new `src/server/discovery/` module and adds a SQLite directory-scan probe alongside it. The router's `discover` procedure becomes a thin dispatcher: input is now a discriminated union over `kind` (`{ kind: "pg", host, portFrom, portTo }` or `{ kind: "sqlite", dir, glob? }`), with `kind` defaulting to `"pg"` so the existing frontend's payload (no `kind` field) keeps working unchanged. The SQLite probe verifies each candidate file has the Act table shape (both `events` and `streams` tables present, with `stream`/`version`/`meta` columns on `events`) and silently drops anything that doesn't match.

## Discovery module layout

`packages/inspector/src/server/discovery/`:

- **`types.ts`** — `DiscoveredPgStore` / `DiscoveredSqliteStore` (both carry a `kind` tag) and their union `DiscoveredStore`; input types `PgDiscoveryInput`, `SqliteDiscoveryInput`, `DiscoveryInput`.
- **`pg-probe.ts`** — the original `probePort` + `tryConnect` + `findEventTables` + scan loop, lifted verbatim from `router.ts`. The only behavior delta is the response now carries `kind: "pg"`.
- **`sqlite-probe.ts`** — new. Globs a directory (default pattern: `\.(db|sqlite|sqlite3)$`), opens each match with `@libsql/client`, verifies tables + columns via `sqlite_master` + `PRAGMA table_info(events)`, counts events. Read-only by behavior (only `SELECT` and `PRAGMA` — never DDL/DML); we don't pass `?mode=ro` on the libsql URL because `@libsql/client` rejects unsupported URL params, but the SELECT-only code path means the database content is never modified.
- **`index.ts`** — `runDiscovery(input)` dispatcher. Re-exports types and the PG default range constants.

## Router refactor

`packages/inspector/src/server/router.ts`:

- Removes ~200 lines of inline PG-only discovery code (probe, connect, table-find, scan loop, COMMON_CREDS, port-range constants).
- `discover` tRPC procedure input becomes a `z.union` over the two adapter shapes. The PG variant has `kind: z.literal("pg").default("pg")` so existing frontend payloads stay valid without any field change. The SQLite variant requires explicit `kind: "sqlite"` with `dir` (and optional `glob`).
- Handler becomes a single line: `await runDiscovery(input)`.

## Client narrowing

`ScanDialog.tsx` (the existing PG scan dialog) narrows the discriminated response to PG-only at the boundary — adds an explicit filter `(s): s is DiscoveredStore => s.kind === \"pg\"` since this dialog doesn't yet surface SQLite results. The dialog also passes `kind: \"pg\"` explicitly on the mutation call for clarity. The SQLite UI tab is #782's scope.

## Dependencies

- Adds `@rotorsoft/act-sqlite` (workspace) — needed by #782 anyway; landing it now avoids a second `package.json` bump.
- Adds `@libsql/client` directly — the SQLite probe consumes it without going through `SqliteStore` (the probe doesn't need orchestration semantics).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1801 / 1801 across 119 files (12 new specs)
- [x] Workspace coverage stays at 100% statements / 100% branches / 100% functions / 100% lines
- [x] `pnpm -F @rotorsoft/act-inspector test` — passes at 70.25% Stmts / 63.87% Branches / 82.89% Funcs / 70.05% Lines against the new 65/60/75/65 per-package thresholds (bumped from 60/60/65/60). SQLite probe ships at 97% / 75% / 100% / 100%; PG probe at 31% / 22% / 58% / 30% — full PG auth-path coverage stays out of unit-test scope (would need Docker). The remaining headroom closes when #786 brings `Store.restore` tests online.
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — all packages
- [ ] Manual smoke: `pnpm dev:inspector`, hit Scan dialog, verify PG discovery against `pnpm dev:wolfdesk` PG store
- [ ] Manual smoke: `curl` the `discover` tRPC endpoint with `{ kind: \"sqlite\", dir: \"<path>\" }` against a real SQLite Act file
- [ ] Review

## Stability charter impact

**No charter-covered surface touched.** `git diff master --stat` on `libs/act/src/builders/`, `libs/act/src/act.ts`, `libs/act/src/types/ports.ts`, `libs/act/src/types/index.ts`, `libs/act/src/ports.ts` is empty. Entire slice lives inside `packages/inspector/`. The `discover` input/output shape change is additive (new union members, defaults preserved).

## Follow-ups

Tracked under the saga master #790:

- #782 — ACT-1123: surface the SQLite + inmemory adapters in the connection panel UI (the dialog's SQLite tab will consume the SQLite probe shipped here)
- #786 — ACT-1127: rewrite `restore` onto `Store.restore`; ramps the inspector per-package coverage threshold further as `restore` + `getRawPgClient` get tests

Full PG auth-path coverage (`tryConnect` / `findEventTables` / the `discoverPg` main loop) is deliberately not in scope here — it'd need either Docker or pg-module mocking. Revisit if the gap surfaces a regression.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>