### PR TITLE
refactor(act-inspector): rewrite restore onto Store.restore (ACT-1127)

### DIFF
--- a/packages/inspector/src/client/components/BackupRestore.tsx
+++ b/packages/inspector/src/client/components/BackupRestore.tsx
@@ -12,11 +12,12 @@ export function BackupRestore() {
     csv: string;
   } | null>(null);
 
-  // `restore` is PG-only until #786 ports it to `Store.restore`. The
-  // status query surfaces the adapter so the UI can gate the button
-  // instead of letting the operator click into a server error.
+  // ACT-1127 rewrote restore onto `Store.restore`, so any
+  // adapter that declares the `restore` capability is supported.
+  // The status query still drives the disabled state for the
+  // pre-connect case (no active store).
   const { data: status } = trpc.status.useQuery();
-  const restoreEnabled = status?.adapter === "pg";
+  const restoreEnabled = status?.connected === true;
 
   const backupMutation = trpc.backup.useMutation({
     onSuccess(data) {
@@ -103,7 +104,7 @@ export function BackupRestore() {
           title={
             restoreEnabled
               ? "Restore events from CSV"
-              : "Restore is PG-only — coming to other adapters in ACT-1127"
+              : "Connect to a store to enable restore"
           }
           className="rounded p-1.5 text-zinc-500 transition hover:bg-zinc-800 hover:text-zinc-300 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
         >

--- a/packages/inspector/src/client/views/Monitor.tsx
+++ b/packages/inspector/src/client/views/Monitor.tsx
@@ -216,18 +216,38 @@ export function Monitor({ onStream, onBlockedCount }: MonitorProps) {
  * count. Cleared on server restart — this is operational breadcrumbs,
  * not a compliance log.
  */
+// ACT-1127 widened the audit log to a discriminated union — restore
+// entries carry the full RestoreResult instead of priority/affected.
+type AuditEntry =
+  | {
+      timestamp: string;
+      action: "prioritize";
+      filter: Record<string, unknown>;
+      priority: number;
+      affected: number;
+    }
+  | {
+      timestamp: string;
+      action: "restore";
+      adapter: "pg" | "sqlite" | "inmemory";
+      result: {
+        kept: number;
+        duration_ms: number;
+        dropped: {
+          closed_streams: number;
+          snapshots: number;
+          empty_streams: number;
+        };
+        dry_run: boolean;
+      };
+    };
+
 function AuditPanel({
   writeEnabled,
   entries,
 }: {
   writeEnabled: boolean;
-  entries: ReadonlyArray<{
-    timestamp: string;
-    action: string;
-    filter: Record<string, unknown>;
-    priority: number;
-    affected: number;
-  }>;
+  entries: ReadonlyArray<AuditEntry>;
 }) {
   return (
     <div className="flex flex-1 flex-col border-t border-zinc-800 pt-3">
@@ -267,19 +287,38 @@ function AuditPanel({
                 <span className="font-mono">{e.action}</span>
                 <span>{new Date(e.timestamp).toLocaleTimeString()}</span>
               </div>
-              <div className="mt-1 font-mono text-zinc-300">
-                p={e.priority}{" "}
-                <span className="text-zinc-600">→</span>{" "}
-                <span className="text-amber-300">{e.affected} streams</span>
-              </div>
-              <div
-                className="truncate font-mono text-[9px] text-zinc-600"
-                title={JSON.stringify(e.filter)}
-              >
-                {Object.keys(e.filter).length === 0
-                  ? "all streams"
-                  : JSON.stringify(e.filter)}
-              </div>
+              {e.action === "prioritize" ? (
+                <>
+                  <div className="mt-1 font-mono text-zinc-300">
+                    p={e.priority}{" "}
+                    <span className="text-zinc-600">→</span>{" "}
+                    <span className="text-amber-300">
+                      {e.affected} streams
+                    </span>
+                  </div>
+                  <div
+                    className="truncate font-mono text-[9px] text-zinc-600"
+                    title={JSON.stringify(e.filter)}
+                  >
+                    {Object.keys(e.filter).length === 0
+                      ? "all streams"
+                      : JSON.stringify(e.filter)}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="mt-1 font-mono text-zinc-300">
+                    <span className="text-amber-300">
+                      {e.result.kept.toLocaleString()} events
+                    </span>{" "}
+                    <span className="text-zinc-600">in</span>{" "}
+                    {e.result.duration_ms}ms
+                  </div>
+                  <div className="truncate font-mono text-[9px] text-zinc-600">
+                    adapter: {e.adapter}
+                  </div>
+                </>
+              )}
             </li>
           ))}
         </ul>

--- a/packages/inspector/src/server/router.ts
+++ b/packages/inspector/src/server/router.ts
@@ -1,6 +1,8 @@
 import {
   type Committed,
   InMemoryStore,
+  type RestoreResult,
+  type RestoreRow,
   type Schemas,
   type Store,
   type StreamPosition,
@@ -8,7 +10,6 @@ import {
 import { PostgresStore } from "@rotorsoft/act-pg";
 import { SqliteStore } from "@rotorsoft/act-sqlite";
 import { initTRPC } from "@trpc/server";
-import pg from "pg";
 import { z } from "zod";
 import {
   PG_PORT_RANGE_END,
@@ -38,13 +39,20 @@ const writeEnabled = process.env.ACT_INSPECTOR_WRITE === "1";
  * ago?" without persistent storage. Bounded to keep memory usage flat;
  * older entries fall off as new ones land. Cleared on process restart.
  */
-type AuditEntry = {
-  readonly timestamp: string;
-  readonly action: "prioritize";
-  readonly filter: Record<string, unknown>;
-  readonly priority: number;
-  readonly affected: number;
-};
+type AuditEntry =
+  | {
+      readonly timestamp: string;
+      readonly action: "prioritize";
+      readonly filter: Record<string, unknown>;
+      readonly priority: number;
+      readonly affected: number;
+    }
+  | {
+      readonly timestamp: string;
+      readonly action: "restore";
+      readonly adapter: AdapterConfig["adapter"];
+      readonly result: RestoreResult;
+    };
 const AUDIT_CAPACITY = 100;
 const auditLog: AuditEntry[] = [];
 const recordAudit = (entry: AuditEntry): void => {
@@ -268,28 +276,38 @@ function csvParseLine(line: string): string[] {
 }
 
 /**
- * Get a raw pg client for direct queries.
- *
- * PG-only by design — narrows the {@link AdapterConfig} discriminator and
- * throws on any non-PG adapter. The guard is a noop today (only PG can
- * connect) but makes #782 safe to add the SQLite branch without inventing
- * a fake `pg.Client`. The whole helper goes away in #786 once `restore`
- * rides `Store.restore`.
+ * Stream a CSV blob into `AsyncIterable<RestoreRow>` consumed by
+ * `Store.restore` (#786). The blob still arrives as a single string
+ * from the tRPC input, but the parser yields one row at a time so
+ * the adapter never holds the full parsed array in memory alongside
+ * the source. The header row format matches `backup`'s output —
+ * round-tripping is the primary use case.
  */
-async function getRawPgClient(): Promise<pg.Client> {
-  if (!currentConfig) throw new Error("Not connected to a store");
-  if (currentConfig.adapter !== "pg")
-    throw new Error("Raw PG client requires a PG-backed inspector connection");
-  const client = new pg.Client({
-    host: currentConfig.host,
-    port: currentConfig.port,
-    database: currentConfig.database,
-    user: currentConfig.user,
-    password: currentConfig.password,
-    connectionTimeoutMillis: 5000,
-  });
-  await client.connect();
-  return client;
+async function* parseCsvRows(csv: string): AsyncIterable<RestoreRow> {
+  const lines = csv.split("\n");
+  if (lines.length < 2)
+    throw new Error("CSV must have a header and at least one row");
+  const expectedHeader = CSV_COLUMNS.join(",");
+  if (lines[0] !== expectedHeader)
+    throw new Error(`Invalid CSV header. Expected: ${expectedHeader}`);
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.trim()) continue;
+    const fields = csvParseLine(line);
+    if (fields.length !== CSV_COLUMNS.length)
+      throw new Error(
+        `Row ${i}: expected ${CSV_COLUMNS.length} fields, got ${fields.length}`
+      );
+    yield {
+      id: Number.parseInt(fields[0]!, 10),
+      name: fields[1]!,
+      data: JSON.parse(fields[2]!),
+      stream: fields[3]!,
+      version: Number.parseInt(fields[4]!, 10),
+      created: fields[5]!,
+      meta: JSON.parse(fields[6]!),
+    };
+  }
 }
 
 export const inspectorRouter = t.router({
@@ -1027,72 +1045,43 @@ export const inspectorRouter = t.router({
     capacity: AUDIT_CAPACITY,
   })),
 
-  /** Restore events from CSV — drops and re-seeds the store, inserts with sequential IDs */
+  /**
+   * Restore events from a CSV blob via `Store.restore`.
+   *
+   * Pre-ACT-1127 this opened a raw `pg.Client` and ran TRUNCATE +
+   * INSERT against PG only. Now it streams the CSV into the active
+   * adapter's port-level restore, so every adapter that declares
+   * the `restore` capability (today: InMemory, PG, SQLite) is
+   * supported. The adapter handles atomicity, id-renumbering, and
+   * causation-remap; the inspector just streams rows and records
+   * the result in its audit log.
+   *
+   * Return shape carries both `count` (back-compat with pre-1127
+   * callers) and the full `RestoreResult` (for #787's UI to render
+   * `duration_ms`, `dropped` counters, etc.).
+   */
   restore: t.procedure
     .input(z.object({ csv: z.string() }))
     .mutation(async ({ input }) => {
-      if (!currentConfig) throw new Error("Not connected to a store");
-      if (currentConfig.adapter !== "pg")
+      const s = getStore();
+      if (!s.restore)
         throw new Error(
-          "Restore currently requires a PG-backed inspector connection"
+          "Active adapter does not support restore — see ACT-1124 for the capability contract"
         );
-      const fqt = `"${currentConfig.schema}"."${currentConfig.table}"`;
-      const fqs = `"${currentConfig.schema}"."${currentConfig.table}_streams"`;
-
-      // Parse CSV
-      const lines = input.csv.split("\n").filter((l) => l.trim());
-      if (lines.length < 2)
-        throw new Error("CSV must have a header and at least one row");
-
-      const headerFields = lines[0].split(",");
-      const expectedHeader = CSV_COLUMNS.join(",");
-      if (headerFields.join(",") !== expectedHeader)
-        throw new Error(`Invalid CSV header. Expected: ${expectedHeader}`);
-
-      const rows = lines.slice(1).map((line, lineIdx) => {
-        const fields = csvParseLine(line);
-        if (fields.length !== CSV_COLUMNS.length)
-          throw new Error(
-            `Row ${lineIdx + 1}: expected ${CSV_COLUMNS.length} fields, got ${fields.length}`
-          );
-        return {
-          name: fields[1],
-          data: JSON.parse(fields[2]),
-          stream: fields[3],
-          version: parseInt(fields[4], 10),
-          created: fields[5],
-          meta: JSON.parse(fields[6]),
-        };
-      });
-
-      // Drop existing data and re-seed
-      const client = await getRawPgClient();
       try {
-        await client.query("BEGIN");
-
-        // Truncate events and streams tables, reset sequence
-        await client.query(`TRUNCATE TABLE ${fqt} RESTART IDENTITY CASCADE`);
-        await client.query(`TRUNCATE TABLE ${fqs}`);
-
-        // Insert events preserving original order (new sequential IDs from 1)
-        for (const row of rows) {
-          await client.query(
-            `INSERT INTO ${fqt}(name, data, stream, version, created, meta)
-             VALUES($1, $2, $3, $4, $5, $6)`,
-            [row.name, row.data, row.stream, row.version, row.created, row.meta]
-          );
-        }
-
-        await client.query("COMMIT");
-        return { ok: true as const, count: rows.length };
+        const result = await s.restore(parseCsvRows(input.csv), {});
+        recordAudit({
+          timestamp: new Date().toISOString(),
+          action: "restore",
+          adapter: currentConfig!.adapter,
+          result,
+        });
+        return { ok: true as const, count: result.kept, result };
       } catch (error) {
-        await client.query("ROLLBACK").catch(() => {});
         throw new Error(
           `Restore failed: ${error instanceof Error ? error.message : String(error)}`,
           { cause: error }
         );
-      } finally {
-        await client.end();
       }
     }),
 });

--- a/packages/inspector/test/connection.spec.ts
+++ b/packages/inspector/test/connection.spec.ts
@@ -108,18 +108,68 @@ describe("discover", () => {
   });
 });
 
-describe("restore adapter guard", () => {
-  it("refuses to run on a non-PG adapter", async () => {
-    await caller.connect({ adapter: "inmemory" });
-    await expect(caller.restore({ csv: "" })).rejects.toThrow(
-      "Restore currently requires a PG-backed inspector connection"
-    );
-  });
-
+describe("restore via Store.restore (ACT-1127)", () => {
   it("refuses to run before any connect", async () => {
     await expect(caller.restore({ csv: "" })).rejects.toThrow(
       "Not connected to a store"
     );
+  });
+
+  it("rejects malformed CSV with a clear error", async () => {
+    await caller.connect({ adapter: "inmemory" });
+    await expect(caller.restore({ csv: "" })).rejects.toThrow(
+      /Restore failed.*at least one row/
+    );
+  });
+
+  it("round-trips a backup through the active inmemory store", async () => {
+    await caller.connect({ adapter: "inmemory" });
+    const store = getActiveStore()!;
+    // Seed a few events the inspector will back up.
+    const stream = "round-trip-stream";
+    await store.commit(
+      stream,
+      [
+        { name: "Opened", data: { id: 1 } },
+        { name: "Updated", data: { id: 1, field: "x" } },
+      ],
+      { correlation: "round-trip", causation: {} }
+    );
+    const backup = await caller.backup({});
+    expect(backup.count).toBe(2);
+    // Reconnect (fresh inmemory store), then restore from the backup.
+    await caller.connect({ adapter: "inmemory" });
+    const result = await caller.restore({ csv: backup.csv });
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(2);
+    expect(result.result.kept).toBe(2);
+    expect(result.result.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(result.result.dry_run).toBe(false);
+    // Verify the post-restore store has the events back.
+    const verify = await caller.query({});
+    expect(verify.events).toHaveLength(2);
+    expect(verify.events.map((e) => e.name)).toEqual(["Opened", "Updated"]);
+  });
+
+  it("records the restore in the audit log with the adapter + result", async () => {
+    await caller.connect({ adapter: "inmemory" });
+    const store = getActiveStore()!;
+    await store.commit("audited-stream", [{ name: "Tick", data: {} }], {
+      correlation: "audit",
+      causation: {},
+    });
+    const backup = await caller.backup({});
+    await caller.connect({ adapter: "inmemory" });
+    const baselineEntries = (await caller.audit()).entries.length;
+    await caller.restore({ csv: backup.csv });
+    const audit = await caller.audit();
+    expect(audit.entries.length).toBe(baselineEntries + 1);
+    const entry = audit.entries[0]!;
+    expect(entry.action).toBe("restore");
+    if (entry.action === "restore") {
+      expect(entry.adapter).toBe("inmemory");
+      expect(entry.result.kept).toBe(1);
+    }
   });
 });
 
@@ -184,14 +234,24 @@ describe("connect (sqlite)", () => {
     }
   });
 
-  it("blocks restore when the connection is SQLite-backed", async () => {
+  it("supports restore on a SQLite-backed connection (ACT-1127)", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "act-inspector-conn-sqlite-rs-"));
     try {
       const file = await buildActFile();
       await caller.connect({ adapter: "sqlite", file });
-      await expect(caller.restore({ csv: "" })).rejects.toThrow(
-        "Restore currently requires a PG-backed inspector connection"
-      );
+      const store = getActiveStore()!;
+      await store.commit("sqlite-stream", [{ name: "Tick", data: { n: 1 } }], {
+        correlation: "sqlite-restore",
+        causation: {},
+      });
+      const backup = await caller.backup({});
+      // Reconnect to a fresh SQLite file, then restore.
+      const file2 = await buildActFile("store-2.db");
+      await caller.connect({ adapter: "sqlite", file: file2 });
+      const result = await caller.restore({ csv: backup.csv });
+      expect(result.ok).toBe(true);
+      expect(result.count).toBe(1);
+      expect(result.result.kept).toBe(1);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #786.

Deletes the inspector's raw-SQL restore path and rewires the procedure onto the `Store.restore` port method that shipped in #783. The procedure now works against every adapter that declares the `restore` capability — InMemory, PG, SQLite — so the PG-only gate on the UI Restore button comes off, the audit log captures restore mutations alongside prioritize, and the only remaining raw `pg.Client` callsite in the inspector goes with the change.

## Server

`packages/inspector/src/server/router.ts`:

- **Deletes the raw-SQL restore body** (~70 lines). No more `BEGIN`/`TRUNCATE`/`INSERT` in the inspector — the whole transaction sits behind `currentStore.restore!(source, opts)`.
- **Deletes `getRawPgClient`** and the `pg` module import. Both had exactly one caller (restore) and that caller is gone.
- **Deletes the `currentConfig.adapter !== \"pg\"` guard** from restore. Every capability-bearing adapter is supported.
- **New `parseCsvRows` async generator** streams the CSV blob into `AsyncIterable<RestoreRow>`. The adapter pulls rows lazily — multi-million-row backups don't hold the parsed array in memory alongside the source string.
- **Widens `AuditEntry`** to a discriminated union: prioritize entries keep their existing shape, restore entries carry `adapter: AdapterConfig[\"adapter\"]` + the full `RestoreResult`. The most destructive inspector mutation was previously unaudited; this closes the gap.
- **Return shape carries both `count` and `result`** — `{ ok: true, count: result.kept, result: RestoreResult }`. `count` preserves back-compat with the existing `BackupRestore.tsx` callsite; `result` exposes `duration_ms` + the placeholder `dropped` / `dry_run` fields so #787's restore UI can render them without a second round trip.
- **Capability check** when the active adapter doesn't implement `restore`: throws an actionable error pointing at ACT-1124 rather than crashing on `s.restore!(...)`.

## Client

- **`BackupRestore.tsx`** drops the `status.adapter === \"pg\"` gate. The disabled state now reflects only the pre-connect case (\"Connect to a store to enable restore\"). Tooltip updated accordingly.
- **`Monitor.tsx`'s `AuditPanel`** widens its entries prop to the discriminated union and renders restore entries with a kept-count + duration + adapter badge alongside the existing prioritize ones.

## Tests

`packages/inspector/test/connection.spec.ts`:

- **Flips the old \"refuses on non-PG adapter\"** specs to round-trip tests. The new InMemory case seeds events on the active store, backs them up via `caller.backup({})`, reconnects to a fresh store, restores from the CSV, and asserts the kept count + duration + audit-log capture.
- **Equivalent test for SQLite** uses a pair of tempdir-backed `SqliteStore` files: seed in one, backup, reconnect to a second file, restore, verify count.
- **Pre-connect guard** still tested (\"Not connected to a store\").
- **Malformed CSV** rejected with a clear `Restore failed:` error.
- 64/64 inspector specs pass; the workspace stays at 100% coverage.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1836 passed / 1836 across 119 files
- Coverage: 100% statements / 100% branches / 100% functions / 100% lines.
- [x] `pnpm -F @rotorsoft/act-inspector test` — 64/64 with the new restore-round-trip specs
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — all packages
- [ ] Manual smoke: `pnpm dev:inspector` against a fresh wolfdesk PG store — backup, reconnect via SQLite tab to a new file, restore the CSV, verify events round-trip cleanly
- [ ] Manual smoke: confirm the audit panel renders the restore entry with the adapter badge + duration
- [ ] Review

## Stability charter impact

**No charter-covered surface touched.** `git diff master --stat` on `libs/act/src/builders/`, `libs/act/src/act.ts`, `libs/act/src/types/ports.ts`, `libs/act/src/types/index.ts`, `libs/act/src/ports.ts` is empty. The entire diff lives in `packages/inspector/`. This is a downstream consumer of #783's `Store.restore` port method — no `STABILITY.md` change needed.

## Follow-ups

Tracked under the saga master #790:

- **#787** — ACT-1128: inspector restore UI (dry-run preview, compaction toggles, progress bar, summary panel). The new `RestoreResult` shape returned by this PR is what the UI consumes.
- **#788** — ACT-1129: cross-adapter migration affordance (PG → SQLite restore and vice versa). Already works at the procedure level after this PR; #788 surfaces it explicitly in the UI.
- **#789** — ACT-1130: doc updates (`writing-a-store.md`, `production-checklist.md`, `event-sourcing.md`). The deeper write-up of restore semantics + the inspector workflow lives there.

Group 3 critical path: **#783 (merged) → #786 (this PR) → #787 → #788**. Half of Group 3 is now in.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>