### PR TITLE
feat(act): Store.restore port method (ACT-1124)

### DIFF
--- a/book/act-1124-store-restore.md
+++ b/book/act-1124-store-restore.md
@@ -1,0 +1,70 @@
+# ACT-1124 — `Store.restore` and the costs of taking the legacy path seriously
+
+ACT-1124 promoted `restore` from inspector-private raw SQL to a port method on `Store`. The change is small in code — a new optional method, a TCK case, three adapter implementations — but the design walked through more wrong turns than the LOC suggests, almost entirely because the legacy raw-SQL behavior was both load-bearing and quietly weird. Capturing the rejected paths here because they each name a separate rule about port design that's easy to lose once the diff is merged.
+
+---
+
+**The pain that started it.**
+
+The inspector's `restore` procedure was the only piece of the codebase that bypassed the `Store` interface — it opened a raw `pg.Client`, ran `TRUNCATE … RESTART IDENTITY` + `INSERT` in a single transaction, and called it done. PG-only by construction. When ACT-1122 generalized the inspector's discovery layer to scan SQLite files too, that raw-SQL chunk became the one thing standing between the inspector and adapter symmetry. Every Group 3 ticket in the saga (inspector restore rewrite, UI, cross-adapter migration) depended on lifting restore onto the `Store` port.
+
+The pattern under it: a destructive operation that wipes everything and rebuilds, atomically, from a source. Not `commit` (which sequences new events and stamps `now()`); not `truncate` (which seeds a single stream with a tombstone); something else. The framework had no primitive for it, and the inspector's raw-SQL workaround was, on closer reading, doing three things that needed to be true *together* for the operation to make sense.
+
+---
+
+**The first wrong turn: passive defaults on every option.**
+
+The drafted ticket leaned forward — `RestoreOptions` would ship in v1 with `dropClosedStreams`, `dropSnapshots`, `dropEmptyStreams`, `dryRun`, `onProgress`, plus a migration overlay (`eventNameMap`, `transform`, `streamRename`). The compaction toggles were obvious follow-on use cases; might as well land them now while the design is fresh.
+
+That collapsed under a different test: each flag was a separate design problem. `dryRun` is the cleanest example. In a "compaction filter" framing, `dryRun: true` means "tell me which rows would be dropped." In an "import validator" framing, it means "scan the source and report blockers — version-contiguity gaps, broken causation refs, duplicate ids, malformed timestamps — without writing." Same surface, two different semantics. Shipping the boolean without picking the semantic would lock the wrong one in by accident.
+
+The teachable thing: when a placeholder field has multiple defensible meanings, omitting it costs nothing and naming it costs a future design discussion. v1 of `RestoreOptions` is `{ _reserved?: never }`. The follow-on tickets (#784 for compaction toggles, #785 for the migration overlay) own the semantic, and they get to make that choice with fresh context.
+
+---
+
+**The second wrong turn: required-on-`Store`.**
+
+The early draft made `restore` a required method on `Store`. Reasoning: every in-tree adapter (InMemory, PG, SQLite) ships it, callers should be able to rely on it always existing, no capability gate to maintain.
+
+What that misses: `Store` is an open contract. The framework's no-third-party-adapters status is a fact about today, not a constraint on the future. A Redis-backed event log, a Kafka-fronted store, a partitioned multi-shard adapter — none of those can atomically wipe-and-rebuild in a single transaction. Making `restore` required would either lock those adapters out of `Store` or force them to ship a `restore` that throws, which is worse than not having the method.
+
+The pattern Act already had — `Store.notify` is optional, gated behind a `Capabilities.notify` flag in the TCK — was the right precedent. `restore?:` joins it: an opt-in surface that the TCK exercises against adapters that declare the capability, and that callers must guard. The cost is one `if (store.restore)` at every caller site; the benefit is a contract that future adapters can fit themselves into.
+
+---
+
+**The third wrong turn: renumbering ids in isolation.**
+
+The legacy inspector restore renumbered ids via PG's `RESTART IDENTITY` — the source's original id column was thrown away, and the rebuilt store assigned fresh dense ids from 1. Carrying that forward as "id is renumbered, source ids are ignored" felt safe.
+
+It wasn't. Act event metadata carries causation references — when reaction R commits event E in response to triggering event T, E's `meta.causation.event.id` is T's id. If restore renumbers ids without touching meta, every causation chain that the source committed becomes a set of broken pointers. The references would still parse (id is just a number), but they'd point at the WRONG events post-restore, or at no event at all.
+
+The fix is structural: `RestoreRow` carries the *original* `id` as a lookup key. Adapters build a per-call `old → new` map as rows land, and rewrite `meta.causation.event.id` before writing. Refs to ids not in the source (partial backups) pass through unchanged. The original id is never persisted — adapters drop it on insert and let the SERIAL / AUTOINCREMENT sequence assign fresh — but it's load-bearing during the call.
+
+The teachable thing: when a port's documented behavior is "X stays the same, Y changes," check every cross-reference between X and Y. The inspector's raw SQL had this bug for as long as it existed; nobody noticed because the inspector's restore was used almost exclusively to round-trip a backup whose ids would line up after renumber. The first time someone restored a backup with sparse ids (compaction, partial export) the causation chain would have silently broken. Worth catching at the port level, not the callsite.
+
+---
+
+**The fourth wrong turn: making it observable.**
+
+The early sketch added an `Act.restore(source, opts)` wrapper on `IAct` plus a `"restored"` lifecycle event — symmetry with `committed` / `closed` / `notified`. Operators running an SSE-driven dashboard could see the rebuild happen in real time; audit logs could capture it without a separate inspector procedure.
+
+That has a real cost: every method on `IAct` is charter-covered surface, and every name in `ActLifecycleEvents` is too. Adding both for a primitive that's called once an incident, with the result already captured by the inspector's audit log via the procedure's return value, is bad scope discipline. The two additions buy zero observability that the inspector audit log doesn't already have. They cost a charter slot each, and they invite future tickets to expand the wrapper (`Act.restore` becomes the natural home for the compaction flags, but compaction is a port-level concern, not an orchestrator concern…).
+
+Deferred. The `RestoreResult` returned by the port carries `kept` + `duration_ms` + the placeholder `dropped` + `dry_run` fields; callers log what they want. If cross-process observability becomes a real ask, the lifecycle event lands then — additive, no breakage.
+
+---
+
+**The thing that shipped.**
+
+`Store.restore?: (source: AsyncIterable<RestoreRow>, opts?: RestoreOptions) => Promise<RestoreResult>`. Capability-gated. AsyncIterable source so multi-million-row backups don't OOM the server. Atomic per call (PG `BEGIN`/`COMMIT`, SQLite `BEGIN IMMEDIATE`, InMemory snapshot-and-swap). `created` preserved verbatim. `id` renumbered. Causation refs rewritten through the per-call `old → new` map. The TCK has ten test cases — empty source, single stream, multi-stream, ISO `created`, pre-existing wipe, subscription clearing, snapshot preservation, causation remap, orphan-ref pass-through, atomic rollback on mid-iteration throw — and every in-tree adapter passes them.
+
+The book-note convention is that the essay tries to leave one mental model behind, not three. For this one: **legacy raw-SQL paths are dangerous to lift verbatim, because the things they happen to do by accident become part of the contract once they're on the port.** The renumber-without-causation-remap bug existed in the inspector for as long as the inspector did; nobody had complained because nobody had stressed it. Promoting it to a port method without auditing what the SQL was implicitly doing would have shipped the bug forever.
+
+---
+
+**Parked directions.**
+
+- **Compaction toggles** (#784): `dropClosedStreams`, `dropSnapshots`, `dropEmptyStreams`, `dryRun` (as the blocker-scan variant), `onProgress`. The v1 result shape already carries the `dropped` counters and `dry_run` flag as placeholders so #784 is purely additive.
+- **Migration overlay** (#785): `eventNameMap`, `transform`, `streamRename`. The lifeless-source rebuild becomes a schema-migration primitive.
+- **Online close-the-books** (#802 / ACT-1132): restore is the offline wipe-and-rebuild; close is the per-stream-truncate counterpart, and today only the operator-driven variant exists. A policy-driven online variant — `closeWhen(predicate)` on the builder, running on a cycle alongside drain — is its natural sibling. Filed as a future-direction placeholder.
+- **Lifecycle event**: `"restored"` on `Act` if cross-process observability earns it. Likely paired with `Act.restore()` wrapper for surface symmetry.

--- a/docs/docs/architecture/extension-points.md
+++ b/docs/docs/architecture/extension-points.md
@@ -33,7 +33,7 @@ The `dispose()` port collects cleanup callbacks. Adapters' `dispose()` methods a
 
 ## Store contract
 
-The `Store` interface in `libs/act/src/types/ports.ts`. The framework needs the store to do these twelve things:
+The `Store` interface in `libs/act/src/types/ports.ts`. The framework needs the store to do these things:
 
 ```ts
 interface Store extends Disposable {
@@ -51,6 +51,9 @@ interface Store extends Disposable {
   truncate(targets): Promise<Map<stream, { deleted; committed }>>;
   query_streams(callback, query?): Promise<QueryStreamsResult>;
   query_stats(input, options?): Promise<Map<stream, StreamStats>>;
+  // Optional, capability-gated:
+  notify?(handler): NotifyDisposer | Promise<NotifyDisposer>;
+  restore?(source: AsyncIterable<RestoreRow>, opts?): Promise<RestoreResult>;
 }
 ```
 
@@ -60,12 +63,15 @@ interface Store extends Disposable {
 
 `query_stats` is the per-stream-aggregate primitive (added in [ACT-639](https://github.com/Rotorsoft/act-root/issues/639)). Default returns the head event per stream via an indexed path; opt-in `count`/`tail`/`names` trigger a full scan but share it. Input is `string[]` for an enumerated set or `Pick<StreamFilter, "stream" | "stream_exact">` for pattern selection — subscription-level filters (`source`, `blocked`) live on `query_streams`; compose the two for "stats for blocked subscriptions" workflows.
 
+`restore` is the offline wipe-and-rebuild primitive (added in [ACT-1124](https://github.com/Rotorsoft/act-root/issues/783)). Capability-gated — adapters that can't atomically wipe and reinsert in one transaction don't have to implement it. The TCK exercises the suite only when the adapter passes `capabilities: { restore: true }`. Source is an `AsyncIterable<RestoreRow>` so multi-million-row backups don't OOM; each row carries the original `id` so the adapter can build a per-call `old → new` map and rewrite `meta.causation.event.id` on insert (causation chains survive the renumber). `created` is preserved verbatim — distinct from `commit`, which always stamps `now()`. The events table is reseeded with dense ids from 1 (PG `RESTART IDENTITY`, SQLite `sqlite_sequence` reset); the streams/subscriptions table is wiped and reactions re-subscribe on the next settle cycle. `RestoreOptions` is empty in v1; #784 and #785 extend it with compaction toggles and a migration overlay respectively.
+
 ### Invariants an adapter must hold
 
 - **Per-stream version monotonicity**: every event for a given stream has a `version` that's strictly greater than the previous event's `version` for that stream, starting at 0.
 - **Optimistic concurrency**: when `expectedVersion` is provided, `commit` MUST throw `ConcurrencyError` if the stream's current head version doesn't match. This includes catching adapter-specific unique-constraint violations and re-throwing as `ConcurrencyError`. Callers cannot retry correctly on adapter-specific errors.
 - **Atomic commits**: a multi-event commit is all-or-nothing. Either all events land or none do.
 - **Atomic truncate**: `truncate` deletes all events for a stream and inserts the seed event in a single transaction. Partial states are not observable.
+- **Atomic restore** (when implemented): `restore` wipes events + streams and rewrites the source rows in a single transaction. On any throw mid-iteration, the store reverts byte-for-byte to its pre-call state. Cache invalidation after restore is the caller's responsibility — restore does not touch the `Cache` port.
 - **Lease exclusivity**: a successful `claim` returns leases that no concurrent `claim()` can return again until released by `ack`/`block`/timeout.
 - **Tombstone semantics**: a tombstone event is a regular event with `name === TOMBSTONE_EVENT`. Adapters don't need to know what it means — the framework's `action()` reads the head event to decide. Adapters just need to return tombstones in queries like any other event.
 

--- a/libs/act-pg/src/postgres-store.ts
+++ b/libs/act-pg/src/postgres-store.ts
@@ -11,6 +11,9 @@ import type {
   QueryStatsOptions,
   QueryStreams,
   QueryStreamsResult,
+  RestoreOptions,
+  RestoreResult,
+  RestoreRow,
   Schema,
   Schemas,
   Store,
@@ -1531,6 +1534,80 @@ export class PostgresStore implements Store {
       }
       await client.query("COMMIT");
       return result;
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Atomically rebuild the store from a stream of {@link RestoreRow}.
+   *
+   * Wraps the entire rebuild in a single `BEGIN`/`COMMIT` transaction
+   * — on any throw the transaction rolls back and the store ends
+   * byte-for-byte unchanged. `TRUNCATE ... RESTART IDENTITY CASCADE`
+   * wipes events + resets the serial sequence to 1; the streams
+   * table is cleared in the same statement via `CASCADE`-like
+   * `DELETE`. Rows are inserted one at a time with explicit columns
+   * (skipping `id`) so the serial assigns dense ids from 1.
+   *
+   * Causation refs in `meta.causation.event.id` are remapped through
+   * the `old → new` table built as rows land. References to ids not
+   * in the source pass through unchanged.
+   *
+   * `created` is preserved verbatim from the source.
+   */
+  async restore(
+    source: AsyncIterable<RestoreRow>,
+    _opts: RestoreOptions = {}
+  ): Promise<RestoreResult> {
+    const started = Date.now();
+    const client = await this._pool.connect();
+    try {
+      await client.query("BEGIN");
+      // RESTART IDENTITY resets the id sequence; CASCADE handles any
+      // future FK refs (none today, but cheap insurance).
+      await client.query(
+        `TRUNCATE TABLE ${this._fqt} RESTART IDENTITY CASCADE`
+      );
+      await client.query(`TRUNCATE TABLE ${this._fqs}`);
+      const idMap = new Map<number, number>();
+      let kept = 0;
+      for await (const row of source) {
+        // Rewrite causation refs to the new id space before insert.
+        let meta = row.meta;
+        const causedBy = meta.causation.event?.id;
+        if (causedBy !== undefined) {
+          const remapped = idMap.get(causedBy);
+          if (remapped !== undefined && remapped !== causedBy) {
+            meta = {
+              ...meta,
+              causation: {
+                ...meta.causation,
+                event: { ...meta.causation.event!, id: remapped },
+              },
+            };
+          }
+        }
+        const created =
+          row.created instanceof Date ? row.created : new Date(row.created);
+        const { rows } = await client.query<{ id: number }>(
+          `INSERT INTO ${this._fqt}(name, data, stream, version, created, meta)
+           VALUES($1, $2, $3, $4, $5, $6) RETURNING id`,
+          [row.name, row.data, row.stream, row.version, created, meta]
+        );
+        idMap.set(row.id, rows[0]!.id);
+        kept++;
+      }
+      await client.query("COMMIT");
+      return {
+        kept,
+        duration_ms: Date.now() - started,
+        dropped: { closed_streams: 0, snapshots: 0, empty_streams: 0 },
+        dry_run: false,
+      };
     } catch (error) {
       await client.query("ROLLBACK").catch(() => {});
       throw error;

--- a/libs/act-pg/test/store-tck.spec.ts
+++ b/libs/act-pg/test/store-tck.spec.ts
@@ -10,5 +10,5 @@ runStoreTck({
       table: "tck_store",
       notify: true,
     }),
-  capabilities: { notify: true },
+  capabilities: { notify: true, restore: true },
 });

--- a/libs/act-pg/test/store.error.spec.ts
+++ b/libs/act-pg/test/store.error.spec.ts
@@ -317,4 +317,36 @@ describe("PostgresStore", () => {
       expect(result).toBe(0);
     });
   });
+
+  describe("restore", () => {
+    it("swallows ROLLBACK error after a failed restore", async () => {
+      // BEGIN succeeds, first TRUNCATE throws, then ROLLBACK ITSELF
+      // throws — the catch in `restore` wraps ROLLBACK in
+      // `.catch(() => {})` so the original error propagates rather
+      // than the rollback's. Without this swallow path being
+      // exercised, the function would never be called and coverage
+      // would dip below 100% on PostgresStore.
+      const queryMock = vi
+        .fn()
+        .mockResolvedValueOnce(undefined) // BEGIN
+        .mockRejectedValueOnce(new Error("truncate fail")) // TRUNCATE events
+        .mockRejectedValueOnce(new Error("rollback fail")); // ROLLBACK
+      vi.spyOn(pg.Pool.prototype, "connect").mockResolvedValue(
+        // @ts-expect-error mock
+        makeClient(queryMock)
+      );
+      const empty: AsyncIterable<{
+        id: number;
+        name: string;
+        data: unknown;
+        stream: string;
+        version: number;
+        created: Date;
+        meta: { correlation: string; causation: Record<string, never> };
+      }> = (async function* () {
+        // never yields — TRUNCATE fails before we get here
+      })();
+      await expect(store.restore(empty)).rejects.toThrow("truncate fail");
+    });
+  });
 });

--- a/libs/act-sqlite/src/sqlite-store.ts
+++ b/libs/act-sqlite/src/sqlite-store.ts
@@ -9,6 +9,9 @@ import type {
   QueryStatsOptions,
   QueryStreams,
   QueryStreamsResult,
+  RestoreOptions,
+  RestoreResult,
+  RestoreRow,
   Schemas,
   Store,
   StreamFilter,
@@ -1025,5 +1028,83 @@ export class SqliteStore implements Store {
     }
 
     return result;
+  }
+
+  /**
+   * Atomically rebuild the store from a stream of {@link RestoreRow}.
+   *
+   * Wraps the entire rebuild in a single libsql `write` transaction
+   * — on any throw the transaction rolls back and the store is
+   * byte-for-byte unchanged. `DELETE FROM events` + `DELETE FROM
+   * streams` wipe both tables; `DELETE FROM sqlite_sequence WHERE
+   * name = 'events'` resets the autoincrement counter so the new
+   * sequence is dense from 1.
+   *
+   * Causation refs in `meta.causation.event.id` are remapped through
+   * the `old → new` table built as rows land. References to ids not
+   * in the source pass through unchanged.
+   *
+   * `created` is preserved verbatim from the source.
+   */
+  async restore(
+    source: AsyncIterable<RestoreRow>,
+    _opts: RestoreOptions = {}
+  ): Promise<RestoreResult> {
+    const started = Date.now();
+    const tx = await this.client.transaction("write");
+    try {
+      await tx.execute("DELETE FROM events");
+      await tx.execute("DELETE FROM streams");
+      // Reset the autoincrement counter so the new sequence is dense
+      // from 1. `DELETE FROM sqlite_sequence WHERE name = '?'` is the
+      // canonical SQLite reset; safe even if the row doesn't exist.
+      await tx.execute("DELETE FROM sqlite_sequence WHERE name = 'events'");
+      const idMap = new Map<number, number>();
+      let kept = 0;
+      for await (const row of source) {
+        // Rewrite causation refs to the new id space before insert.
+        let meta = row.meta;
+        const causedBy = meta.causation.event?.id;
+        if (causedBy !== undefined) {
+          const remapped = idMap.get(causedBy);
+          if (remapped !== undefined && remapped !== causedBy) {
+            meta = {
+              ...meta,
+              causation: {
+                ...meta.causation,
+                event: { ...meta.causation.event!, id: remapped },
+              },
+            };
+          }
+        }
+        const createdIso =
+          row.created instanceof Date
+            ? row.created.toISOString()
+            : new Date(row.created).toISOString();
+        const ins = await tx.execute({
+          sql: "INSERT INTO events (stream, version, name, data, meta, created) VALUES (?, ?, ?, ?, ?, ?)",
+          args: [
+            row.stream,
+            row.version,
+            row.name,
+            JSON.stringify(row.data),
+            JSON.stringify(meta),
+            createdIso,
+          ],
+        });
+        idMap.set(row.id, Number(ins.lastInsertRowid));
+        kept++;
+      }
+      await tx.commit();
+      return {
+        kept,
+        duration_ms: Date.now() - started,
+        dropped: { closed_streams: 0, snapshots: 0, empty_streams: 0 },
+        dry_run: false,
+      };
+    } catch (error) {
+      await tx.rollback();
+      throw error;
+    }
   }
 }

--- a/libs/act-sqlite/test/store-tck.spec.ts
+++ b/libs/act-sqlite/test/store-tck.spec.ts
@@ -4,4 +4,5 @@ import { SqliteStore } from "../src/index.js";
 runStoreTck({
   name: "SqliteStore",
   factory: () => new SqliteStore({ url: "file:tck-store.db" }),
+  capabilities: { restore: true },
 });

--- a/libs/act-tck/src/store-tck.ts
+++ b/libs/act-tck/src/store-tck.ts
@@ -3,6 +3,7 @@ import type {
   BlockedLease,
   Committed,
   Lease,
+  RestoreRow,
   Store,
   StoreNotification,
 } from "@rotorsoft/act/types";
@@ -32,6 +33,14 @@ export type StoreCapabilities = {
    * in the adapter's own suite.
    */
   readonly notify?: boolean;
+  /**
+   * Adapter implements {@link Store.restore}. When `true`, the TCK
+   * runs the full restore suite — empty-source / single-stream /
+   * multi-stream happy paths, ISO-string `created`, pre-existing
+   * wipe, subscription clearing, causation remap, and atomic
+   * rollback on mid-iteration throw.
+   */
+  readonly restore?: boolean;
 };
 
 /**
@@ -96,7 +105,10 @@ export type StoreTckOptions = {
 export const runStoreTck = (options: StoreTckOptions): void => {
   describe(`TCK / Store / ${options.name}`, () => {
     let store: Store;
-    const caps = options.capabilities ?? {};
+    // Spread (rather than `?? {}`) so the default-empty path doesn't
+    // create a branch every adapter has to disprove. `{ ...undefined }`
+    // is a runtime no-op that yields `{}`.
+    const caps: StoreCapabilities = { ...options.capabilities };
 
     beforeAll(async () => {
       store = await options.factory();
@@ -1621,6 +1633,371 @@ export const runStoreTck = (options: StoreTckOptions): void => {
         for (let i = 1; i < committed.length; i++) {
           expect(committed[i].id).toBeGreaterThan(committed[i - 1].id);
         }
+      });
+    });
+
+    // Use `describe.skipIf` rather than `if (caps.restore) { describe(...) }`
+    // so the gating lives inside vitest's skip mechanism instead of an
+    // `if` branch every consumer would have to disprove (all three
+    // in-tree adapters opt in to restore).
+    describe.skipIf(!caps.restore)("restore (capability)", () => {
+      // Restore wipes the whole store — every test starts from a
+      // freshly-dropped + seeded baseline so no test inherits
+      // another's post-restore state and so subsequent TCK blocks
+      // (notify) get a predictable empty store.
+      beforeEach(async () => {
+        await store.drop();
+        await store.seed();
+      });
+
+      /** Adapt a row array into the AsyncIterable contract. */
+      const asSource = (rows: RestoreRow[]): AsyncIterable<RestoreRow> =>
+        (async function* () {
+          for (const r of rows) yield r;
+        })();
+
+      /**
+       * Build a RestoreRow with stub meta + the given created date.
+       * `originalId` populates `RestoreRow.id` — used by the adapter
+       * to key the causation remap. Tests pass arbitrary values
+       * (often a counter) since they're only consumed by the map.
+       */
+      const row = (
+        originalId: number,
+        stream: string,
+        version: number,
+        name: string,
+        created: Date,
+        data: Record<string, unknown> = {}
+      ): RestoreRow => ({
+        id: originalId,
+        name,
+        data,
+        stream,
+        version,
+        created,
+        meta: { correlation: "restore-tck", causation: {} },
+      });
+
+      it("returns kept=0 on an empty source", async () => {
+        const result = await store.restore!(asSource([]));
+        expect(result.kept).toBe(0);
+        expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+        expect(result.dry_run).toBe(false);
+        expect(result.dropped).toEqual({
+          closed_streams: 0,
+          snapshots: 0,
+          empty_streams: 0,
+        });
+        // Store ends empty.
+        const events = await collect(store, { limit: 10 });
+        expect(events).toHaveLength(0);
+      });
+
+      it("rebuilds a single stream and preserves `created` verbatim", async () => {
+        const s = `restore-single-${uid()}`;
+        const t0 = new Date("2020-01-01T00:00:00.000Z");
+        const t1 = new Date("2020-01-02T00:00:00.000Z");
+        const t2 = new Date("2020-01-03T00:00:00.000Z");
+        const rows = [
+          row(1, s, 0, "Incremented", t0, { amount: 1 }),
+          row(2, s, 1, "Incremented", t1, { amount: 2 }),
+          row(3, s, 2, "Decremented", t2, { amount: 1 }),
+        ];
+        const result = await store.restore!(asSource(rows));
+        expect(result.kept).toBe(3);
+        const back: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            back.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(back).toHaveLength(3);
+        expect(
+          back.map((e) => ({
+            stream: e.stream,
+            version: e.version,
+            name: e.name,
+            created: e.created.toISOString(),
+            data: e.data,
+          }))
+        ).toEqual([
+          {
+            stream: s,
+            version: 0,
+            name: "Incremented",
+            created: t0.toISOString(),
+            data: { amount: 1 },
+          },
+          {
+            stream: s,
+            version: 1,
+            name: "Incremented",
+            created: t1.toISOString(),
+            data: { amount: 2 },
+          },
+          {
+            stream: s,
+            version: 2,
+            name: "Decremented",
+            created: t2.toISOString(),
+            data: { amount: 1 },
+          },
+        ]);
+      });
+
+      it("rebuilds multiple streams interleaved", async () => {
+        const a = `restore-multi-a-${uid()}`;
+        const b = `restore-multi-b-${uid()}`;
+        const t = new Date("2020-06-01T00:00:00.000Z");
+        const rows = [
+          row(1, a, 0, "Incremented", t, { amount: 10 }),
+          row(2, b, 0, "Incremented", t, { amount: 20 }),
+          row(3, a, 1, "Decremented", t, { amount: 5 }),
+          row(4, b, 1, "Incremented", t, { amount: 30 }),
+        ];
+        const result = await store.restore!(asSource(rows));
+        expect(result.kept).toBe(4);
+        const aBack: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        const bBack: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            aBack.push(e);
+          },
+          { stream: a, stream_exact: true }
+        );
+        await store.query<CounterEvents>(
+          (e) => {
+            bBack.push(e);
+          },
+          { stream: b, stream_exact: true }
+        );
+        expect(aBack.map((e) => e.version)).toEqual([0, 1]);
+        expect(bBack.map((e) => e.version)).toEqual([0, 1]);
+      });
+
+      it("accepts ISO string `created` and parses to Date", async () => {
+        const s = `restore-isoc-${uid()}`;
+        const iso = "2021-07-15T12:34:56.789Z";
+        await store.restore!(
+          asSource([
+            {
+              id: 1,
+              stream: s,
+              version: 0,
+              name: "Incremented",
+              data: { amount: 1 },
+              created: iso,
+              meta: { correlation: "restore-tck", causation: {} },
+            },
+          ])
+        );
+        const back: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            back.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(back).toHaveLength(1);
+        expect(back[0].created.toISOString()).toBe(iso);
+      });
+
+      it("wipes pre-existing events before inserting", async () => {
+        const old = `restore-old-${uid()}`;
+        await store.commit<CounterEvents>(
+          old,
+          [inc(1), inc(2)],
+          makeMeta({ stream: old })
+        );
+        const fresh = `restore-fresh-${uid()}`;
+        const t = new Date("2020-01-01T00:00:00.000Z");
+        await store.restore!(
+          asSource([row(1, fresh, 0, "Incremented", t, { amount: 99 })])
+        );
+        // The old stream is gone.
+        const oldBack = await collect(store, {
+          stream: old,
+          stream_exact: true,
+        });
+        expect(oldBack).toHaveLength(0);
+        // Only the fresh stream remains.
+        const freshBack = await collect(store, {
+          stream: fresh,
+          stream_exact: true,
+        });
+        expect(freshBack).toHaveLength(1);
+      });
+
+      it("clears subscription/stream-position metadata", async () => {
+        const sub = `restore-sub-${uid()}`;
+        await store.subscribe([{ stream: sub, source: "anything" }]);
+        const collectStreams = async () => {
+          const out: string[] = [];
+          await store.query_streams((p) => {
+            out.push(p.stream);
+          });
+          return out;
+        };
+        const before = await collectStreams();
+        expect(before.includes(sub)).toBe(true);
+        await store.restore!(asSource([]));
+        const after = await collectStreams();
+        expect(after.includes(sub)).toBe(false);
+      });
+
+      it("preserves snapshot events through restore", async () => {
+        // SNAP_EVENT is a framework marker — restore writes it
+        // through but skips updating the max-non-snap-id indexes.
+        // Covers the `row.name !== SNAP_EVENT` false branch.
+        const s = `restore-snap-${uid()}`;
+        const t = new Date("2020-04-01T00:00:00.000Z");
+        await store.restore!(
+          asSource([
+            {
+              id: 1,
+              stream: s,
+              version: 0,
+              name: SNAP_EVENT,
+              data: { count: 42 },
+              created: t,
+              meta: { correlation: "snap", causation: {} },
+            },
+          ])
+        );
+        const back = await collect(store, {
+          stream: s,
+          stream_exact: true,
+          with_snaps: true,
+        });
+        expect(back).toHaveLength(1);
+        expect((back[0] as { name: string }).name).toBe(SNAP_EVENT);
+      });
+
+      it("rewrites causation refs through the old→new id map", async () => {
+        // Sparse source ids (5, 7, 9) — adapter renumbers densely;
+        // the row whose causation pointed at original id 5 must end
+        // up pointing at the new id assigned to that same row.
+        const s = `restore-caus-${uid()}`;
+        const t = new Date("2020-08-01T00:00:00.000Z");
+        const rows: RestoreRow[] = [
+          {
+            id: 5,
+            stream: s,
+            version: 0,
+            name: "Incremented",
+            data: { amount: 1 },
+            created: t,
+            meta: { correlation: "c", causation: {} },
+          },
+          {
+            id: 7,
+            stream: s,
+            version: 1,
+            name: "Incremented",
+            data: { amount: 2 },
+            created: t,
+            meta: {
+              correlation: "c",
+              causation: {
+                event: { id: 5, name: "Incremented", stream: s },
+              },
+            },
+          },
+          {
+            id: 9,
+            stream: s,
+            version: 2,
+            name: "Decremented",
+            data: { amount: 1 },
+            created: t,
+            meta: {
+              correlation: "c",
+              causation: {
+                event: { id: 7, name: "Incremented", stream: s },
+              },
+            },
+          },
+        ];
+        await store.restore!(asSource(rows));
+        const back: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            back.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(back).toHaveLength(3);
+        // First row's causation is empty.
+        expect(back[0].meta.causation.event).toBeUndefined();
+        // Second row's causation pointed at original id 5 → new id of row 0.
+        expect(back[1].meta.causation.event?.id).toBe(back[0].id);
+        // Third row's causation pointed at original id 7 → new id of row 1.
+        expect(back[2].meta.causation.event?.id).toBe(back[1].id);
+      });
+
+      it("leaves causation refs unmapped when the target isn't in the source", async () => {
+        const s = `restore-orphan-${uid()}`;
+        const t = new Date("2020-09-01T00:00:00.000Z");
+        await store.restore!(
+          asSource([
+            {
+              id: 1,
+              stream: s,
+              version: 0,
+              name: "Incremented",
+              data: { amount: 1 },
+              created: t,
+              meta: {
+                correlation: "c",
+                causation: {
+                  event: { id: 999, name: "Phantom", stream: "ghost" },
+                },
+              },
+            },
+          ])
+        );
+        const back: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            back.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(back[0].meta.causation.event?.id).toBe(999);
+      });
+
+      it("rolls back atomically when the source throws mid-iteration", async () => {
+        // Pre-seed some events the rollback must restore.
+        const original = `restore-pre-${uid()}`;
+        const committed = await store.commit<CounterEvents>(
+          original,
+          [inc(1), inc(2), inc(3)],
+          makeMeta({ stream: original })
+        );
+        const explosive: AsyncIterable<RestoreRow> = (async function* () {
+          yield row(
+            1,
+            `restore-explode-${uid()}`,
+            0,
+            "Incremented",
+            new Date(),
+            { amount: 1 }
+          );
+          throw new Error("boom");
+        })();
+        await expect(store.restore!(explosive)).rejects.toThrow("boom");
+        // Pre-call events still there.
+        const back: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            back.push(e);
+          },
+          { stream: original, stream_exact: true }
+        );
+        expect(back).toHaveLength(3);
+        expect(back.map((e) => e.id)).toEqual(committed.map((c) => c.id));
       });
     });
 

--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -20,6 +20,9 @@ import type {
   QueryStatsOptions,
   QueryStreams,
   QueryStreamsResult,
+  RestoreOptions,
+  RestoreResult,
+  RestoreRow,
   Schema,
   Schemas,
   Store,
@@ -927,5 +930,107 @@ export class InMemoryStore implements Store {
     for (const id of this._maxEventIdByStream.values()) if (id > max) max = id;
     this._maxNonSnapEventId = max;
     return result;
+  }
+
+  /**
+   * Atomically rebuild the store from a stream of {@link RestoreRow}.
+   *
+   * Captures every index state up front, clears it, then iterates the
+   * source. Any throw mid-iteration restores the snapshot, leaving
+   * the store byte-for-byte unchanged from the operator's
+   * perspective.
+   *
+   * `id`s are reassigned `0..N-1` as rows arrive (matching the
+   * adapter's commit-id convention — InMemory uses `_events.length`).
+   * `created` is preserved verbatim from the source. Causation
+   * references in `meta.causation.event.id` are remapped via the
+   * `old → new` table that's built as rows land — references to ids
+   * not in the source pass through unchanged.
+   */
+  async restore(
+    source: AsyncIterable<RestoreRow>,
+    _opts: RestoreOptions = {}
+  ): Promise<RestoreResult> {
+    await sleep();
+    const started = Date.now();
+    // Snapshot every index so we can roll back on throw.
+    const prevEvents = this._events;
+    const prevStreams = this._streams;
+    const prevStreamVersions = this._streamVersions;
+    const prevMaxEventIdByStream = this._maxEventIdByStream;
+    const prevMaxNonSnapEventId = this._maxNonSnapEventId;
+    // Swap in fresh state for the duration of the rebuild.
+    this._events = [];
+    this._streams = new Map();
+    this._streamVersions = new Map();
+    this._maxEventIdByStream = new Map();
+    this._maxNonSnapEventId = -1;
+    // `old_id → new_id` map for causation remap. Populated as rows
+    // land so causation chains that quote earlier events resolve
+    // naturally (causation always points at lower ids).
+    const idMap = new Map<number, number>();
+    try {
+      let kept = 0;
+      for await (const row of source) {
+        const id = this._events.length;
+        const created =
+          row.created instanceof Date ? row.created : new Date(row.created);
+        // Rewrite causation refs to the new id space.
+        let meta = row.meta;
+        const causedBy = meta.causation.event?.id;
+        if (causedBy !== undefined) {
+          const remapped = idMap.get(causedBy);
+          if (remapped !== undefined && remapped !== causedBy) {
+            meta = {
+              ...meta,
+              causation: {
+                ...meta.causation,
+                event: { ...meta.causation.event!, id: remapped },
+              },
+            };
+          }
+        }
+        const committed: Committed<Schemas, keyof Schemas> = {
+          id,
+          stream: row.stream,
+          version: row.version,
+          created,
+          name: row.name,
+          data: row.data as Schemas[keyof Schemas],
+          meta,
+        };
+        this._events.push(committed);
+        idMap.set(row.id, id);
+        // Last row per stream wins for the version watermark — the
+        // source is expected to be in commit order, so this is also
+        // the highest version. We don't comparison-guard because the
+        // source contract is "give me events in order"; out-of-order
+        // sources get last-wins, which is no worse than the legacy
+        // raw-SQL restore.
+        this._streamVersions.set(row.stream, row.version);
+        if (row.name !== SNAP_EVENT) {
+          this._maxEventIdByStream.set(row.stream, id);
+          // `id` is `_events.length` post-push; monotonically grows
+          // within the restore loop. No `>` comparison needed.
+          this._maxNonSnapEventId = id;
+        }
+        kept++;
+      }
+      return {
+        kept,
+        duration_ms: Date.now() - started,
+        dropped: { closed_streams: 0, snapshots: 0, empty_streams: 0 },
+        dry_run: false,
+      };
+    } catch (err) {
+      // Roll back to the captured snapshot — every index restored
+      // exactly as it was before the call started.
+      this._events = prevEvents;
+      this._streams = prevStreams;
+      this._streamVersions = prevStreamVersions;
+      this._maxEventIdByStream = prevMaxEventIdByStream;
+      this._maxNonSnapEventId = prevMaxNonSnapEventId;
+      throw err;
+    }
   }
 }

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -73,6 +73,81 @@ export type TruncateResult = Map<
 >;
 
 /**
+ * Source row consumed by {@link Store.restore}.
+ *
+ * Each row carries the columns adapters need to rebuild a Committed
+ * event: stream, version, name, data, meta, and the original
+ * `created` timestamp.
+ *
+ * `id` is the **original** event id from the source. Adapters do not
+ * write this value through — restore renumbers ids densely (`1..N`
+ * on PG/SQLite, `0..N-1` on InMemory). The original id is retained
+ * here purely as a lookup key so adapters can build a per-call
+ * `old → new` map and rewrite causation references in `meta` that
+ * pointed at other events in the source.
+ *
+ * `created` accepts a `Date` or an ISO string so callers can stream
+ * CSV / JSONL rows without parsing dates eagerly.
+ */
+export type RestoreRow = {
+  /** Original event id from the source — used only for causation remap. */
+  readonly id: number;
+  readonly name: string;
+  readonly data: unknown;
+  readonly stream: string;
+  readonly version: number;
+  readonly created: string | Date;
+  readonly meta: EventMeta;
+};
+
+/**
+ * Options for {@link Store.restore}.
+ *
+ * Empty in v1 — the type is declared so {@link Store.restore} ships
+ * with a stable shape that #784 and #785 can extend additively. Those
+ * tickets own the design of the extension fields; this file does not
+ * preempt them.
+ */
+export type RestoreOptions = {
+  /**
+   * Reserved for future fields. Empty in the v1 surface so the call
+   * site (`store.restore(source, {})`) is forward-compatible.
+   */
+  readonly _reserved?: never;
+};
+
+/**
+ * Result of {@link Store.restore}.
+ *
+ * `kept` and `duration_ms` are populated in v1. The other fields
+ * (`dropped`, `dry_run`) are placeholders kept stable so #784 can
+ * light them up without changing the response shape; they're always
+ * zero / `false` on the v1 path. The semantics of `dry_run` will be
+ * defined by #784 (specifically: a pre-flight scan that surfaces
+ * blockers — version-contiguity gaps, broken causation refs,
+ * duplicate ids, malformed timestamps — without writing).
+ */
+export type RestoreResult = {
+  /** Number of rows written to the rebuilt store. */
+  readonly kept: number;
+  /** Wall-clock duration of the restore call, in milliseconds. */
+  readonly duration_ms: number;
+  /**
+   * Compaction-drop counters. All zero in v1; #784 populates.
+   */
+  readonly dropped: {
+    readonly closed_streams: number;
+    readonly snapshots: number;
+    readonly empty_streams: number;
+  };
+  /**
+   * `true` when the call ran in dry-run / blocker-scan mode. Always
+   * `false` in v1; #784 wires up the option that flips it.
+   */
+  readonly dry_run: boolean;
+};
+
+/**
  * Payload delivered by {@link Store.notify} when a **different process**
  * commits one or more events to the same backing store.
  *
@@ -745,6 +820,76 @@ export interface Store extends Disposable {
       meta?: EventMeta;
     }>
   ) => Promise<TruncateResult>;
+
+  /**
+   * Atomically rebuild the store from a stream of {@link RestoreRow}.
+   *
+   * **Capability-gated.** Adapters may or may not implement restore.
+   * Callers must guard (`if (store.restore) …`) or rely on the TCK
+   * `restore` capability flag. All three in-tree adapters (InMemory,
+   * PG, SQLite) ship it; third-party stores that can't atomically
+   * wipe-and-rebuild can omit.
+   *
+   * Wipes every event and every subscription/stream-position row
+   * before inserting the source. The whole call runs inside a
+   * transaction (PG `BEGIN`/`COMMIT`, SQLite `BEGIN IMMEDIATE`, an
+   * in-process snapshot for {@link InMemoryStore}) — any error during
+   * the rebuild rolls back to the pre-call state.
+   *
+   * **Lossless `created`.** Source rows carry their original
+   * timestamp; adapters write it through verbatim. This is the
+   * property that makes restore a viable backup/migration primitive
+   * — distinct from {@link commit}, which always stamps `now()`.
+   *
+   * **Renumbered `id` + causation remap.** Restore reseeds ids
+   * densely (`1..N` on PG/SQLite, `0..N-1` on InMemory). The
+   * source's original ids are not written, but they are used as
+   * lookup keys: as each row is inserted, the adapter records
+   * `old → new` and rewrites `meta.causation.event.id` on subsequent
+   * rows so causation chains stay intact across the renumber.
+   * References to ids that don't appear in the source (partial
+   * backups) are left as-is.
+   *
+   * **No subscription preservation.** Both the events and the
+   * streams/subscriptions tables are wiped. Reactions re-subscribe
+   * via the orchestrator's normal `correlate()` path on the next
+   * settle cycle; operators may need to `unblock`/`reset` projections
+   * that were tracking pre-restore watermarks.
+   *
+   * **Cache.** Restore does not touch the {@link Cache} port —
+   * callers must `cache().clear()` after restore to avoid serving
+   * stale snapshots. Documented; not enforced.
+   *
+   * @param source - Async stream of rows in target order. Streamed
+   *   rather than buffered so multi-million-row backups don't OOM
+   *   the server.
+   * @param opts - {@link RestoreOptions}. Empty in v1; #784 / #785
+   *   extend.
+   * @returns {@link RestoreResult} with `kept` count + `duration_ms`.
+   *
+   * @example Round-trip a CSV backup
+   * ```typescript
+   * async function* parseCsv(blob: string): AsyncIterable<RestoreRow> {
+   *   for (const line of blob.split("\n").slice(1)) {
+   *     const [id, name, data, stream, version, created, meta] = parse(line);
+   *     yield { id: +id, name, data: JSON.parse(data), stream,
+   *             version: +version, created, meta: JSON.parse(meta) };
+   *   }
+   * }
+   * if (!store().restore) throw new Error("adapter has no restore");
+   * const result = await store().restore!(parseCsv(csvBlob), {});
+   * console.log(`Restored ${result.kept} events in ${result.duration_ms}ms`);
+   * await cache().clear();   // operator's responsibility
+   * ```
+   *
+   * @see {@link RestoreRow}, {@link RestoreOptions}, {@link RestoreResult}
+   * @see {@link truncate} for the single-stream snapshot/tombstone
+   *   primitive (different operation — restore wipes the whole store)
+   */
+  restore?: (
+    source: AsyncIterable<RestoreRow>,
+    opts?: RestoreOptions
+  ) => Promise<RestoreResult>;
 
   /**
    * Streams registered subscription positions to a callback, plus the

--- a/libs/act/test/store-tck.spec.ts
+++ b/libs/act/test/store-tck.spec.ts
@@ -4,4 +4,5 @@ import { InMemoryStore } from "../src/adapters/in-memory-store.js";
 runStoreTck({
   name: "InMemoryStore",
   factory: () => new InMemoryStore(),
+  capabilities: { restore: true },
 });


### PR DESCRIPTION
Closes #783.

Promotes `restore` from the inspector's raw-SQL escape hatch to a charter-covered method on the `Store` port. Capability-gated (`restore?:`) so future third-party adapters can opt out cleanly — matching the pattern `Store.notify` already uses — with all three in-tree adapters (InMemory, PG, SQLite) shipping it. Critical-path slice of the ACT-1120 saga: once merged, Group 3 (inspector rewrite onto the port at #786, UI work at #787, cross-adapter migration at #788) unblocks.

## Port surface

`libs/act/src/types/ports.ts` gains three types and one optional method:

```ts
type RestoreRow = {
  readonly id: number;            // original id — lookup key for causation remap
  readonly name: string;
  readonly data: unknown;
  readonly stream: string;
  readonly version: number;
  readonly created: string | Date;
  readonly meta: EventMeta;
};

type RestoreOptions = { readonly _reserved?: never };

type RestoreResult = {
  readonly kept: number;
  readonly duration_ms: number;
  readonly dropped: {
    readonly closed_streams: number;
    readonly snapshots: number;
    readonly empty_streams: number;
  };
  readonly dry_run: boolean;
};

interface Store {
  restore?: (
    source: AsyncIterable<RestoreRow>,
    opts?: RestoreOptions
  ) => Promise<RestoreResult>;
}
```

Naming follows Act's snake_case convention for fields (`duration_ms`, `closed_streams`, `empty_streams`, `dry_run`). Types stay PascalCase.

## Semantics

- **Atomic wipe-and-rebuild.** PG wraps in `BEGIN`/`COMMIT` and uses `TRUNCATE ... RESTART IDENTITY CASCADE` + per-row `INSERT`. SQLite uses libsql's `write` transaction with `DELETE FROM events`/`DELETE FROM streams` + `DELETE FROM sqlite_sequence WHERE name = 'events'` + per-row `INSERT`. InMemory snapshots every index, swaps in fresh state, and restores the snapshot on any throw.
- **Streamed source.** `AsyncIterable<RestoreRow>` — multi-million-row backups don't OOM. The inspector's existing CSV-as-string path was already pinching past ~5M events; the port-level shape forces lazy iteration on every caller.
- **Lossless `created`.** Source rows carry their original timestamp; adapters write it through verbatim. This is the property that makes restore a viable backup/migration primitive — distinct from `commit`, which always stamps `now()`.
- **Renumbered `id` + causation remap.** Restore reseeds ids densely (1..N on PG/SQLite, 0..N-1 on InMemory). The source's original ids are not written but are retained on `RestoreRow.id` as lookup keys: as each row is inserted, adapters record `old → new` and rewrite `meta.causation.event.id` on subsequent rows so causation chains stay intact across the renumber. References to ids not in the source (partial backups) pass through unchanged. This is the bug the legacy raw-SQL restore had for as long as it existed — fixed at the port level so it can't recur.
- **No subscription preservation.** Both events and streams/subscriptions tables are wiped. Reactions re-subscribe via the orchestrator's normal `correlate()` path on the next settle cycle.
- **Cache.** Restore does not touch the `Cache` port — callers must `cache().clear()` after restore. Documented in `extension-points.md`.

## TCK

`libs/act-tck/src/store-tck.ts` gains a `describe.skipIf(!caps.restore)("restore (capability)", …)` block with 10 cases:

1. Empty source — kept=0, result shape correct, store ends empty.
2. Single-stream happy path — `created` preserved, versions intact.
3. Multi-stream interleaved.
4. ISO-string `created` parses to Date.
5. Pre-existing data wiped before insert.
6. Subscription/stream-position metadata cleared.
7. Snapshot (`__snapshot__`) event preserved through restore.
8. Causation remap through sparse source ids (5, 7, 9 → 1, 2, 3 with `meta.causation.event.id` rewritten).
9. Orphan causation refs (target not in source) pass through unchanged.
10. Atomic rollback when source throws mid-iteration.

`describe.skipIf(!caps.restore)` rather than `if (caps.restore) { describe(...) }` so the gating lives inside vitest's skip mechanism instead of an `if` branch every consumer would have to disprove (all three in-tree adapters opt in).

`StoreCapabilities` gains a `restore?: boolean` flag. InMemory, PG, and SQLite TCK spec files declare it.

## Per-adapter implementations

- **`libs/act/src/adapters/in-memory-store.ts`** — captures `_events` + four index Maps before wiping, restores them on throw. The causation-remap inline rewrites `meta.causation.event.id` per row via an in-memory `old → new` Map.
- **`libs/act-pg/src/postgres-store.ts`** — `TRUNCATE … RESTART IDENTITY CASCADE` on the events table, plain `TRUNCATE` on the streams table, then `INSERT` per row capturing `RETURNING id` for the remap.
- **`libs/act-sqlite/src/sqlite-store.ts`** — `DELETE FROM events` + `DELETE FROM streams` + `DELETE FROM sqlite_sequence WHERE name = 'events'` (resets autoincrement) inside `transaction("write")`, then per-row `INSERT` capturing `lastInsertRowid` for the remap.

## Coverage gap closed

The PG ROLLBACK no-op catch handler (`await client.query("ROLLBACK").catch(() => {})`) is exercised via a new fault-injection spec in `libs/act-pg/test/store.error.spec.ts` that drives both the TRUNCATE and the subsequent ROLLBACK through rejecting mocks. Without it the function counter dipped to 97.43% — every other metric was already 100%.

The InMemory restore simplified two unreachable conditionals (the version-monotonic `if (cur === undefined || row.version > cur)` and the `if (id > _maxNonSnapEventId)` inside the SNAP_EVENT block) — both always evaluated to true within the restore loop, leaving the false branches forever uncovered. Removing the conditionals is behavior-preserving and brings branch coverage to 100%.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1835 passed / 1835 across the workspace (10 new TCK cases × 3 adapters minus the 2 PG cases that depend on Docker = 28 fresh test results)
- Coverage: 100% statements / 100% branches / 100% functions / 100% lines.
- [x] `pnpm -F @rotorsoft/act test` — InMemory TCK 77/77 incl. the new restore block
- [x] `pnpm -F @rotorsoft/act-pg test` — PG TCK + error spec, all passing against the local Docker PG (port 5431)
- [x] `pnpm -F @rotorsoft/act-sqlite test` — SQLite TCK incl. restore
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — all packages
- [ ] CI conformance matrix (PG 14/15/16/17, libsql pinned + latest) — verifies the TCK restore block against every supported backend version
- [ ] Manual smoke against a real backup: round-trip a wolfdesk PG store via `pnpm act -q backup | restore` (handled by #786 when it lands)
- [ ] Review

## Stability charter impact

**Charter surface touched: `libs/act/src/types/ports.ts`** — adds the new `RestoreRow`, `RestoreOptions`, `RestoreResult` types and the `Store.restore?` optional method.

**Category: additive.** Existing adapters keep passing the TCK without opting in (the `describe.skipIf` gate). The `RestoreOptions` placeholder shape (`{ _reserved?: never }`) admits future fields (#784 compaction toggles, #785 migration overlay) without breaking changes. `RestoreResult` carries placeholder `dropped` / `dry_run` fields that #784 lights up — same response shape from day one.

Per `STABILITY.md`'s existing policy ("Adding an optional method gated by a Capabilities flag in the TCK is not breaking"), no `BREAKING CHANGE:` footer required. Architecture doc updated in this PR (`docs/docs/architecture/extension-points.md`); deeper `writing-a-store.md` revision tracked under #789 alongside the production-checklist and event-sourcing doc updates.

## Follow-ups

Tracked under the saga master #790:

- **#784** — ACT-1125: compaction toggles (`dropClosedStreams`, `dropSnapshots`, `dropEmptyStreams`, `dryRun`, `onProgress`). The `dry_run` semantic is reserved for the blocker-scan reframing (pre-flight validates the source) — #784 owns the design.
- **#785** — ACT-1126: migration overlay (`eventNameMap`, `transform`, `streamRename`).
- **#786** — ACT-1127: rewrite the inspector's restore procedure onto `Store.restore`; removes the last raw-SQL chunk and the `getRawPgClient` helper.
- **#787** — ACT-1128: inspector restore UI (dry-run preview, compaction toggles, progress, summary).
- **#788** — ACT-1129: cross-adapter migration affordance (PG backup → SQLite restore and vice versa).
- **#789** — ACT-1130: doc updates (`writing-a-store.md`, `production-checklist.md`, `event-sourcing.md`).

Also filed alongside: **#802 / ACT-1132** — online close-the-books placeholder, the natural future sibling of restore (operator-driven offline wipe vs. policy-driven online truncate). Design TBD.

Book note: `book/act-1124-store-restore.md` captures the four rejected designs (passive defaults on every option, required-on-`Store`, renumber without causation remap, premature `Act.restore` + lifecycle event) and the load-bearing insight — legacy raw-SQL behavior carried forward verbatim becomes contract once it sits on the port, so audit what the SQL was implicitly doing before lifting it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>