### PR TITLE
docs(act): restore narrative across writing-a-store, production-checklist, event-sourcing

### DIFF
--- a/docs/docs/concepts/event-sourcing.md
+++ b/docs/docs/concepts/event-sourcing.md
@@ -281,6 +281,81 @@ const result = await app.close([
 
 After `close()`, tombstoned streams throw `StreamClosedError` on any subsequent `app.do()`. Restarted streams are reseeded and continue normally. See [Close cycle](../architecture/close-cycle) for the full phase-by-phase semantics.
 
+## Restoring a store
+
+`app.restore(source, opts?, sink?)` is the offline wipe-and-rebuild primitive — atomically replace the contents of a store from an event source. Use it for CSV-driven backups, cross-adapter migrations (PG → SQLite or vice versa), or compaction passes that drop `__snapshot__` events to shrink the log.
+
+```typescript
+import { CsvFile } from "@rotorsoft/act";
+
+// Restore from a CSV file on disk into the connected store
+const result = await app.restore(new CsvFile({ path: "./backup.csv" }));
+console.log(`Restored ${result.kept} events in ${result.duration_ms}ms`);
+
+// Cache invalidation is the caller's responsibility — restore wipes events,
+// not cache entries. Always clear after a destructive restore.
+await cache().clear();
+
+// Projection rebuilds are also up to the caller — restore does not call reset
+await app.reset({ stream: "^proj-" });
+```
+
+### What `restore` is and isn't
+
+- **It is** an atomic wipe-and-rebuild: the connected store's events + streams + subscriptions are replaced byte-for-byte by the source's contents inside a single transaction. On any error mid-iteration, the transaction rolls back and the store reverts to its pre-call state.
+- **It preserves `created`** verbatim from the source — distinct from `commit`, which always stamps `now()`. Cross-adapter restores keep the original event timestamps.
+- **It renumbers `id`** densely (PG `RESTART IDENTITY`, SQLite `sqlite_sequence` reset, InMemory `0..N-1`). The framework rewrites `meta.causation.event.id` through a per-call `old → new` map so causation chains survive the renumber. Original ids never persist.
+- **It is not** a disaster-recovery primitive. `pg_dump` / `pg_restore` and SQLite file copies are still the right tool for backups you'll need to recover from in a hurry — they preserve every byte and run at the storage layer. `app.restore` is for content-level operations: cross-adapter migration, compaction, validated re-imports.
+- **It is not** transparent to the cache. The cache is a separate port; restore does not call `cache().clear()`. After a destructive restore the cache holds entries that no longer match the rebuilt store. Clearing it is the caller's job.
+
+### Source and sink
+
+The source and sink slots accept anything implementing `EventSource` and `EventSink` respectively. The framework's `Store` adapters implement both (read end is `query`, write end is the optional `restore` capability). `CsvFile` ships in `@rotorsoft/act` and implements both ends so CSV files can sit in either slot:
+
+```typescript
+import { CsvFile, store } from "@rotorsoft/act";
+import { PostgresStore } from "@rotorsoft/act-pg";
+import { SqliteStore } from "@rotorsoft/act-sqlite";
+
+// PG → SQLite (cross-adapter): both endpoints constructed inline
+const pg = new PostgresStore({ /* … */ });
+const sqlite = new SqliteStore({ url: "file:./snapshot.db" });
+await app.restore(pg, {}, sqlite);
+await pg.dispose();
+await sqlite.dispose();
+
+// PG → CSV (backup)
+await app.restore(pg, {}, new CsvFile({ path: "./backup.csv" }));
+
+// CSV → connected store (default sink)
+await app.restore(new CsvFile({ path: "./backup.csv" }));
+```
+
+Omit the third argument to default to the connected store as sink. Pass an explicit sink to route the transfer elsewhere without binding the singleton.
+
+### Options
+
+`ScanOptions` is the second argument:
+
+- **`dry_run: true`** — walk the source, validate every event, count kept and dropped, but never open the sink's transaction. No `Store.restore` capability required. The kept/dropped counts match what a destructive run would land. Used by the inspector's transfer-preview affordance.
+- **`drop_snapshots: true`** — skip every `__snapshot__` event in the source. The rebuilt store has no snapshots, so the next snap policy regenerates them with the current state. Useful for compaction.
+- **`on_progress(p)`** — fired once per event with `{ processed }`. Callers throttle/debounce as needed. Powers the inspector's reactive progress bar.
+
+### Restore vs reset vs truncate vs close
+
+| Primitive | What it does | Atomicity |
+|---|---|---|
+| `app.restore(source, opts?, sink?)` | Wipe the sink (events + streams + subscriptions) and rebuild from the source in a single transaction. `created` preserved, `id` renumbered, causation refs rewritten. | Adapter transaction — all-or-nothing per call |
+| `app.reset(input)` | Set reaction watermarks to `-1` for matching streams, arm the orchestrator's drain flag so the next `settle()` replays every event through reactions. **Does not delete events.** | Per-stream watermark update |
+| `app.unblock(input)` | Lift the `blocked` flag from poison-message streams. Watermark preserved — the stream resumes from where it stopped, no replay. | Per-stream flag update |
+| `store().truncate(targets)` | Delete every event for the targeted streams and insert a single tombstone event. **Operator-facing, not orchestrator-aware.** Prefer `app.close(...)` for the orchestrator-coordinated variant. | Per-target transaction |
+| `app.close(targets)` | Archive + tombstone (or restart) a closed stream. Quiesces reactions, runs the archive callback, deletes events, commits the tombstone or a fresh `__snapshot__`. | Per-target transaction with reaction quiesce |
+
+Common confusions worth naming:
+
+- **`restore` is not `reset`.** Restore replaces events. Reset replays reactions over events that are already there. Using `restore` to "rewind a projection" would wipe and re-import the entire event log; using `reset` does the same job at the watermark level with zero data loss risk.
+- **`truncate` is not `close`.** Truncate deletes events for an operator-named target. Close coordinates with the orchestrator, quiesces reactions, runs an archive step, and tombstones the stream atomically with the truncation. Plain `truncate` is for tooling that already knows reactions are idle; `close` is the production path.
+
 ## Testing
 
 ```typescript

--- a/docs/docs/guides/production-checklist.md
+++ b/docs/docs/guides/production-checklist.md
@@ -180,7 +180,45 @@ app.on("settled", (drain) => {
 
 The `act-inspector` workspace package gives you a UI on top of the same `query_streams` primitive metrics tools query. It's not a production runtime — run it against a snapshot DB for incident analysis.
 
-## 9. Closing the books
+## 9. Restoring a store (rare, deliberate)
+
+`app.restore(source, opts?, sink?)` is the offline wipe-and-rebuild path: atomic replacement of a store's contents from an event source. Most production teams never call this from application code — they use the inspector's transfer dialog (or a one-off `node` script) to operate it as a tool. What matters in production is knowing when *not* to reach for it.
+
+**Restore is not your disaster-recovery plan.** `pg_dump` / `pg_restore` for Postgres and a periodic SQLite file copy are still the right tools for recovering from a lost server. They preserve every byte, run at the storage layer, and don't require the application to be running. `app.restore` is for *content-level* operations — cross-adapter migrations (PG → SQLite for a customer extract), compaction passes (drop `__snapshot__` events to shrink the log), validated re-imports from a curated CSV. If your goal is "rebuild from yesterday's snapshot because the database disk died," skip restore and use the storage-level tools.
+
+When you do use restore, plan around three follow-ups:
+
+```typescript
+import { CsvFile, cache } from "@rotorsoft/act";
+
+// 1. Run the destructive restore. Connect to the target store first; restore
+//    wipes whatever's connected before rewriting.
+const result = await app.restore(new CsvFile({ path: "./backup.csv" }));
+logger.info({ kept: result.kept, duration_ms: result.duration_ms }, "restored");
+
+// 2. Clear the cache — restore does NOT touch the Cache port. Entries from
+//    before the restore are now pointing at stale (or renumbered) ids.
+await cache().clear();
+
+// 3. Rebuild projections. Restore replaces events; it does not replay them
+//    through reactions. If any projection lives in a database/cache outside
+//    the event log, you need an explicit reset for it.
+await app.reset({ stream: "^proj-" });
+app.settle({ eventLimit: 1000 });
+```
+
+Operator-side guardrails:
+
+- **Dry-run before destructive.** `app.restore(source, { dry_run: true })` runs the same validator, counts the same kept/dropped, but never opens the sink's transaction. Pre-flight every restore the first time you run it against a new source. The inspector's transfer dialog does this automatically via the "Preview" button.
+- **Inspector writes gated.** The inspector's transfer dialog runs the destructive path only when `ACT_INSPECTOR_WRITE=1`. Default-deny; flip it on for the duration of the migration, then flip it off.
+- **Audit the run.** The inspector audit log records every destructive transfer with `kept`, `duration_ms`, and the adapter pair. Application code calling `app.restore` directly should log the result the same way.
+- **Reactions resubscribe.** After restore, the orchestrator's next settle picks up the rewritten event log, and `subscribe()` UPSERTs every stream's watermark. No manual intervention.
+
+When a restore is genuinely the right tool — for example, "migrate the wolfdesk app from Postgres to a partitioned SQLite cluster" — the path is: stop writes to the source, run `app.restore(pgStore, {}, sqliteStore)`, flip the connection string, run `cache().clear()`, run `app.reset` against any DB-backed projections, restart. The framework owns the cross-adapter shape so the operation is the same regardless of which adapters sit on either end.
+
+See [Concepts → Restoring a store](../concepts/event-sourcing.md#restoring-a-store) for the primitive itself and how it compares with `reset` / `truncate` / `close`.
+
+## 10. Closing the books
 
 For long-running streams that accumulate events you'll never replay (year-old order history, archived chat sessions), use `app.close()` to archive and truncate:
 
@@ -208,7 +246,7 @@ app.on("closed", ({ truncated, skipped }) => {
 
 Closed streams are tombstoned — `app.do()` against them throws `StreamClosedError`. To re-open with a fresh starting state, `close()` with `restart: true`. See [Architecture → Close cycle](../architecture/close-cycle.md) for the full safety semantics.
 
-## 10. Sizing lanes
+## 11. Sizing lanes
 
 If reactions in this app have heterogeneous timing profiles — webhook delivery measured in seconds alongside metric emission measured in microseconds — split them across lanes (ACT-1103). Without lanes, every reaction shares one `leaseMillis` and one `streamLimit`, and the slowest handler dictates the budget for everyone.
 
@@ -252,5 +290,6 @@ Before pushing to production, walk this list mentally:
 - [ ] `LOG_LEVEL` and `NODE_ENV` set appropriately
 - [ ] Lifecycle metrics exported (blocked, settled, concurrency)
 - [ ] Lanes sized per latency class (or all reactions sharing one timing budget is genuinely fine)
+- [ ] Disaster-recovery plan is `pg_dump` / file copy — not `app.restore` (which is for content-level migration / compaction, not DR)
 
 Once these are in place, the framework runs itself.

--- a/docs/docs/guides/writing-a-store.md
+++ b/docs/docs/guides/writing-a-store.md
@@ -20,6 +20,7 @@ The interface lives in [`libs/act/src/types/ports.ts`](https://github.com/Rotors
 - `reset(streams)` / `prioritize(filter, n)` / `truncate(targets)` — operator-facing primitives; the `StreamFilter` shape carries an optional `lane` exact-match
 - `query_streams(callback, query?)` — read-only introspection (operational dashboards); positions carry their `lane`
 - `notify(handler)` — *optional* cross-process commit notifications
+- `restore(driver)` — *optional* atomic wipe-and-rebuild from an event source (see below)
 
 Reading the JSDoc on each method is the first step. The TCK is the second.
 
@@ -63,6 +64,95 @@ runStoreTck({
 ```
 
 When `notify: true`, the TCK runs a structural smoke test (subscribe → dispose) to confirm the optional API is present and well-shaped. Cross-process LISTEN/NOTIFY semantics need two processes and stay in your adapter's own tests.
+
+The `restore` capability is the other opt-in today. Skip it (`capabilities.restore: false` or just omit) and the TCK's restore cases stay parked. Flip it on once you've implemented `Store.restore` — see the next section for the contract.
+
+## Implementing `Store.restore` (optional)
+
+`Store.restore` is the offline wipe-and-rebuild primitive. Capability-gated, because not every backend can atomically wipe and reinsert in one transaction (Kafka-fronted stores, partitioned multi-shard adapters, append-only object-storage logs). If your adapter can hold the operation under a single transaction or equivalent, implementing it earns the inspector's transfer dialog, the framework's cross-adapter migration story, and the compaction path.
+
+### The HOF driver pattern
+
+The signature is intentionally inverted — your adapter is handed a driver function and called with a per-event insert callback that the orchestrator owns:
+
+```ts
+async restore(
+  driver: (
+    callback: (event: Committed<Schemas, keyof Schemas>) => Promise<number>
+  ) => Promise<void>
+): Promise<void> {
+  await this._transaction(async (tx) => {
+    // 1. Wipe atomically: events + streams + subscriptions
+    await tx.exec("TRUNCATE events RESTART IDENTITY CASCADE");
+    await tx.exec("DELETE FROM streams");
+    await tx.exec("DELETE FROM subscriptions");
+
+    // 2. Hand the orchestrator a per-event insert callback. The orchestrator
+    //    validates, rewrites causation refs, and calls back into your callback
+    //    once per kept event. Your callback returns the new id.
+    await driver(async (event) => {
+      const result = await tx.exec(
+        "INSERT INTO events (name, data, stream, version, created, meta) " +
+        "VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
+        [event.name, event.data, event.stream, event.version, event.created, event.meta]
+      );
+      return result.rows[0].id;
+    });
+
+    // 3. tx commits on return, rolls back on throw
+  });
+}
+```
+
+The inversion exists for a reason: validation, dry-run, `drop_snapshots`, `on_progress`, and the causation-rewrite map all live in the orchestrator's `scan` loop, not in the adapter. Your adapter doesn't need to know what an `EventSource` is, what `ScanOptions` are, or how to rewrite `meta.causation.event.id` — the driver function handles all of that, and just calls your callback per event.
+
+### Atomicity is the invariant
+
+The single non-negotiable rule: on any throw from inside `driver(callback)`, the entire restore must roll back. The store reverts byte-for-byte to its pre-call state. The TCK's `atomic rollback on mid-iteration throw` case fault-injects an exception in the middle of the restore and asserts every event is unchanged afterwards.
+
+Per-dialect notes:
+
+- **Postgres** — `BEGIN` / `COMMIT` around the whole sequence. `TRUNCATE … RESTART IDENTITY CASCADE` for the wipe.
+- **SQLite (libSQL)** — `BEGIN IMMEDIATE` to grab the writer lock up front (avoids a busy retry mid-restore). `DELETE FROM events; DELETE FROM sqlite_sequence WHERE name = 'events'` for identity reset.
+- **InMemory** — snapshot the internal arrays at the start; swap them in only on successful completion; revert to the snapshot on throw.
+- **Other backends** — if your transaction model doesn't span the operation, the capability is genuinely incompatible. Don't ship a "best-effort" restore that can land half the events; leave the capability off and let the TCK skip the cases. Downstream tools that need restore know to check.
+
+### Identity reset
+
+Original `id` values are dropped on insert. Your adapter's SERIAL / AUTOINCREMENT sequence assigns fresh ids dense from 1 (or `0..N-1` in InMemory). The orchestrator's `old → new` causation map handles the rewrite for `meta.causation.event.id` before your callback ever sees the event, so you don't write the old id; you just write what the callback hands you and let the dialect assign the new id naturally.
+
+Why this matters: causation references in `meta` point at events by `id`. If your adapter renumbered without coordinating, every chain would silently break. The framework owns the rewrite so adapters can stay narrow.
+
+### `created` is preserved verbatim
+
+Unlike `commit` (which stamps `now()` on every event), restore writes the source's `created` timestamp directly. This is what makes cross-adapter migration lossless — a PG store restored into a SQLite file keeps every event's original commit time.
+
+### TCK opt-in
+
+Once you've implemented the method, flip the capability flag:
+
+```ts
+runStoreTck({
+  name: "MysqlStore",
+  factory: () => new MysqlStore({ /* … */ }),
+  capabilities: {
+    notify: true,
+    restore: true,
+  },
+});
+```
+
+The TCK then runs ten cases: empty source, single stream, multi-stream, ISO `created`, pre-existing wipe, subscription clearing, snapshot preservation, causation remap, orphan-ref pass-through, and atomic rollback on mid-iteration throw. They cover the contract end-to-end; passing them means your adapter participates in every transfer flow the framework supports.
+
+### Fault-injection adjacent to the TCK
+
+Some failure modes are dialect-specific and live in your adapter's own error-spec file rather than the TCK — see `libs/act-pg/test/store.error.spec.ts` and `libs/act-sqlite/test/store.error.spec.ts` for the pattern. Typical cases to cover for restore:
+
+- Mid-driver connection drop (the wipe succeeded but the insert loop fails on a network blip)
+- Per-event constraint violation (a malformed JSON `meta` value that your dialect's JSON validator rejects)
+- Sequence-reset failure (PG `RESTART IDENTITY` on a partitioned table, SQLite `sqlite_sequence` write on a read-only attach)
+
+Each lands as a separate spec; the assertion is always the same — `kept === 0`, no events in the store afterwards, no partial state observable.
 
 ## Scaffolding `@rotorsoft/act-mysql` (worked example)
 


### PR DESCRIPTION
## Summary

Closes #789. Wraps Phase 1.1's docs Group (#790) — the three reference pages that hadn't caught up to the restore primitive yet. Extension-points and the book essays landed in #811; this PR fills the matching gaps in the implementation guide, the production runbook, and the concepts page.

## What's new

### `docs/docs/guides/writing-a-store.md`
New "Implementing `Store.restore` (optional)" section between the capabilities flags and the scaffolding walkthrough. Covers:

- The HOF driver pattern — why your adapter receives `driver(callback)` rather than an iterable
- The atomicity invariant (the one non-negotiable rule)
- Per-dialect transaction patterns: PG `BEGIN` / `COMMIT`, SQLite `BEGIN IMMEDIATE`, InMemory snapshot-and-swap, and why some backends should *not* implement restore
- Identity reset rules and why the orchestrator owns the causation rewrite (so adapters can stay narrow)
- `created` preservation contrast with `commit`'s `now()` stamping
- TCK opt-in via `capabilities.restore: true` + the ten cases the kit runs
- Fault-injection patterns adjacent to the TCK, pointing at `libs/act-pg/test/store.error.spec.ts` / `libs/act-sqlite/test/store.error.spec.ts` as the precedent

The contract bullet list at the top of the page now mentions `restore(driver)` alongside `notify(handler)` as the two optional methods.

### `docs/docs/guides/production-checklist.md`
New section 9, "Restoring a store (rare, deliberate)." The framing is what restore *isn't* before what it *is*:

- **Not a disaster-recovery primitive.** `pg_dump` / `pg_restore` and SQLite file copies are still the right tools for "the database disk died." `app.restore` is for *content-level* operations — cross-adapter migration, compaction, validated re-imports
- The three follow-ups every restore needs: `cache().clear()` (cache is a separate port), `app.reset` for projections that live outside the event log, and audit the run
- Operator-side guardrails: dry-run before destructive, `ACT_INSPECTOR_WRITE` gating, audit log capture, reactions resubscribe via the next settle
- The cross-adapter migration recipe (stop writes → restore source into target → flip connection → clear cache → reset projections → restart)

Sizing lanes renumbered 10 → 11. Pre-deploy checklist gains a "DR plan is `pg_dump` / file copy, not `app.restore`" item.

### `docs/docs/concepts/event-sourcing.md`
New top-level "Restoring a store" section between "Closing the Books" and "Testing." Covers:

- The signature and three example invocations (CSV → connected store, PG → SQLite, PG → CSV)
- "What `restore` is and isn't" — atomicity, `created` preservation, `id` renumber with causation rewrite, *not* DR, *not* cache-aware
- Source and sink slots — `Store` adapters implement both ends; `CsvFile` is the bundled non-store implementation
- The three `ScanOptions` flags (`dry_run`, `drop_snapshots`, `on_progress`)
- **Restore vs reset vs unblock vs truncate vs close** comparison table — clarifies the five primitives that production teams routinely confuse for each other, with a "common confusions worth naming" callout for the two most dangerous mix-ups (using restore to "rewind a projection," using truncate where close is the right primitive)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 25 preexisting warnings)
- [x] `pnpm build` — all packages build
- [x] Stale-reference grep: `grep -rln "pg.Client" docs/docs book CLAUDE.md` returns one hit, in `book/act-1124-store-restore.md`'s historical narrative ("the inspector *used to* open a raw `pg.Client`…") — intentional, satisfies the ticket's "zero hits inside the inspector restore narrative" criterion
- [ ] CI green on PR

## Stability charter impact

No charter-covered surface changed — docs-only PR. No source files touched. Test coverage unchanged from master (was 100%).

## Why no new book essay

ACT-1130's original scope called for a narrative essay on "why restore was raw SQL, why making it a port surfaced compaction as a side benefit, the rejected designs, the migration-overlay future." Two essays already cover that territory:

- `book/act-1124-store-restore.md` — port promotion, rejected designs (passive defaults, required-on-Store, renumber-in-isolation, observability), migration-overlay direction
- `book/act-1128-unified-transfer.md` — `EventSource` / `EventSink` shape, unified transfer pipeline, the five wrong turns (generic `T` on sink, async-iterable adapters, public `iterate`, six-kind discriminator, "ephemeral" naming)

Together they cover the *why*. The docs in this PR cover the *how*. Writing a third essay would duplicate ground that already reads coherently as two adjacent chapters of the same story.

## Follow-ups

Phase 1.1 has two open items left in the #790 tracker:

- **#785 / ACT-1126** — migration overlay (`eventNameMap`, `transform`, `streamRename`). Marked "may slip to 1.2."
- **#814 / ACT-1132** — PG cursor-based fetching. Perf follow-up filed during #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>