### PR TITLE
fix(docs): docusaurus deploy — jsx flag + drop dead act-sse references

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -77,11 +77,6 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "link",
-          label: "@rotorsoft/act-sse",
-          href: "/docs/api/act-sse/src",
-        },
-        {
-          type: "link",
           label: "@rotorsoft/act-http",
           href: "/docs/api/act-http/src/webhook",
         },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,6 +2,10 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "../tsconfig.eslint.json",
   "compilerOptions": {
+    // act-diagram ships TSX (`client/`) under its `src/**` tree —
+    // typedoc loads the whole include set into its TS program even
+    // when entryPoints stay narrow, so the JSX has to parse here.
+    "jsx": "react-jsx",
     "paths": {
       "@rotorsoft/act": ["../libs/act/src/index.ts"],
       "@rotorsoft/act-diagram": ["../libs/act-diagram/src/index.ts"],

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -4,7 +4,7 @@
     "../libs/act-patch/src/index.ts",
     "../libs/act-pg/src/index.ts",
     "../libs/act-sqlite/src/index.ts",
-    "../libs/act-sse/src/index.ts",
+    "../libs/act-tck/src/index.ts",
     "../libs/act-http/src/webhook/index.ts",
     "../libs/act-http/src/sse/index.ts"
   ],

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -337,7 +337,7 @@ export class Act<
    * and projections in one pass.
    *
    * @param registry  Schemas for every event and action across registered states
-   * @param _states   Merged map of state name → state definition
+   * @param states    Merged map of state name → state definition
    * @param batchHandlers Static-target projection batch handlers (target → handler)
    * @param options   Tuning knobs — see {@link ActOptions}
    * @param lanes     Declared drain lanes (ACT-1103). The builder collects


### PR DESCRIPTION
## Summary

The Docusaurus deploy step has been failing on master since #823 merged. Two unrelated root causes from earlier PRs interacted to break it; both fixed here in one small PR.

## #1 — `Cannot use JSX unless the '--jsx' flag is provided`

The TS 6 modernization on #823 added \`act-diagram/src/**\` to \`docs/tsconfig.json\`'s \`include\` set (the docs reference act-diagram in prose). \`act-diagram/src/client/\` contains TSX components. Typedoc loads everything in the \`include\` set into its TS program even when \`entryPoints\` stays narrow, so the JSX has to parse — but the docs tsconfig chain has no \`jsx\` setting (it didn't need one before because \`act-sse\` was the only previously-included member and is TSX-free).

Fix: add \`\"jsx\": \"react-jsx\"\` to \`docs/tsconfig.json\` \`compilerOptions\`. One line.

## #2 — Two stale sidebar links

The earlier act-sse deprecation cleanup removed it from \`typedoc.json\` entryPoints, but the \`sidebars.ts\` link to \`/docs/api/act-sse/src\` was left behind — Docusaurus flagged it as a broken link.

\`act-tck\` had a sidebar link but was never in typedoc entryPoints, so its API page never generated — also a broken link.

Fix: drop the dead \`act-sse\` sidebar entry, add \`act-tck\` to \`typedoc.json\` (it IS a public package whose contract is worth documenting).

## #3 — Stale @param JSDoc

While re-running typedoc I noticed it warned about \`@param _states\` in act.ts (left over from the parameter-property refactor on #823 — constructor param stays \`states\`; only the field is \`_states\`). Renamed.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm -F docs build:all\` succeeds (typedoc + docusaurus)
- [x] Sidebar links to /docs/api/act-sse/src and /docs/api/act-tck/src no longer flagged as broken
- [ ] CI \`Deploy Docusaurus Docs\` workflow green on merge

## Stability charter impact

No charter-covered files changed.

## Follow-ups

Two pre-existing broken-link warnings remain (\`PERFORMANCE.md\` and \`act-http/README.md\` linking to lib READMEs outside the docs tree). Not in scope here — they're warnings, not errors, and the build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>