### PR TITLE
feat(act): listen and drain build options for non-reactive instances (#803)

### DIFF
--- a/docs/docs/concepts/configuration.md
+++ b/docs/docs/concepts/configuration.md
@@ -113,6 +113,32 @@ const app = act()
 - **`maxSubscribedStreams`** (default `1000`) — cap for the LRU set tracking already-subscribed reaction targets. Apps that mint many dynamic targets (e.g. one stream per user activity) should raise this; the LRU is a memory bound, not a correctness mechanism — eviction at most causes a redundant `subscribe()` call.
 - **`settleDebounceMs`** (default `10`) — debounce window used by `settle()` when no per-call `debounceMs` is given. Coalesces commits in the same tick into a single correlate→drain pass. Lower for tight tests; raise for bursty production traffic.
 - **`onlyLanes`** (default: every declared lane) — restrict this process to a subset of declared drain lanes (ACT-1103). See [Lanes](#lanes) below.
+- **`listen`** (default `true`) — subscribe to `Store.notify` on this instance. Set `false` on writer-only instances: commits still notify, but the instance doesn't subscribe to the channel. The subscriber-connection budget is the practical scaling ceiling for the notify/listen pattern; writer-only fleets shouldn't spend it.
+- **`drain`** (default `true`) — run the local reaction pipeline. Set `false` to make `correlate()`, `drain()`, and `settle()` no-ops and skip auto-cycle workers. The `notified` lifecycle event still fires when `listen` is on, so observability sidecars (`listen: true, drain: false`) work.
+
+### Deployment shapes via `listen` / `drain`
+
+The two flags are orthogonal — independent costs, independent toggles:
+
+| `listen` | `drain` | Use case |
+|---|---|---|
+| `true` | `true` | Default. Reactive instance in a multi-process cluster. |
+| `false` | `true` | Single-instance app. Nothing else to listen to, but own commits still trigger reactions. Minor optimization. |
+| `false` | `false` | Pure writer fleet (write-heavy frontend, ingest worker, API server). Notifies on commit but doesn't react. |
+| `true` | `false` | Observability sidecar. Sees every cross-process commit via the `notified` lifecycle event without processing it. |
+
+```typescript
+// Writer fleet — scales horizontally without touching the subscriber budget.
+const writer = act().withState(Order).build({ listen: false, drain: false });
+
+// Reactive fleet — same codebase, opposite flags. Sized to the reaction workload.
+const reactor = act()
+  .withState(Order)
+  .on("OrderPlaced").do(reduceInventory).to("inventory")
+  .build(); // defaults: listen + drain
+```
+
+Commits from the writer fleet emit notifications (that's part of the store's commit protocol); the reactor fleet picks them up via its `Store.notify` subscription and runs reactions locally.
 
 ## Lanes
 

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -165,6 +165,25 @@ export type ActOptions<TLanes extends string = string> = {
   readonly correlator?: Correlator;
   /** Restrict this process to a subset of declared lanes (ACT-1103). */
   readonly onlyLanes?: ReadonlyArray<TLanes>;
+  /**
+   * Subscribe to {@link Store.notify} on this instance (#803). Defaults
+   * to `true`. Set `false` on instances that only commit and never
+   * react — the subscriber-connection budget is the practical scaling
+   * ceiling for the notify/listen pattern, and writer-only fleets
+   * spend it for nothing when they subscribe to a channel they never
+   * read. Commits still emit notifications (that's part of the
+   * store's commit protocol); only the subscriber side is gated.
+   */
+  readonly listen?: boolean;
+  /**
+   * Run the local reaction pipeline on this instance (#803). Defaults
+   * to `true`. Set `false` on writer-only or sidecar instances: drain
+   * controllers' auto-cycle workers don't start, `correlate()` /
+   * `drain()` / `settle()` become no-ops, and the notify handler
+   * skips its drain-wakeup arm (but still emits the `notified`
+   * lifecycle event so observability sidecars work).
+   */
+  readonly drain?: boolean;
 };
 
 export class Act<
@@ -176,6 +195,10 @@ export class Act<
 > implements IAct<TEvents, TActions, TActor>
 {
   private _emitter = new EventEmitter();
+  /** #803: gate the `Store.notify` subscription side. */
+  private readonly _listen: boolean;
+  /** #803: gate the local reaction pipeline (drain controllers, settle, correlate). */
+  private readonly _drain: boolean;
   /** Event names with at least one registered reaction (computed at build time) */
   private readonly _reactive_events: ReadonlySet<string>;
   /** One DrainController per active lane, keyed by lane name. */
@@ -362,6 +385,8 @@ export class Act<
       eventToLanes,
     } = classifyRegistry(this.registry, this._states);
     this._reactive_events = reactiveEvents;
+    this._listen = options.listen !== false;
+    this._drain = options.drain !== false;
     this._event_to_state = eventToState;
     this._event_to_lanes = eventToLanes;
 
@@ -406,7 +431,11 @@ export class Act<
       // cycleMs — the intent of `withLane({cycleMs: 100})` is "drive
       // this lane every 100 ms," independent of the Act-level settle
       // loop. unref()'d so the timer doesn't keep the process alive.
-      if (cfg?.cycleMs !== undefined) controller.start(cfg.cycleMs);
+      // #803: skip the auto-start on writer-only instances
+      // (`drain: false`) — they construct the controller but never
+      // run reactions locally.
+      if (cfg?.cycleMs !== undefined && options.drain !== false)
+        controller.start(cfg.cycleMs);
       this._drain_controllers.set(name, controller);
     }
 
@@ -430,9 +459,10 @@ export class Act<
       hasDynamicResolvers,
       this._cd,
       options.maxSubscribedStreams ?? DEFAULT_MAX_SUBSCRIBED_STREAMS,
-      // Cold start: assume drain is needed (historical events may need processing)
+      // Cold start: assume drain is needed (historical events may need processing).
+      // #803: writer-only instances skip the cold-start arm.
       () => {
-        if (this._reactive_events.size > 0) this._armAll();
+        if (this._drain && this._reactive_events.size > 0) this._armAll();
       }
     );
     this._settle = new SettleLoop<TEvents>(
@@ -495,6 +525,10 @@ export class Act<
   ): Promise<(() => void | Promise<void>) | undefined> {
     if (this._reactive_events.size === 0) return undefined;
     if (!s.notify) return undefined;
+    // #803: writer-only / single-instance deployments opt out of the
+    // subscriber-connection cost. Commits still notify (that's the
+    // store's commit protocol); only the subscriber side is gated.
+    if (!this._listen) return undefined;
     try {
       return await s.notify((notification) => {
         // Generic concerns (lifecycle emit, drain wakeup, listener
@@ -509,10 +543,15 @@ export class Act<
           // belonging to bounded contexts this process doesn't react to.
           // ACT-1103: selective arming via the shared helper — only the
           // lanes whose reactions match the notified events.
-          const armed = this._armForEventNames(
-            notification.events.map((e) => e.name)
-          );
-          if (armed) this._settle.schedule({ debounceMs: 0 });
+          // #803: the sidecar pattern (listen: true, drain: false)
+          // wants the `notified` lifecycle event for observability
+          // without engaging the local reaction pipeline.
+          if (this._drain) {
+            const armed = this._armForEventNames(
+              notification.events.map((e) => e.name)
+            );
+            if (armed) this._settle.schedule({ debounceMs: 0 });
+          }
         } catch (err) {
           this._logger.error(err, "notified handler threw");
         }
@@ -853,6 +892,11 @@ export class Act<
    * @see {@link start_correlations} for automatic correlation
    */
   async drain(options: DrainOptions = {}): Promise<Drain<TEvents>> {
+    // #803: writer-only instances skip the local reaction pipeline.
+    // Return an empty Drain result so call sites that aggregate (e.g.,
+    // `settle` listeners) keep working without special-casing.
+    if (!this._drain)
+      return { fetched: [], leased: [], acked: [], blocked: [] };
     return this._scoped(() => this._drainAll(options));
   }
 
@@ -959,6 +1003,10 @@ export class Act<
   async correlate(
     query: Query = { after: -1, limit: 10 }
   ): Promise<{ subscribed: number; last_id: number }> {
+    // #803: writer-only instances skip dynamic stream discovery. The
+    // {subscribed, last_id} pair returns the no-op result; the
+    // checkpoint stays where it was.
+    if (!this._drain) return { subscribed: 0, last_id: -1 };
     return this._scoped(() => this._correlate.correlate(query));
   }
 
@@ -1424,6 +1472,10 @@ export class Act<
    * @see {@link correlate} for manual correlation
    */
   settle(options: SettleOptions = {}): void {
+    // #803: writer-only instances skip settle entirely. The bootstrap
+    // pattern `app.on("committed", () => app.settle())` keeps working —
+    // it just runs zero work on writers.
+    if (!this._drain) return;
     this._settle.schedule(options);
   }
 }

--- a/libs/act/test/listen-drain.spec.ts
+++ b/libs/act/test/listen-drain.spec.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { InMemoryStore } from "../src/adapters/in-memory-store.js";
+import { act, dispose, state, store, ZodEmpty } from "../src/index.js";
+import type { StoreNotification } from "../src/types/index.js";
+
+/**
+ * #803 — ActOptions.listen and ActOptions.drain.
+ *
+ * Two orthogonal boolean flags on Act build options that gate the
+ * subscription side (`listen`) and the local reaction pipeline
+ * (`drain`). Default true for both, so existing builds are
+ * untouched.
+ */
+
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Tick: ZodEmpty })
+  .patch({ Tick: (_, s) => ({ count: s.count + 1 }) })
+  .on({ tick: ZodEmpty })
+  .emit(() => ["Tick", {}])
+  .build();
+
+// A store with a `notify` method we can intercept to count subscription
+// wirings. The implementation just records subscribers; nothing actually
+// fires from it.
+class NotifyStore extends InMemoryStore {
+  public subscribed = 0;
+  public unsubscribed = 0;
+  public lastHandler: ((n: StoreNotification) => void) | null = null;
+  // biome-ignore lint/style/useNamingConvention: matches Store.notify
+  notify = async (handler: (notification: StoreNotification) => void) => {
+    this.subscribed++;
+    this.lastHandler = handler;
+    return async () => {
+      this.unsubscribed++;
+      this.lastHandler = null;
+    };
+  };
+}
+
+let notifyStore: NotifyStore;
+
+beforeEach(() => {
+  notifyStore = new NotifyStore();
+  store(notifyStore);
+});
+
+afterEach(async () => {
+  await dispose()();
+});
+
+describe("ActOptions.listen and .drain", () => {
+  it("defaults: subscribes to notify and runs local reactions", async () => {
+    const handler = vi.fn();
+    const app = act()
+      .withState(Counter)
+      .on("Tick")
+      .do(handler)
+      .to("tick-log")
+      .build();
+    // Give the async _wireNotify a microtask to complete.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(notifyStore.subscribed).toBe(1);
+    await app.do("tick", { stream: "c1", actor: { id: "u", name: "U" } }, {});
+    await app.correlate();
+    await app.drain();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("listen: false skips the Store.notify subscription", async () => {
+    act().withState(Counter).on("Tick").do(vi.fn()).to("x").build({
+      listen: false,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(notifyStore.subscribed).toBe(0);
+  });
+
+  it("listen: false still drains local commits", async () => {
+    const handler = vi.fn();
+    const app = act()
+      .withState(Counter)
+      .on("Tick")
+      .do(handler)
+      .to("local-log")
+      .build({ listen: false });
+    await app.do("tick", { stream: "c2", actor: { id: "u", name: "U" } }, {});
+    await app.correlate();
+    await app.drain();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("drain: false makes drain/correlate/settle no-ops", async () => {
+    const handler = vi.fn();
+    const app = act()
+      .withState(Counter)
+      .on("Tick")
+      .do(handler)
+      .to("noop-log")
+      .build({ drain: false });
+    await app.do("tick", { stream: "c3", actor: { id: "u", name: "U" } }, {});
+    const drainResult = await app.drain();
+    expect(drainResult).toEqual({
+      fetched: [],
+      leased: [],
+      acked: [],
+      blocked: [],
+    });
+    const corrResult = await app.correlate();
+    expect(corrResult).toEqual({ subscribed: 0, last_id: -1 });
+    // settle is sync and void — just verify it doesn't throw.
+    app.settle();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drain: false + listen: true emits `notified` without draining", async () => {
+    const notified = vi.fn();
+    const handler = vi.fn();
+    const app = act()
+      .withState(Counter)
+      .on("Tick")
+      .do(handler)
+      .to("sidecar-log")
+      .build({ drain: false, listen: true });
+    app.on("notified", notified);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(notifyStore.subscribed).toBe(1);
+    // Simulate a remote commit arriving on the wire.
+    notifyStore.lastHandler?.({
+      stream: "remote-c",
+      events: [{ id: 1, name: "Tick" }],
+    });
+    expect(notified).toHaveBeenCalledTimes(1);
+    // No drain wakeup — handler never runs.
+    await Promise.resolve();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("listen: false + drain: false is the writer-only fleet", async () => {
+    const handler = vi.fn();
+    const app = act()
+      .withState(Counter)
+      .on("Tick")
+      .do(handler)
+      .to("writer-log")
+      .build({ listen: false, drain: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(notifyStore.subscribed).toBe(0);
+    // Commit still works — the store's commit protocol is unchanged.
+    await app.do(
+      "tick",
+      { stream: "writer", actor: { id: "u", name: "U" } },
+      {}
+    );
+    // But nothing drains locally.
+    await app.drain();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #803. Two orthogonal boolean flags on `ActOptions`, both defaulting to `true` so existing builds are untouched.

```ts
.build()                                   // default: listen + drain (full reactive)
.build({ listen: false })                  // single-instance: skip subscription, still drain locally
.build({ listen: false, drain: false })    // pure writer: notify on commit, nothing else
.build({ drain: false })                   // observability sidecar: listen but don't process
```

The two flags gate two independent costs:

- **`listen`** (default `true`) — controls whether the orchestrator wires a `Store.notify` subscription. When `false`, commits still emit notifications on this instance (that's the store's commit protocol), but the instance doesn't subscribe to the channel. The subscriber-connection budget is the practical scaling ceiling for the notify/listen pattern; writer-only fleets shouldn't spend it on a channel they never read.
- **`drain`** (default `true`) — controls whether the orchestrator runs the local reaction pipeline. When `false`, `correlate()` / `drain()` / `settle()` become no-ops, per-lane `cycleMs` auto-workers don't start, and the notify handler skips its drain-wakeup arm. The `notified` lifecycle event still fires (so observability sidecars work).

## Deployment shapes

| `listen` | `drain` | Use case |
|---|---|---|
| `true` | `true` | Default. Reactive instance in a multi-process cluster. |
| `false` | `true` | Single-instance app. Tiny optimization. |
| `false` | `false` | Pure writer fleet (write-heavy frontend, ingest worker, API server). |
| `true` | `false` | Observability sidecar — sees every cross-process commit via the `notified` event without processing it. |

The operational pattern this enables is one codebase deployed as both a write-heavy frontend (`listen: false, drain: false`) and a smaller reactive fleet (defaults). The writer fleet scales horizontally without touching the subscriber budget; the reactor fleet picks up the writers' notifications and runs reactions locally.

## Framework changes

Small. Most of the work is just adding two booleans and threading them through existing guards.

- `_wireNotify` returns `undefined` when `!this._listen`. The early return joins the existing `_reactive_events.size === 0` and `!s.notify` guards.
- Notify-handler's `_armForEventNames` + `_settle.schedule` skipped when `!this._drain`. The `emit("notified", …)` runs first so observability is preserved.
- Per-lane `cycleMs` auto-start skipped on writer-only instances (`controller.start(cfg.cycleMs)` gated).
- Cold-start arm in `CorrelateCycle` init callback gated on `_drain`.
- `correlate()` returns `{ subscribed: 0, last_id: -1 }` when `!this._drain`.
- `drain()` returns `{ fetched: [], leased: [], acked: [], blocked: [] }` so call sites that aggregate don't need to special-case.
- `settle()` is a no-op. The bootstrap pattern `app.on(\"committed\", () => app.settle())` keeps working — it just runs zero work on writers.

## What doesn't change

- Application code: reactions, projections, invariants, `.emits(...)`, `.on(...)` all stay identical.
- The `Store` port and its adapters. Notifications continue to fire on commit; only the subscription side and the local drain are gated.
- Existing public API of the orchestrator. The flags are additive.
- Behavior when neither flag is specified.

## Tests

`libs/act/test/listen-drain.spec.ts` covers six cases:

- Defaults: subscribes to notify, runs local reactions.
- `listen: false` skips the `Store.notify` subscription.
- `listen: false` still drains local commits.
- `drain: false` makes drain/correlate/settle no-ops.
- `drain: false, listen: true` emits `notified` without draining (sidecar).
- `listen: false, drain: false` is the writer-only fleet — commits work, nothing drains.

Mock `NotifyStore` extends `InMemoryStore` to count subscription wirings and capture the notify handler, letting us drive remote notifications synchronously.

## Docs

`docs/docs/concepts/configuration.md` — two new bullets in the `ActOptions` reference plus a \"Deployment shapes via `listen` / `drain`\" subsection with the combinations table and the writer/reactor split example.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1894 / 1894 pass, framework coverage **100% statements / 100% branches / 100% functions / 100% lines**
- [x] `pnpm lint` clean
- [x] All six listen/drain combinations covered
- [ ] CI green on PR

## Stability charter impact

**Charter surface modified — additive only.**

- `libs/act/src/act.ts` — `ActOptions.listen?: boolean` and `ActOptions.drain?: boolean` added. Existing callers unaffected; defaults preserve current behavior.

## Follow-ups

The book's Chapter 17 (\"Scaling Out\") references both flags as committed behavior in the \"Scaling Boundaries\" section — landing these in 1.1 lets the book describe them as shipped before publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>