### PR TITLE
fix(docs): add act subpath path mappings for typedoc

### DIFF
--- a/docs/docs/architecture/extension-points.md
+++ b/docs/docs/architecture/extension-points.md
@@ -302,7 +302,7 @@ Concrete scenarios:
 - **Notify subscriptions bind to the scoped store at construction.** `Store.notify` is wired once per Act, against `options.scoped.store` when scoped or the singleton otherwise. Same as the singleton case: late injection after `build()` doesn't take effect.
 - **Lifecycle is the operator's.** Scoped adapters are *not* registered with the framework's `dispose()` registry. You own them — dispose them explicitly (or wrap your own `dispose()` callback that does). The singleton registry only tracks adapters installed via `store(adapter)` / `cache(adapter)` / `log(adapter)`.
 - **Logger stays singleton.** `ActOptions.scoped` doesn't include a logger; all Acts in a process share `log()`. Per-Act logger overrides aren't required by current scenarios — add via child binding (`log().child({ tenant: ... })`) at the call site if you need correlation.
-- **Performance.** ALS adds no measurable overhead in modern Node — the port getter is ~65 ns whether scoped or not, and `app.do()` / `app.load()` show no difference between scoped and unscoped Acts. See [`libs/act/PERFORMANCE.md` § Per-Act scoped ports](../../../libs/act/PERFORMANCE.md).
+- **Performance.** ALS adds no measurable overhead in modern Node — the port getter is ~65 ns whether scoped or not, and `app.do()` / `app.load()` show no difference between scoped and unscoped Acts. See [`libs/act/PERFORMANCE.md` § Per-Act scoped ports](https://github.com/Rotorsoft/act-root/blob/master/libs/act/PERFORMANCE.md).
 
 ## Pointers
 

--- a/docs/docs/guides/external-integration.md
+++ b/docs/docs/guides/external-integration.md
@@ -405,7 +405,7 @@ The migration itself is cheap: replace the inline reaction's body with a `bus.pu
 
 ## Related
 
-- [Webhook helper](../../../../../libs/act-http/README.md) — the `@rotorsoft/act-http/webhook` package and its `timeoutMs`/`leaseMillis` constraint
+- [Webhook helper](https://github.com/Rotorsoft/act-root/blob/master/libs/act-http/README.md) — the `@rotorsoft/act-http/webhook` package and its `timeoutMs`/`leaseMillis` constraint
 - [Error handling](../concepts/error-handling.md) — backoff, non-retryable errors, blocked streams, `unblock`
 - [Cross-process reactions](../architecture/cross-process-reactions.md) — `Store.notify`, competing consumers, topology shapes
 - [Concurrency model](../architecture/concurrency-model.md) — lease lifecycle, `claim`/`ack`/`block`/timeout transitions

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -8,6 +8,8 @@
     "jsx": "react-jsx",
     "paths": {
       "@rotorsoft/act": ["../libs/act/src/index.ts"],
+      "@rotorsoft/act/types": ["../libs/act/src/types/index.ts"],
+      "@rotorsoft/act/test": ["../libs/act/src/test/index.ts"],
       "@rotorsoft/act-diagram": ["../libs/act-diagram/src/index.ts"],
       "@rotorsoft/act-http/webhook": ["../libs/act-http/src/webhook/index.ts"],
       "@rotorsoft/act-http/sse": ["../libs/act-http/src/sse/index.ts"],

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -1123,7 +1123,7 @@ export class Act<
    * fully catches up paginated streams without forcing callers to roll
    * their own loop.
    *
-   * @param streams - Reaction target streams (e.g., projection names) to reset
+   * @param input - Reaction target streams (e.g., projection names) to reset, or a {@link StreamFilter} for bulk operations
    * @returns Count of streams that were actually reset
    *
    * @example Rebuild a projection (production)
@@ -1164,7 +1164,7 @@ export class Act<
    * directly, but `store().unblock(...)` alone leaves the flag
    * untouched.
    *
-   * @param streams - Stream names to unblock
+   * @param input - Stream names to unblock, or a {@link StreamFilter} for bulk recovery
    * @returns Count of streams that were actually flipped (were blocked)
    *
    * @example Recover from a 4xx webhook after fixing the bug


### PR DESCRIPTION
## Summary

The master Deploy Docusaurus Docs workflow failed again after #825 merged. Root cause: #825 added \`act-tck\` to typedoc's entryPoints AND to \`docs/tsconfig.json\`'s include set, but act-tck imports from \`@rotorsoft/act/types\` and \`@rotorsoft/act/test\` subpath exports — and \`docs/tsconfig.json\`'s \`paths\` only mapped the root \`@rotorsoft/act\`.

## The cascade

\`\`\`
../libs/act-tck/src/cache-tck.ts(1,40): error TS2307:
  Cannot find module '@rotorsoft/act/types'.
../libs/act-tck/src/fixtures/helpers.ts(83,37): error TS7006:
  Parameter 'e' implicitly has an 'any' type.
…(~50 more noImplicitAny errors throughout act-tck)
\`\`\`

Once the \`Schemas\` type import failed (TS2307), every \`Schemas\`-typed callback parameter cascaded to \`any\` and tripped the strict check. The deluge of TS7006 errors was the second-order symptom, not the root cause.

## Why it worked locally but not in CI

Locally, pnpm's symlink farm had the lib \`dist/@types/\` directories populated from prior builds, so module resolution succeeded via the package.json \`exports\` field. CI's fresh checkout doesn't pre-build the libs before typedoc runs, so it relied on \`paths\` — which didn't have entries for the subpaths.

## Fix

Add explicit \`paths\` entries for both subpaths:

\`\`\`diff
   "paths": {
     "@rotorsoft/act": ["../libs/act/src/index.ts"],
+    "@rotorsoft/act/types": ["../libs/act/src/types/index.ts"],
+    "@rotorsoft/act/test": ["../libs/act/src/test/index.ts"],
     "@rotorsoft/act-diagram": [...],
\`\`\`

TypeScript treats \`paths\` keys as exact prefix matches; \`/types\` and \`/test\` need their own entries.

## Test plan

- [x] \`pnpm -F docs build:all\` succeeds (typedoc + docusaurus) against a clean \`.docusaurus\` + \`build\` + \`docs/api\` cache
- [x] Typedoc reports 0 errors, 2 pre-existing warnings unchanged
- [ ] CI Deploy Docusaurus Docs workflow green on merge

## Stability charter impact

No charter-covered files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>