### PR TITLE
feat(act-inspector): sqlite adapter — connect branch + UI tab (ACT-1123)

### DIFF
--- a/packages/inspector/src/client/components/BackupRestore.tsx
+++ b/packages/inspector/src/client/components/BackupRestore.tsx
@@ -12,6 +12,12 @@ export function BackupRestore() {
     csv: string;
   } | null>(null);
 
+  // `restore` is PG-only until #786 ports it to `Store.restore`. The
+  // status query surfaces the adapter so the UI can gate the button
+  // instead of letting the operator click into a server error.
+  const { data: status } = trpc.status.useQuery();
+  const restoreEnabled = status?.adapter === "pg";
+
   const backupMutation = trpc.backup.useMutation({
     onSuccess(data) {
       const blob = new Blob([data.csv], { type: "text/csv" });
@@ -92,9 +98,14 @@ export function BackupRestore() {
           <Download size={14} />
         </button>
         <button
-          onClick={() => fileRef.current?.click()}
-          title="Restore events from CSV"
-          className="rounded p-1.5 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300"
+          onClick={() => restoreEnabled && fileRef.current?.click()}
+          disabled={!restoreEnabled}
+          title={
+            restoreEnabled
+              ? "Restore events from CSV"
+              : "Restore is PG-only — coming to other adapters in ACT-1127"
+          }
+          className="rounded p-1.5 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
         >
           <Upload size={14} />
         </button>

--- a/packages/inspector/src/client/components/ConnectDialog.tsx
+++ b/packages/inspector/src/client/components/ConnectDialog.tsx
@@ -2,8 +2,21 @@ import { useState } from "react";
 import { trpc } from "../trpc.js";
 import { Logo } from "./Logo.js";
 import { ScanDialog, type ScanResult } from "./ScanDialog.js";
+import {
+  SqliteScanDialog,
+  type SqliteScanResult,
+} from "./SqliteScanDialog.js";
 
-type Connection = {
+/**
+ * Connection persistence (ACT-1123).
+ *
+ * Saved connections widen to a discriminated union so SQLite entries
+ * can live alongside PG ones in the same localStorage list. Pre-1.1
+ * payloads (no `kind` field) are migrated as PG on load so existing
+ * users don't lose their bookmarks.
+ */
+type PgConnection = {
+  kind: "pg";
   name: string;
   host: string;
   port: number;
@@ -15,8 +28,18 @@ type Connection = {
   ssl: boolean;
 };
 
-const defaultConn: Connection = {
-  name: "Local",
+type SqliteConnection = {
+  kind: "sqlite";
+  name: string;
+  file: string;
+  table: string;
+};
+
+type Connection = PgConnection | SqliteConnection;
+
+const defaultPg: PgConnection = {
+  kind: "pg",
+  name: "Local PG",
   host: "localhost",
   port: 5432,
   database: "postgres",
@@ -27,22 +50,41 @@ const defaultConn: Connection = {
   ssl: false,
 };
 
+const defaultSqlite: SqliteConnection = {
+  kind: "sqlite",
+  name: "Local SQLite",
+  file: "./events.db",
+  table: "events",
+};
+
 function loadSaved(): Connection[] {
   try {
     const raw = localStorage.getItem("inspector:connections");
-    return raw ? JSON.parse(raw) : [];
+    if (!raw) return [];
+    const parsed: unknown[] = JSON.parse(raw);
+    // Migrate legacy entries (no `kind` field) — these predate ACT-1123
+    // and are always PG.
+    return parsed.map((c) => {
+      if (
+        typeof c === "object" &&
+        c !== null &&
+        "kind" in (c as Record<string, unknown>)
+      ) {
+        return c as Connection;
+      }
+      return { kind: "pg", ...(c as Omit<PgConnection, "kind">) };
+    });
   } catch {
     return [];
   }
 }
 
 function saveConnections(conns: Connection[]) {
-  // Strip passwords before persisting — user re-enters on connect
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const safe = conns.map(({ password: _pw, ...rest }) => ({
-    ...rest,
-    password: "",
-  }));
+  // Strip PG passwords before persisting — user re-enters on connect.
+  // SQLite has no password to strip.
+  const safe = conns.map((c) =>
+    c.kind === "pg" ? { ...c, password: "" } : c
+  );
   localStorage.setItem("inspector:connections", JSON.stringify(safe));
 }
 
@@ -53,11 +95,21 @@ type Props = {
 
 export function ConnectDialog({ onConnected, onClose }: Props) {
   const [saved, setSaved] = useState<Connection[]>(loadSaved);
-  const [conn, setConn] = useState<Connection>(saved[0] ?? defaultConn);
+  const initialConn = saved[0] ?? defaultPg;
+  const [conn, setConn] = useState<Connection>(initialConn);
   const [error, setError] = useState("");
   const [testing, setTesting] = useState(false);
   const [showScan, setShowScan] = useState(false);
   const [connString, setConnString] = useState("");
+
+  // The active tab follows the current `conn.kind`. Switching tabs
+  // swaps in the appropriate default (or the most recently used saved
+  // connection of that kind, if any).
+  const handleSwitchTab = (kind: Connection["kind"]) => {
+    if (conn.kind === kind) return;
+    const recent = saved.find((s) => s.kind === kind);
+    setConn(recent ?? (kind === "pg" ? defaultPg : defaultSqlite));
+  };
 
   const connectMutation = trpc.connect.useMutation({
     onSuccess: () => {
@@ -73,20 +125,33 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
     },
   });
 
-  const handleScanSelect = (result: ScanResult) => {
-    // Connection name: schema.table if descriptive, otherwise database name
+  const handlePgScanSelect = (result: ScanResult) => {
     const isDefault = result.schema === "public" && result.table === "events";
     const label = isDefault
       ? result.database
       : `${result.schema}.${result.table}`;
     setConn({
-      ...conn,
+      kind: "pg",
       name: label,
       host: result.host,
       port: result.port,
       user: result.user,
       database: result.database,
       schema: result.schema,
+      table: result.table,
+      password: conn.kind === "pg" ? conn.password : "",
+      ssl: conn.kind === "pg" ? conn.ssl : false,
+    });
+    setShowScan(false);
+  };
+
+  const handleSqliteScanSelect = (result: SqliteScanResult) => {
+    // Use the file's basename as a friendlier default name.
+    const base = result.file.split(/[/\\]/).pop() ?? result.file;
+    setConn({
+      kind: "sqlite",
+      name: base,
+      file: result.file,
       table: result.table,
     });
     setShowScan(false);
@@ -95,7 +160,16 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
   const handleConnect = () => {
     setError("");
     setTesting(true);
+    if (conn.kind === "sqlite") {
+      connectMutation.mutate({
+        adapter: "sqlite",
+        file: conn.file,
+        table: conn.table,
+      });
+      return;
+    }
     connectMutation.mutate({
+      adapter: "pg",
       host: conn.host,
       port: conn.port,
       database: conn.database,
@@ -139,6 +213,26 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
           )}
         </div>
 
+        {/* Adapter tabs */}
+        <div className="mb-4 flex gap-1 border-b border-zinc-800">
+          {([
+            ["pg", "Postgres"],
+            ["sqlite", "SQLite"],
+          ] as const).map(([kind, label]) => (
+            <button
+              key={kind}
+              onClick={() => handleSwitchTab(kind)}
+              className={`-mb-px border-b-2 px-3 py-1.5 text-xs font-medium transition ${
+                conn.kind === kind
+                  ? "border-emerald-500 text-emerald-400"
+                  : "border-transparent text-zinc-500 hover:text-zinc-300"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
         {/* Saved connections */}
         {saved.length > 0 && (
           <div className="mb-4">
@@ -150,12 +244,15 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
                 <div key={s.name} className="flex items-center gap-1">
                   <button
                     onClick={() => handleSavedSelect(s.name)}
-                    className={`rounded-md border px-3 py-1 text-xs transition ${
+                    className={`flex items-center gap-1.5 rounded-md border px-3 py-1 text-xs transition ${
                       conn.name === s.name
                         ? "border-emerald-600 bg-emerald-950 text-emerald-400"
                         : "border-zinc-700 bg-zinc-800 text-zinc-300 hover:border-zinc-600"
                     }`}
                   >
+                    <span className="rounded bg-zinc-700/60 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-zinc-400">
+                      {s.kind}
+                    </span>
                     {s.name}
                   </button>
                   <button
@@ -170,91 +267,126 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
           </div>
         )}
 
-        {/* Connection string */}
-        <div className="mb-3">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs text-zinc-400">Connection String</span>
-            <input
-              type="text"
-              value={connString}
-              onChange={(e) => {
-                setConnString(e.target.value);
-                // Parse: postgresql://user:pass@host:port/database?options
-                try {
-                  const url = new URL(e.target.value);
-                  const sslMode = url.searchParams.get("sslmode");
-                  setConn({
-                    ...conn,
-                    name: url.pathname.slice(1) || conn.name,
-                    host: url.hostname,
-                    port: Number(url.port) || 5432,
-                    database: url.pathname.slice(1) || "postgres",
-                    user: url.username || "postgres",
-                    password: decodeURIComponent(url.password || ""),
-                    schema: url.searchParams.get("schema") || "public",
-                    table: url.searchParams.get("table") || "events",
-                    ssl:
-                      sslMode === "require" ||
-                      sslMode === "prefer" ||
-                      url.hostname.includes("neon") ||
-                      url.hostname.includes("supabase"),
-                  });
-                } catch {
-                  // Not a valid URL yet, ignore
-                }
-              }}
-              placeholder="postgresql://user:pass@host:port/database"
-              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
-            />
-          </label>
-        </div>
+        {/* PG form */}
+        {conn.kind === "pg" && (
+          <>
+            <div className="mb-3">
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-zinc-400">Connection String</span>
+                <input
+                  type="text"
+                  value={connString}
+                  onChange={(e) => {
+                    setConnString(e.target.value);
+                    try {
+                      const url = new URL(e.target.value);
+                      const sslMode = url.searchParams.get("sslmode");
+                      setConn({
+                        kind: "pg",
+                        name: url.pathname.slice(1) || conn.name,
+                        host: url.hostname,
+                        port: Number(url.port) || 5432,
+                        database: url.pathname.slice(1) || "postgres",
+                        user: url.username || "postgres",
+                        password: decodeURIComponent(url.password || ""),
+                        schema: url.searchParams.get("schema") || "public",
+                        table: url.searchParams.get("table") || "events",
+                        ssl:
+                          sslMode === "require" ||
+                          sslMode === "prefer" ||
+                          url.hostname.includes("neon") ||
+                          url.hostname.includes("supabase"),
+                      });
+                    } catch {
+                      // Not a valid URL yet, ignore
+                    }
+                  }}
+                  placeholder="postgresql://user:pass@host:port/database"
+                  className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition placeholder:text-zinc-600 focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+                />
+              </label>
+            </div>
 
-        {/* Connection form */}
-        <div className="grid grid-cols-2 gap-3">
-          {(
-            [
-              ["Connection Name", "name", "text"],
-              ["Host", "host", "text"],
-              ["Port", "port", "number"],
-              ["Database", "database", "text"],
-              ["User", "user", "text"],
-              ["Password", "password", "password"],
-              ["Schema", "schema", "text"],
-              ["Table", "table", "text"],
-            ] as const
-          ).map(([label, key, type]) => (
-            <label key={key} className="flex flex-col gap-1">
-              <span className="text-xs text-zinc-400">{label}</span>
+            <div className="grid grid-cols-2 gap-3">
+              {(
+                [
+                  ["Connection Name", "name", "text"],
+                  ["Host", "host", "text"],
+                  ["Port", "port", "number"],
+                  ["Database", "database", "text"],
+                  ["User", "user", "text"],
+                  ["Password", "password", "password"],
+                  ["Schema", "schema", "text"],
+                  ["Table", "table", "text"],
+                ] as const
+              ).map(([label, key, type]) => (
+                <label key={key} className="flex flex-col gap-1">
+                  <span className="text-xs text-zinc-400">{label}</span>
+                  <input
+                    type={type}
+                    value={String(conn[key] ?? "")}
+                    onChange={(e) =>
+                      setConn({
+                        ...conn,
+                        [key]:
+                          type === "number"
+                            ? Number(e.target.value)
+                            : e.target.value,
+                      })
+                    }
+                    className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+                  />
+                </label>
+              ))}
+            </div>
+
+            <label className="mt-2 flex items-center gap-2">
               <input
-                type={type}
-                value={conn[key]}
-                onChange={(e) =>
-                  setConn({
-                    ...conn,
-                    [key]:
-                      type === "number"
-                        ? Number(e.target.value)
-                        : e.target.value,
-                  })
-                }
+                type="checkbox"
+                checked={conn.ssl}
+                onChange={(e) => setConn({ ...conn, ssl: e.target.checked })}
+                className="h-3.5 w-3.5 rounded border-zinc-600 bg-zinc-800 text-emerald-600"
+              />
+              <span className="text-xs text-zinc-400">
+                SSL (required for Neon, Supabase, etc.)
+              </span>
+            </label>
+          </>
+        )}
+
+        {/* SQLite form */}
+        {conn.kind === "sqlite" && (
+          <div className="flex flex-col gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-zinc-400">Connection Name</span>
+              <input
+                type="text"
+                value={conn.name}
+                onChange={(e) => setConn({ ...conn, name: e.target.value })}
                 className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
               />
             </label>
-          ))}
-        </div>
-
-        {/* SSL toggle */}
-        <label className="mt-2 flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={conn.ssl}
-            onChange={(e) => setConn({ ...conn, ssl: e.target.checked })}
-            className="h-3.5 w-3.5 rounded border-zinc-600 bg-zinc-800 text-emerald-600"
-          />
-          <span className="text-xs text-zinc-400">
-            SSL (required for Neon, Supabase, etc.)
-          </span>
-        </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-zinc-400">File path</span>
+              <input
+                type="text"
+                value={conn.file}
+                onChange={(e) => setConn({ ...conn, file: e.target.value })}
+                placeholder="/absolute/path/to/store.db"
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 font-mono text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-zinc-400">Table</span>
+              <input
+                type="text"
+                value={conn.table}
+                onChange={(e) => setConn({ ...conn, table: e.target.value })}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+              />
+            </label>
+          </div>
+        )}
 
         {error && (
           <div className="mt-3 rounded-md border border-red-900 bg-red-950 px-3 py-2 text-xs text-red-400">
@@ -290,11 +422,18 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
         </div>
       </div>
 
-      {/* Scan popup */}
-      {showScan && (
+      {/* Adapter-specific scanner */}
+      {showScan && conn.kind === "pg" && (
         <ScanDialog
           initialHost={conn.host}
-          onSelect={handleScanSelect}
+          onSelect={handlePgScanSelect}
+          onClose={() => setShowScan(false)}
+        />
+      )}
+      {showScan && conn.kind === "sqlite" && (
+        <SqliteScanDialog
+          initialDir={conn.file.replace(/[^/\\]+$/, "") || "."}
+          onSelect={handleSqliteScanSelect}
           onClose={() => setShowScan(false)}
         />
       )}

--- a/packages/inspector/src/client/components/ConnectDialog.tsx
+++ b/packages/inspector/src/client/components/ConnectDialog.tsx
@@ -79,20 +79,31 @@ function loadSaved(): Connection[] {
   }
 }
 
+type SavedPgConnection = Omit<PgConnection, "password">;
+type SavedConnection = SavedPgConnection | SqliteConnection;
+
 function saveConnections(conns: Connection[]) {
-  // Drop the PG `password` field entirely before persisting — never
-  // serialize sensitive data into localStorage. Operator re-enters on
-  // connect. The destructure-omit pattern (rather than overriding
-  // `password = ""`) is what CodeQL's `js/clear-text-storage-of-
-  // sensitive-data` rule recognizes as a real strip. SQLite has no
-  // password to strip.
-  const safe = conns.map((c) => {
-    if (c.kind === "pg") {
-      const { password: _pw, ...rest } = c;
-      return rest;
-    }
-    return c;
-  });
+  // Never touch `password` — not by spread, not by destructure-omit.
+  // Both still register as property accesses to CodeQL's taint
+  // analyzer (`js/clear-text-storage-of-sensitive-data`), which then
+  // taints the resulting `localStorage.setItem` sink. Build the saved
+  // record field by field so the password field is never read at all;
+  // the operator re-enters it on connect.
+  const safe: SavedConnection[] = conns.map((c) =>
+    c.kind === "pg"
+      ? {
+          kind: "pg",
+          name: c.name,
+          host: c.host,
+          port: c.port,
+          database: c.database,
+          user: c.user,
+          schema: c.schema,
+          table: c.table,
+          ssl: c.ssl,
+        }
+      : c
+  );
   localStorage.setItem("inspector:connections", JSON.stringify(safe));
 }
 

--- a/packages/inspector/src/client/components/ConnectDialog.tsx
+++ b/packages/inspector/src/client/components/ConnectDialog.tsx
@@ -12,8 +12,15 @@ import {
  *
  * Saved connections widen to a discriminated union so SQLite entries
  * can live alongside PG ones in the same localStorage list. Pre-1.1
- * payloads (no `kind` field) are migrated as PG on load so existing
- * users don't lose their bookmarks.
+ * payloads (no `kind` field) are migrated as PG on load.
+ *
+ * `PgConnection` deliberately does NOT carry a `password` field — the
+ * password lives in a separate `useState` slot that is never spread
+ * into the saved list and never persisted. CodeQL's
+ * `js/clear-text-storage-of-sensitive-data` rule taint-tracks any
+ * object that ever held a `password` property through `localStorage`,
+ * so structurally excluding the field from the persisted type is the
+ * only stable way to keep the rule green.
  */
 type PgConnection = {
   kind: "pg";
@@ -22,7 +29,6 @@ type PgConnection = {
   port: number;
   database: string;
   user: string;
-  password: string;
   schema: string;
   table: string;
   ssl: boolean;
@@ -44,7 +50,6 @@ const defaultPg: PgConnection = {
   port: 5432,
   database: "postgres",
   user: "postgres",
-  password: "postgres",
   schema: "public",
   table: "events",
   ssl: false,
@@ -62,49 +67,37 @@ function loadSaved(): Connection[] {
     const raw = localStorage.getItem("inspector:connections");
     if (!raw) return [];
     const parsed: unknown[] = JSON.parse(raw);
-    // Migrate legacy entries (no `kind` field) — these predate ACT-1123
-    // and are always PG.
+    // Migrate legacy entries (no `kind` field) and pre-ACT-1123
+    // payloads that may have carried `password: ""` — strip explicitly.
     return parsed.map((c) => {
-      if (
-        typeof c === "object" &&
-        c !== null &&
-        "kind" in (c as Record<string, unknown>)
-      ) {
-        return c as Connection;
+      const obj = c as Record<string, unknown>;
+      const isPg = !("kind" in obj) || obj.kind === "pg";
+      if (isPg) {
+        return {
+          kind: "pg",
+          name: String(obj.name ?? "Local"),
+          host: String(obj.host ?? "localhost"),
+          port: Number(obj.port ?? 5432),
+          database: String(obj.database ?? "postgres"),
+          user: String(obj.user ?? "postgres"),
+          schema: String(obj.schema ?? "public"),
+          table: String(obj.table ?? "events"),
+          ssl: Boolean(obj.ssl ?? false),
+        };
       }
-      return { kind: "pg", ...(c as Omit<PgConnection, "kind">) };
+      return obj as unknown as Connection;
     });
   } catch {
     return [];
   }
 }
 
-type SavedPgConnection = Omit<PgConnection, "password">;
-type SavedConnection = SavedPgConnection | SqliteConnection;
-
 function saveConnections(conns: Connection[]) {
-  // Never touch `password` — not by spread, not by destructure-omit.
-  // Both still register as property accesses to CodeQL's taint
-  // analyzer (`js/clear-text-storage-of-sensitive-data`), which then
-  // taints the resulting `localStorage.setItem` sink. Build the saved
-  // record field by field so the password field is never read at all;
-  // the operator re-enters it on connect.
-  const safe: SavedConnection[] = conns.map((c) =>
-    c.kind === "pg"
-      ? {
-          kind: "pg",
-          name: c.name,
-          host: c.host,
-          port: c.port,
-          database: c.database,
-          user: c.user,
-          schema: c.schema,
-          table: c.table,
-          ssl: c.ssl,
-        }
-      : c
-  );
-  localStorage.setItem("inspector:connections", JSON.stringify(safe));
+  // `Connection` has no `password` field by type — and never did at
+  // any point in this function's data flow. CodeQL's taint analyzer
+  // is satisfied because the storage sink can't possibly receive
+  // sensitive data.
+  localStorage.setItem("inspector:connections", JSON.stringify(conns));
 }
 
 type Props = {
@@ -116,6 +109,9 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
   const [saved, setSaved] = useState<Connection[]>(loadSaved);
   const initialConn = saved[0] ?? defaultPg;
   const [conn, setConn] = useState<Connection>(initialConn);
+  // PG password lives in its own state slot — never enters `conn`,
+  // never reaches `saveConnections`, never serialized.
+  const [pgPassword, setPgPassword] = useState("postgres");
   const [error, setError] = useState("");
   const [testing, setTesting] = useState(false);
   const [showScan, setShowScan] = useState(false);
@@ -123,11 +119,12 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
 
   // The active tab follows the current `conn.kind`. Switching tabs
   // swaps in the appropriate default (or the most recently used saved
-  // connection of that kind, if any).
+  // connection of that kind, if any) and clears the password slot.
   const handleSwitchTab = (kind: Connection["kind"]) => {
     if (conn.kind === kind) return;
     const recent = saved.find((s) => s.kind === kind);
     setConn(recent ?? (kind === "pg" ? defaultPg : defaultSqlite));
+    if (kind !== "pg") setPgPassword("");
   };
 
   const connectMutation = trpc.connect.useMutation({
@@ -158,14 +155,12 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
       database: result.database,
       schema: result.schema,
       table: result.table,
-      password: conn.kind === "pg" ? conn.password : "",
       ssl: conn.kind === "pg" ? conn.ssl : false,
     });
     setShowScan(false);
   };
 
   const handleSqliteScanSelect = (result: SqliteScanResult) => {
-    // Use the file's basename as a friendlier default name.
     const base = result.file.split(/[/\\]/).pop() ?? result.file;
     setConn({
       kind: "sqlite",
@@ -193,7 +188,7 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
       port: conn.port,
       database: conn.database,
       user: conn.user,
-      password: conn.password,
+      password: pgPassword,
       schema: conn.schema,
       table: conn.table,
       ssl: conn.ssl,
@@ -202,7 +197,12 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
 
   const handleSavedSelect = (name: string) => {
     const found = saved.find((s) => s.name === name);
-    if (found) setConn(found);
+    if (found) {
+      setConn(found);
+      // Saved connections never carry a password — clear the slot so
+      // the operator re-enters explicitly.
+      if (found.kind === "pg") setPgPassword("");
+    }
   };
 
   const handleDelete = (name: string) => {
@@ -234,10 +234,12 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
 
         {/* Adapter tabs */}
         <div className="mb-4 flex gap-1 border-b border-zinc-800">
-          {([
-            ["pg", "Postgres"],
-            ["sqlite", "SQLite"],
-          ] as const).map(([kind, label]) => (
+          {(
+            [
+              ["pg", "Postgres"],
+              ["sqlite", "SQLite"],
+            ] as const
+          ).map(([kind, label]) => (
             <button
               key={kind}
               onClick={() => handleSwitchTab(kind)}
@@ -307,7 +309,6 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
                         port: Number(url.port) || 5432,
                         database: url.pathname.slice(1) || "postgres",
                         user: url.username || "postgres",
-                        password: decodeURIComponent(url.password || ""),
                         schema: url.searchParams.get("schema") || "public",
                         table: url.searchParams.get("table") || "events",
                         ssl:
@@ -316,6 +317,9 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
                           url.hostname.includes("neon") ||
                           url.hostname.includes("supabase"),
                       });
+                      if (url.password) {
+                        setPgPassword(decodeURIComponent(url.password));
+                      }
                     } catch {
                       // Not a valid URL yet, ignore
                     }
@@ -334,7 +338,6 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
                   ["Port", "port", "number"],
                   ["Database", "database", "text"],
                   ["User", "user", "text"],
-                  ["Password", "password", "password"],
                   ["Schema", "schema", "text"],
                   ["Table", "table", "text"],
                 ] as const
@@ -357,6 +360,15 @@ export function ConnectDialog({ onConnected, onClose }: Props) {
                   />
                 </label>
               ))}
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-zinc-400">Password</span>
+                <input
+                  type="password"
+                  value={pgPassword}
+                  onChange={(e) => setPgPassword(e.target.value)}
+                  className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+                />
+              </label>
             </div>
 
             <label className="mt-2 flex items-center gap-2">

--- a/packages/inspector/src/client/components/ConnectDialog.tsx
+++ b/packages/inspector/src/client/components/ConnectDialog.tsx
@@ -80,11 +80,19 @@ function loadSaved(): Connection[] {
 }
 
 function saveConnections(conns: Connection[]) {
-  // Strip PG passwords before persisting — user re-enters on connect.
-  // SQLite has no password to strip.
-  const safe = conns.map((c) =>
-    c.kind === "pg" ? { ...c, password: "" } : c
-  );
+  // Drop the PG `password` field entirely before persisting — never
+  // serialize sensitive data into localStorage. Operator re-enters on
+  // connect. The destructure-omit pattern (rather than overriding
+  // `password = ""`) is what CodeQL's `js/clear-text-storage-of-
+  // sensitive-data` rule recognizes as a real strip. SQLite has no
+  // password to strip.
+  const safe = conns.map((c) => {
+    if (c.kind === "pg") {
+      const { password: _pw, ...rest } = c;
+      return rest;
+    }
+    return c;
+  });
   localStorage.setItem("inspector:connections", JSON.stringify(safe));
 }
 

--- a/packages/inspector/src/client/components/SqliteScanDialog.tsx
+++ b/packages/inspector/src/client/components/SqliteScanDialog.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { trpc } from "../trpc.js";
+
+// Mirrors the server's `DiscoveredSqliteStore` shape. See
+// `server/discovery/types.ts` — we narrow the `discover` response to
+// just the SQLite variant inside this dialog.
+type DiscoveredSqliteStore = {
+  kind: "sqlite";
+  file: string;
+  table: string;
+  eventCount: number;
+};
+
+export type SqliteScanResult = {
+  file: string;
+  table: string;
+};
+
+type Props = {
+  initialDir: string;
+  onSelect: (result: SqliteScanResult) => void;
+  onClose: () => void;
+};
+
+export function SqliteScanDialog({ initialDir, onSelect, onClose }: Props) {
+  const [dir, setDir] = useState(initialDir);
+  const [glob, setGlob] = useState("");
+  const [stores, setStores] = useState<DiscoveredSqliteStore[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState("");
+  const [scanned, setScanned] = useState(false);
+
+  const discoverMutation = trpc.discover.useMutation({
+    onSuccess: (result) => {
+      const sqliteStores = result.stores.filter(
+        (s): s is DiscoveredSqliteStore => s.kind === "sqlite"
+      );
+      setStores(sqliteStores);
+      setScanning(false);
+      setScanned(true);
+      if (sqliteStores.length === 0) {
+        setError("No Act SQLite stores found");
+      } else if (sqliteStores.length === 1) {
+        handleSelect(sqliteStores[0]);
+      }
+    },
+    onError: (err) => {
+      setError(err.message);
+      setScanning(false);
+      setScanned(true);
+    },
+  });
+
+  const handleScan = () => {
+    if (!dir.trim()) {
+      setError("Directory is required");
+      return;
+    }
+    setError("");
+    setStores([]);
+    setScanning(true);
+    setScanned(false);
+    discoverMutation.mutate({
+      kind: "sqlite",
+      dir,
+      glob: glob.trim() || undefined,
+    });
+  };
+
+  const handleSelect = (store: DiscoveredSqliteStore) => {
+    onSelect({ file: store.file, table: store.table });
+  };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-xl border border-zinc-700 bg-zinc-900 p-5 shadow-2xl">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-zinc-200">
+            Scan Directory for SQLite Stores
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-zinc-500 transition hover:text-zinc-300"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Scan options */}
+        <div className="mb-4 flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-zinc-400">Directory</span>
+            <input
+              type="text"
+              value={dir}
+              onChange={(e) => setDir(e.target.value)}
+              placeholder="/path/to/db/dir"
+              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600 focus:ring-1 focus:ring-emerald-600"
+            />
+          </label>
+          <div className="flex items-end gap-3">
+            <label className="flex flex-1 flex-col gap-1">
+              <span className="text-xs text-zinc-400">
+                File pattern (regex, optional)
+              </span>
+              <input
+                type="text"
+                value={glob}
+                onChange={(e) => setGlob(e.target.value)}
+                placeholder="\.(db|sqlite|sqlite3)$"
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline-none transition focus:border-emerald-600"
+              />
+            </label>
+            <button
+              onClick={handleScan}
+              disabled={scanning}
+              className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-emerald-500 disabled:opacity-50"
+            >
+              {scanning ? "Scanning..." : "Scan"}
+            </button>
+          </div>
+        </div>
+
+        {/* Scanning indicator */}
+        {scanning && (
+          <div className="mb-3 rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-[10px] text-zinc-500">
+            Scanning {dir}...
+          </div>
+        )}
+
+        {/* Results */}
+        {stores.length > 0 && (
+          <div className="max-h-56 overflow-y-auto">
+            <span className="mb-2 block text-xs font-medium text-emerald-400">
+              Found {stores.length} store{stores.length !== 1 ? "s" : ""}
+            </span>
+            <div className="flex flex-col gap-1.5">
+              {stores.map((s) => (
+                <button
+                  key={s.file}
+                  onClick={() => handleSelect(s)}
+                  className="flex items-center gap-2 rounded-md border border-zinc-700/50 bg-zinc-800 px-3 py-2.5 text-left text-xs transition hover:border-emerald-700 hover:bg-emerald-950/30"
+                >
+                  <span className="shrink-0 rounded bg-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-300">
+                    sqlite
+                  </span>
+                  <span className="truncate font-mono text-zinc-300">
+                    {s.file}
+                  </span>
+                  {s.eventCount > 0 && (
+                    <span className="ml-auto shrink-0 rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] text-zinc-400">
+                      {s.eventCount.toLocaleString()} events
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* No results */}
+        {scanned && !scanning && stores.length === 0 && !error && (
+          <div className="rounded-md border border-zinc-800 bg-zinc-950 px-3 py-4 text-center text-xs text-zinc-500">
+            No Act SQLite stores found in {dir}
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-2 rounded-md border border-red-900 bg-red-950 px-3 py-2 text-xs text-red-400">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/inspector/src/server/discovery/sqlite-probe.ts
+++ b/packages/inspector/src/server/discovery/sqlite-probe.ts
@@ -18,6 +18,7 @@
  * permission error — drops the file silently from the result.
  */
 import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 import { createClient } from "@libsql/client";
 import type { DiscoveredSqliteStore, SqliteDiscoveryInput } from "./types.js";
@@ -25,6 +26,22 @@ import type { DiscoveredSqliteStore, SqliteDiscoveryInput } from "./types.js";
 const DEFAULT_FILE_PATTERN = /\.(db|sqlite|sqlite3)$/i;
 const REQUIRED_TABLES = ["events", "streams"] as const;
 const REQUIRED_EVENT_COLUMNS = ["stream", "version", "meta"] as const;
+
+/**
+ * Expand a leading `~` / `~/` to the operator's home directory.
+ *
+ * Shell-style tilde expansion is something users reflexively type into
+ * any path input — the probe runs server-side where Node's `readdir`
+ * treats `~` as a literal directory name, so we have to expand it
+ * here. Any path without a leading `~` passes through unchanged.
+ */
+function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return path.join(homedir(), p.slice(2));
+  }
+  return p;
+}
 
 /** Probe a single file. Returns the discovery row or null. */
 export async function probeSqliteFile(
@@ -74,7 +91,8 @@ export async function probeSqliteFile(
 export async function discoverSqlite(
   input: SqliteDiscoveryInput
 ): Promise<DiscoveredSqliteStore[]> {
-  const { dir, glob } = input;
+  const dir = expandTilde(input.dir);
+  const { glob } = input;
   let pattern: RegExp;
   try {
     pattern = glob ? new RegExp(glob) : DEFAULT_FILE_PATTERN;

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -6,6 +6,7 @@ import {
   type StreamPosition,
 } from "@rotorsoft/act";
 import { PostgresStore } from "@rotorsoft/act-pg";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
 import { initTRPC } from "@trpc/server";
 import pg from "pg";
 import { z } from "zod";
@@ -336,11 +337,14 @@ export const inspectorRouter = t.router({
    * - `pg` (default — backward-compatible with the existing frontend
    *   which doesn't send an `adapter` field) constructs a
    *   `PostgresStore` and verifies the connection with a 1-row probe.
+   * - `sqlite` constructs a `SqliteStore` against the given file path.
+   *   The file must already be an Act SQLite database (use the SQLite
+   *   discovery probe to find candidates); we don't call `.seed()` on
+   *   connect so a non-Act file fails the 1-row probe instead of being
+   *   silently initialized.
    * - `inmemory` constructs an `InMemoryStore` — ephemeral, single
    *   process, no persistent config. Useful for demo / playground
    *   flows and for ACT-1131's test suite (real adapter, no mocking).
-   *
-   * `sqlite` is reserved for #782.
    */
   connect: t.procedure
     .input(
@@ -355,6 +359,11 @@ export const inspectorRouter = t.router({
           schema: z.string().default("public"),
           table: z.string().default("events"),
           ssl: z.boolean().default(false),
+        }),
+        z.object({
+          adapter: z.literal("sqlite"),
+          file: z.string().min(1),
+          table: z.string().default("events"),
         }),
         z.object({
           adapter: z.literal("inmemory"),
@@ -375,6 +384,28 @@ export const inspectorRouter = t.router({
           return {
             ok: true as const,
             config: { adapter: "inmemory" as const },
+          };
+        }
+        if (input.adapter === "sqlite") {
+          const newStore = new SqliteStore({ url: `file:${input.file}` });
+          // Verify the file is an Act-shaped database — the 1-row
+          // probe throws on missing `events` table, which is exactly
+          // what we want (a non-Act file fails connect rather than
+          // being silently seeded).
+          await newStore.query<Schemas>(() => {}, { limit: 1 });
+          currentStore = newStore;
+          currentConfig = {
+            adapter: "sqlite",
+            file: input.file,
+            table: input.table,
+          };
+          return {
+            ok: true as const,
+            config: {
+              adapter: "sqlite" as const,
+              file: input.file,
+              table: input.table,
+            },
           };
         }
         const { adapter, ssl, ...pgConfig } = input;
@@ -410,8 +441,18 @@ export const inspectorRouter = t.router({
     return { ok: true as const };
   }),
 
-  /** Check connection status */
-  status: t.procedure.query(() => ({ connected: currentStore !== null })),
+  /**
+   * Check connection status.
+   *
+   * `adapter` is the kind of currently-connected store (null when not
+   * connected). The UI uses this to gate adapter-specific affordances —
+   * e.g. `BackupRestore` hides the restore button on non-PG adapters
+   * since `restore` is PG-only until #786.
+   */
+  status: t.procedure.query(() => ({
+    connected: currentStore !== null,
+    adapter: currentConfig?.adapter ?? null,
+  })),
 
   /** Query events using the Store interface */
   query: t.procedure

--- a/packages/inspector/test/connection.spec.ts
+++ b/packages/inspector/test/connection.spec.ts
@@ -3,8 +3,14 @@
  *
  * Real InMemoryStore — no mocking. `connect({ adapter: "inmemory" })`
  * constructs a fresh store, `getActiveStore()` returns it so tests can
- * read back the same instance the router holds.
+ * read back the same instance the router holds. ACT-1123 added the
+ * SQLite branch — its happy-path / sad-path tests live below and use
+ * real `SqliteStore` instances against tempdir files.
  */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { getActiveStore, inspectorRouter } from "../src/server/router.js";
 
@@ -16,18 +22,21 @@ afterEach(async () => {
 
 describe("status", () => {
   it("reports disconnected before connect", async () => {
-    expect(await caller.status()).toEqual({ connected: false });
+    expect(await caller.status()).toEqual({ connected: false, adapter: null });
   });
 
-  it("reports connected after connect(inmemory)", async () => {
+  it("reports connected + adapter kind after connect(inmemory)", async () => {
     await caller.connect({ adapter: "inmemory" });
-    expect(await caller.status()).toEqual({ connected: true });
+    expect(await caller.status()).toEqual({
+      connected: true,
+      adapter: "inmemory",
+    });
   });
 
   it("reports disconnected again after disconnect", async () => {
     await caller.connect({ adapter: "inmemory" });
     await caller.disconnect();
-    expect(await caller.status()).toEqual({ connected: false });
+    expect(await caller.status()).toEqual({ connected: false, adapter: null });
   });
 });
 
@@ -111,5 +120,80 @@ describe("restore adapter guard", () => {
     await expect(caller.restore({ csv: "" })).rejects.toThrow(
       "Not connected to a store"
     );
+  });
+});
+
+describe("connect (sqlite)", () => {
+  let dir: string;
+
+  // Build a real Act SQLite file in a tempdir for each test, dispose at
+  // the end. Uses `SqliteStore.seed()` so the file actually has the
+  // events/streams tables the connect-time probe checks for.
+  async function buildActFile(name = "store.db"): Promise<string> {
+    const file = path.join(dir, name);
+    const store = new SqliteStore({ url: `file:${file}` });
+    try {
+      await store.seed();
+    } finally {
+      await store.dispose();
+    }
+    return file;
+  }
+
+  it("connects to a real Act SQLite file", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "act-inspector-conn-sqlite-"));
+    try {
+      const file = await buildActFile();
+      const result = await caller.connect({ adapter: "sqlite", file });
+      expect(result).toEqual({
+        ok: true,
+        config: { adapter: "sqlite", file, table: "events" },
+      });
+      expect(await caller.status()).toEqual({
+        connected: true,
+        adapter: "sqlite",
+      });
+      expect(getActiveStore()).not.toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when the file has no Act schema", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "act-inspector-conn-sqlite-bad-"));
+    try {
+      // SqliteStore without seed() — file exists but has no `events`
+      // table. The 1-row probe rejects.
+      const file = path.join(dir, "empty.db");
+      const empty = new SqliteStore({ url: `file:${file}` });
+      try {
+        // Force libsql to materialize the file with NO Act schema.
+        // Any SELECT works.
+        await empty
+          .query<Record<string, never>>(() => {}, { limit: 1 })
+          .catch(() => {});
+      } finally {
+        await empty.dispose();
+      }
+      await expect(caller.connect({ adapter: "sqlite", file })).rejects.toThrow(
+        /Connection failed/
+      );
+      expect(getActiveStore()).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks restore when the connection is SQLite-backed", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "act-inspector-conn-sqlite-rs-"));
+    try {
+      const file = await buildActFile();
+      await caller.connect({ adapter: "sqlite", file });
+      await expect(caller.restore({ csv: "" })).rejects.toThrow(
+        "Restore currently requires a PG-backed inspector connection"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/inspector/test/discovery/sqlite-probe.spec.ts
+++ b/packages/inspector/test/discovery/sqlite-probe.spec.ts
@@ -145,11 +145,16 @@ describe("discoverSqlite", () => {
     const { homedir } = await import("node:os");
     const marker = `act-inspector-tilde-test-${process.pid}-${Date.now()}.db`;
     const file = path.join(homedir(), marker);
+    // Full regex-metachar escape — CodeQL's `js/incomplete-sanitization`
+    // flags partial escapes (e.g. dots only), even when the input shape
+    // makes other metacharacters impossible.
+    const escapeForRegex = (s: string) =>
+      s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     try {
       await buildActSqlite(file);
       const result = await discoverSqlite({
         dir: "~",
-        glob: marker.replace(/[.]/g, "\\."),
+        glob: `^${escapeForRegex(marker)}$`,
       });
       expect(result).toHaveLength(1);
       expect(result[0]!.file).toBe(file);

--- a/packages/inspector/test/discovery/sqlite-probe.spec.ts
+++ b/packages/inspector/test/discovery/sqlite-probe.spec.ts
@@ -138,6 +138,26 @@ describe("discoverSqlite", () => {
     expect(path.basename(result[0]!.file)).toBe("valid.db");
   });
 
+  it("expands a leading `~/` to the operator's home directory", async () => {
+    // Build an Act file in $HOME directly so a tilde-only path finds
+    // it. We pick a marker filename unlikely to collide with anything
+    // a developer keeps in their home dir, and clean up after.
+    const { homedir } = await import("node:os");
+    const marker = `act-inspector-tilde-test-${process.pid}-${Date.now()}.db`;
+    const file = path.join(homedir(), marker);
+    try {
+      await buildActSqlite(file);
+      const result = await discoverSqlite({
+        dir: "~",
+        glob: marker.replace(/[.]/g, "\\."),
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]!.file).toBe(file);
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
   it("returns [] when given an invalid regex glob", async () => {
     await buildActSqlite(path.join(dir, "store.db"));
     // Unbalanced bracket — `new RegExp(...)` throws.

--- a/packages/inspector/tsconfig.json
+++ b/packages/inspector/tsconfig.json
@@ -5,5 +5,9 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "references": [{ "path": "../../libs/act" }, { "path": "../../libs/act-pg" }]
+  "references": [
+    { "path": "../../libs/act" },
+    { "path": "../../libs/act-pg" },
+    { "path": "../../libs/act-sqlite" }
+  ]
 }


### PR DESCRIPTION
Closes #782.

Wires the SQLite branch into the inspector's `connect` procedure and adds a Postgres / SQLite tab picker to the connection dialog. With the discovery probe from #781 already shipped, this slice closes Group 1 of the saga — the inspector can now point at either backing adapter end-to-end. Every read view (Event Log, Streams, Drain Status, Schema Evolution, etc.) already flows through the `Store` interface, so they all work against the new adapter without further changes.

## Connect procedure

`packages/inspector/src/server/router.ts` — the `connect` z.union grows a third arm: `{ adapter: "sqlite", file, table? }`. The handler constructs `new SqliteStore({ url: \`file:\${file}\` })` and runs the existing 1-row `query` probe to verify the file is an Act SQLite database. We deliberately don't call `.seed()` on connect — a non-Act file fails the probe rather than being silently initialized.

The `status` query now also returns the connected adapter kind (`pg | sqlite | inmemory | null`). This lets adapter-specific UI affordances gate themselves without threading state through every component.

## Frontend

- **`ConnectDialog`** reworked around an adapter tab strip. Each tab swaps the form between PG fields and SQLite `file`+`table`. Switching tabs remembers the most recently used saved connection of that kind.
- **Saved connections** widen to a discriminated union (`PgConnection | SqliteConnection`). Pre-1.1 localStorage payloads (no `kind` field) migrate to PG on load so existing users don't lose their bookmarks. Chips render with a small `pg` / `sqlite` badge.
- **`SqliteScanDialog`** (new component) parallels the existing PG `ScanDialog`. Takes a directory + optional regex glob, calls `discover({ kind: "sqlite", dir, glob? })`, lists each matched file with its event count. Single-result auto-select matches the PG dialog's behavior.
- **`BackupRestore`** gates the Restore button on `status.adapter === "pg"` — disabled with a tooltip pointing at #1127. Backup itself rides `Store.query` and works on every adapter unchanged.

## tsconfig

`packages/inspector/tsconfig.json` adds `libs/act-sqlite` to its project references so per-package tsc (`pnpm -F @rotorsoft/act-inspector typecheck`) sees the new dep. `@rotorsoft/act-sqlite` was already a runtime dependency from #781.

## Tests

3 new specs in `connection.spec.ts`:

- **Happy path** — build a real Act SQLite file in a tempdir via `SqliteStore.seed()`, connect through the public router, assert `status.adapter === "sqlite"` and `getActiveStore() !== null`.
- **Sad path** — create a SQLite file that exists but has no Act schema, attempt connect, assert it rejects with "Connection failed: …" and leaves the router disconnected.
- **Restore cross-check** — after a SQLite connection, `restore` throws the same PG-only guard already covered for the InMemory adapter.

The `status` shape change to include `adapter` is also reflected in the existing status / disconnect tests.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1804 passed / 1804 across 119 files
- [x] Workspace coverage: 100% statements / 100% branches / 100% functions / 100% lines (libs/** scope, unchanged)
- [x] `pnpm -F @rotorsoft/act-inspector test` — passes at 71.46% Stmts / 65.12% Branches / 81.81% Funcs / 71.11% Lines vs the 65/60/75/65 thresholds
- [x] `pnpm lint` — 0 errors (23 pre-existing warnings)
- [x] `pnpm build` — all packages; inspector vite bundle 410 kB / 121 kB gzipped
- [ ] Manual smoke: connect to a fresh `wolfdesk` PG store, then switch tabs to SQLite and connect against a seeded SQLite file built via `pnpm dev:calculator` with `SqliteStore`
- [ ] Manual smoke: scan a directory containing both Act and non-Act `.db` files — confirm only the Act ones surface
- [ ] Review

## Stability charter impact

**No charter-covered surface touched.** `git diff master --stat` on `libs/act/src/builders/`, `libs/act/src/act.ts`, `libs/act/src/types/ports.ts`, `libs/act/src/types/index.ts`, `libs/act/src/ports.ts` is empty. Entire slice lives in `packages/inspector/`. The `connect` and `status` input/output changes are additive (new adapter arm, new optional response field) — defaults preserved for existing frontend payloads.

## Follow-ups

Tracked under the saga master #790:

- #786 — ACT-1127: rewrite `restore` onto `Store.restore`. Removes the `BackupRestore` PG-only gate added here and ramps the inspector per-package coverage threshold further as restore + getRawPgClient gain tests.

Closing Group 1 of the saga (#780, #795, #781, this PR). Group 2 — the `Store.restore` port method — is up next (#783).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>