### PR TITLE
docs(act-patch): document delta's explicit-null propagation

### DIFF
--- a/libs/act-patch/README.md
+++ b/libs/act-patch/README.md
@@ -44,8 +44,41 @@ That's the whole surface — two functions plus the type-level helpers. Everythi
 ## API
 
 - **`patch(original, patches)`** — immutably deep-merges `patches` into `original`. Returns a new state object with structural sharing of unchanged subtrees. Accepts `Patch<S>` (positive changes plus `null`/`undefined` deletion sentinels).
-- **`delta(before, after)`** — computes the smallest `DeepPartial<S>` describing what changed from `before` to `after`. Designed for event payloads — never emits `null`; missing keys in `after` are omitted from the result rather than encoded as deletion sentinels.
-- **Types**: `Patch<T>` (operator-facing recursive partial with `null` deletion), `DeepPartial<T>` (event-payload shape returned by `delta`, no `null` arms), `Schema` (plain-object shape).
+- **`delta(before, after)`** — computes the smallest `DeepPartial<S>` describing what changed from `before` to `after`. Designed for event payloads — never *synthesizes* `null` for a missing key, but always *propagates* `null` when the caller put one in `after`. See [Modeling deletions](#modeling-deletions) for how that asymmetry carries a clear-this-field action all the way to the aggregate.
+- **Types**: `Patch<T>` (operator-facing recursive partial with `null` deletion), `DeepPartial<T>` (event-payload shape returned by `delta`, includes `null` only where the schema declares `T[K]` as nullable), `Schema` (plain-object shape).
+
+## Modeling deletions
+
+The end-to-end deletion flow — action signals "clear this field" → event records it → reducer applies it to state — works through `delta` without you having to switch tools. The rule is short: **`delta` never invents a `null`, but it forwards every `null` the caller put in `after`.** That means the *action* drives the runtime, and the *schema* controls the type:
+
+| What the caller put in `after` for key `k` | What `delta` returns for `k` | What `patch` does on replay |
+|---|---|---|
+| (key omitted)                              | (key omitted)                | leaves `state[k]` alone |
+| explicit `null` (schema permits)           | `null`                       | deletes `state[k]` (null is `patch`'s deletion sentinel) |
+| new value                                  | the new value                | sets `state[k]` |
+| same reference as `before[k]`              | (key omitted)                | leaves `state[k]` alone |
+
+```ts
+// 1) Action with a deletable field — schema declares it `.nullable()`
+const state = { bio: "old", name: "Alice" };
+const data  = { bio: null, name: "Alice" };
+
+const eventPayload = delta(state, data);
+// → { bio: null }      ← propagated, not synthesized
+
+patch(state, eventPayload);
+// → { name: "Alice" }  ← state.bio is gone
+
+// 2) Action that just doesn't touch a field — non-nullable schema is fine
+const data2 = { name: "Bob" };  // no `bio` key at all
+const eventPayload2 = delta(state, data2);
+// → { name: "Bob" }    ← bio is omitted because the action didn't mention it
+
+patch(state, eventPayload2);
+// → { bio: "old", name: "Bob" }  ← bio left alone
+```
+
+The asymmetry is what keeps the konsult-style scenario clean: a schema with no `.nullable()` fields produces a `DeepPartial<S>` with no `| null` arms, an action that conforms to that schema can't carry `null`, and `delta` can't put one in the output because there was nothing in `after` to propagate. The type and the runtime agree: no nulls anywhere. As soon as a schema opts into `.nullable()` on a field, the type widens to admit `null`, the action can carry it, and `delta` carries it through. Same code path, both behaviors, driven by the schema.
 
 ## Common patterns
 
@@ -84,11 +117,14 @@ This is safe in event sourcing because state is typed `Readonly<S>` (compiler pr
 ### Round-trip identity
 
 ```
-patch(before, delta(before, after))  ≡  after        // when keys(after) ⊇ keys(before)
+patch(before, delta(before, after))  ≡  after
+   // when keys(after) ⊇ keys(before),  OR
+   // when every key in before \ after is set to null in after
+
 delta(before, before)                ≡  {}           // idempotent
 ```
 
-The round-trip holds for the equal-shape case (the common shape for event payloads against a stable state schema): every key in `before` is still in `after`, so `delta` records only the changes and `patch` reconstructs `after` faithfully. When `after` has fewer keys than `before`, the missing keys are omitted from `delta`'s output — `patch` then treats the omission as "no change", so the dropped keys survive the replay. This is intentional: `delta` produces event payloads, which record positive facts, not deletion instructions. Express a deletion directly as `patch(state, { key: null })`.
+The round-trip holds whenever `after` faithfully expresses the intended end-state — either by retaining every original key (the equal-shape case, common for event payloads against a stable state schema) or by setting the to-be-removed keys to `null` (the caller-driven deletion case from [Modeling deletions](#modeling-deletions)). If `after` silently *omits* a key that was in `before`, `delta` reads that as "no change" and the dropped key survives the replay — express the deletion as `null` instead, or instruct `patch` directly (`patch(before, { key: null })`).
 
 In Act's event sourcing model, an event's data *is* the (event-shaped) patch. Either direction works: emit `delta(prev, next)` as event data and let the framework apply it via `patch`, or hand-write a `Patch<S>` and emit it directly. No diff/merge logic on the application side.
 
@@ -101,8 +137,9 @@ In Act's event sourcing model, an event's data *is* the (event-shaped) patch. Ei
 | Same reference (`Object.is`) | omit (mirrors patch's structural sharing) |
 | Both plain objects | recurse |
 | Different references, any other diff | set to `after[K]` (wholesale replace) |
-| Key in `before` only | omit (event payloads record changes, not deletions — at any depth) |
-| Key in `after` only | set to `after[K]` |
+| Key in `before` only — *omitted* from `after` | omit (no synthesized null at any depth) |
+| Key in `after` set explicitly to `null` | set to `null` (caller-driven deletion — propagated, see [Modeling deletions](#modeling-deletions)) |
+| Key in `after` only (introduced) | set to `after[K]` |
 
 Two structurally-equal-but-distinct values (e.g. two `Date` instances with the same `getTime()`) emit a replacement — safe semantically, just slightly less compact. `Object.is` handles `NaN === NaN` and distinguishes `+0` from `-0` correctly.
 

--- a/libs/act-patch/src/delta.ts
+++ b/libs/act-patch/src/delta.ts
@@ -2,24 +2,44 @@ import type { DeepPartial, Schema } from "./types.js";
 
 /**
  * Compute the smallest `DeepPartial<S>` describing what changed between
- * `before` and `after`. Designed for event payloads — records positive
- * facts (what changed) rather than `patch` instructions (which include a
- * `null` deletion sentinel).
+ * `before` and `after`. Designed for event payloads — records what the
+ * caller put in `after`, rather than synthesizing `patch` instructions
+ * on the caller's behalf.
  *
- * **Rules** (mirror `patch`'s merging rules for the *change* cases):
- * - Same reference (`Object.is`)            → omit (mirrors structural sharing)
- * - Both plain objects                      → recurse (mirrors deep merge)
- * - Otherwise (any other diff)              → set to `after[K]` (mirrors wholesale replace)
- * - Key in `before` only (missing in after) → omit
+ * ## How `delta` reacts to what's in `after`
  *
- * **Round-trip property**: when `before` and `after` share the same key
- * set (the common case for event payloads against a stable state schema),
- * `patch(before, delta(before, after))` deeply equals `after`. When `after`
- * has fewer keys than `before`, the missing key is omitted from the output
- * rather than encoded as a deletion sentinel — `patch` treats the omission
- * as "no change," so the dropped key survives the round-trip. Use
- * `patch(before, { key: null })` directly if you need to express deletion
- * as an instruction; `delta` is for events.
+ * | What the caller put in `after` for key `k` | What `delta` returns for `k` | What `patch` does on replay |
+ * |---|---|---|
+ * | (key omitted)                              | (key omitted)                | leaves `state[k]` alone |
+ * | explicit `null` (schema permits)           | `null`                       | deletes `state[k]` (null is `patch`'s deletion sentinel) |
+ * | new value                                  | the new value                | sets `state[k]` |
+ * | same reference as `before[k]`              | (key omitted)                | leaves `state[k]` alone |
+ *
+ * The asymmetry that matters: **`delta` never *synthesizes* `null` for a
+ * missing key, but it always *propagates* `null` when the caller put one
+ * in `after`**. So nullable-schema actions can express a deletion as
+ * `{ field: null }`, and the deletion travels through delta → event →
+ * reducer-side `patch(state, eventData)` all the way to the aggregate.
+ * Non-nullable schemas (no `.nullable()` fields) never see `null` in the
+ * type or at runtime — the konsult case.
+ *
+ * ## Recursion
+ *
+ * - Same reference (`Object.is`)                          → omit
+ * - Both plain objects                                    → recurse
+ * - Any other diff (value, type, reference)               → set to `after[K]`
+ * - Key in `before` only (missing in `after`)             → omit
+ * - Key in `after` only, or explicit `null` in `after`    → set to `after[K]` (so an explicit `null` flows through)
+ *
+ * ## Round-trip property
+ *
+ * `patch(before, delta(before, after))` deeply equals `after` when the
+ * key set in `after` is a superset of the key set in `before` (or the
+ * shrinkages are encoded as explicit nulls in `after`). If `after`
+ * silently *omits* keys that were present in `before`, the dropped key
+ * survives the round-trip — `delta` reads the omission as "no change,"
+ * not "delete." Express deletion in `after` (as `null`) or instruct
+ * `patch` directly (`patch(before, { key: null })`).
  *
  * Equality is reference-based, matching `patch`'s structural-sharing model.
  * Two structurally-equal-but-distinct values (e.g. two `Date` instances with
@@ -29,9 +49,9 @@ import type { DeepPartial, Schema } from "./types.js";
  *
  * @param before - The original state object
  * @param after - The desired state object
- * @returns The smallest deep-partial that, when merged onto `before`,
- *   produces an object structurally matching `after` (modulo deletions —
- *   see the round-trip caveat above).
+ * @returns The smallest deep-partial describing what `after` says changed
+ *   relative to `before`. May contain `null` only when `after` itself
+ *   contained `null` at the same path.
  */
 export const delta = <S extends Schema>(
   before: Readonly<S>,

--- a/libs/act-patch/test/delta.spec.ts
+++ b/libs/act-patch/test/delta.spec.ts
@@ -88,11 +88,13 @@ describe("delta", () => {
   });
 
   describe("missing keys — event-payload shape", () => {
-    it("omits every key present only in before (no null sentinel)", () => {
+    it("omits every key present only in before (no synthesized null)", () => {
       expect(delta<Schema>({ a: 1, b: 2, c: 3 }, { a: 1 })).toEqual({});
     });
 
-    it("never produces null at any depth", () => {
+    it("never synthesizes null for missing keys at any depth", () => {
+      // `delta` doesn't *invent* a null for an absent key. (Explicit
+      // nulls in `after` are propagated — see the next describe block.)
       const before = {
         keep: 1,
         drop: 2,
@@ -103,6 +105,53 @@ describe("delta", () => {
       expect(result).toEqual({});
       const stringified = JSON.stringify(result);
       expect(stringified).not.toContain("null");
+    });
+  });
+
+  // Locks in the asymmetry: `delta` never *synthesizes* null for a
+  // missing key, but it always *propagates* null when the caller put
+  // one in `after`. That's the contract that makes the deletion flow
+  // work end-to-end: nullable-schema action carries `{ field: null }`
+  // → delta emits `{ field: null }` → reducer's `patch(state, data)`
+  // reads the null as the deletion sentinel and removes the key.
+  describe("explicit nulls in `after` — caller-driven deletion", () => {
+    it("propagates a shallow explicit null from after", () => {
+      const before = { bio: "old", name: "Alice" };
+      const after = { bio: null, name: "Alice" };
+      expect(delta<Schema>(before, after)).toEqual({ bio: null });
+    });
+
+    it("propagates a nested explicit null from after", () => {
+      const before = {
+        profile: { bio: "old", avatar: "u.png" },
+      };
+      const after = {
+        profile: { bio: null, avatar: "u.png" },
+      };
+      expect(delta<Schema>(before, after)).toEqual({
+        profile: { bio: null },
+      });
+    });
+
+    it("propagates an explicit null introducing a new key", () => {
+      expect(delta<Schema>({ a: 1 }, { a: 1, b: null })).toEqual({ b: null });
+    });
+
+    it("recognizes Object.is(null, null) → omits an unchanged null", () => {
+      expect(delta<Schema>({ b: null }, { b: null })).toEqual({});
+    });
+
+    it("treats null → non-null as a wholesale replace (not a recurse)", () => {
+      expect(delta<Schema>({ x: null }, { x: { nested: 1 } })).toEqual({
+        x: { nested: 1 },
+      });
+    });
+
+    it("round-trips through patch — caller-supplied null deletes the field", () => {
+      const before = { bio: "old", name: "Alice" };
+      const data = { bio: null, name: "Alice" };
+      const d = delta<Schema>(before, data);
+      expect(patch(before, d)).toEqual({ name: "Alice" });
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #830. The fix landed the right runtime behavior, but the docs and tests only described one side of the contract — that `delta` doesn't *synthesize* `null` for missing keys. The other half was implicit in the code and easy to miss reading the README or jsdoc: `delta` *propagates* every `null` the caller put in `after`, so a nullable-schema action carrying `{ field: null }` flows through delta into the event, and the reducer's `patch(state, eventData)` deletes the field on the aggregate. That's the end-to-end deletion path operators reach for, and it deserves a top-billing section.

No code change. Tests, jsdoc, and README only.

## The contract, spelled out

| What the caller put in `after` for key `k` | What `delta` returns for `k` | What `patch` does on replay |
|---|---|---|
| (key omitted)                              | (key omitted)                | leaves `state[k]` alone |
| explicit `null` (schema permits)           | `null`                       | deletes `state[k]` (null is `patch`'s deletion sentinel) |
| new value                                  | the new value                | sets `state[k]` |
| same reference as `before[k]`              | (key omitted)                | leaves `state[k]` alone |

The action drives the runtime; the schema controls the type. Non-nullable schemas (the konsult case) produce a `DeepPartial<S>` with no `| null` arms — an action that conforms can't even carry `null`, so `delta` won't either. Nullable schemas widen the type and admit the deletion path. Same code path serves both scenarios.

## Tests

New describe block in `libs/act-patch/test/delta.spec.ts` — `explicit nulls in 'after' — caller-driven deletion`:

- propagates a shallow explicit null from `after`
- propagates a nested explicit null from `after` (depth ≥ 2)
- propagates an explicit null introducing a new key
- recognizes `Object.is(null, null)` → omits an unchanged null
- treats `null → non-null` as a wholesale replace (not a recurse)
- round-trips through `patch` — caller-supplied null actually deletes the field on the aggregate

Existing test `never produces null at any depth` renamed to `never *synthesizes* null for missing keys at any depth` with an inline comment cross-referencing the new block. The looser name read as "delta will never emit null," which isn't the contract — it just doesn't invent one.

## README

New `## Modeling deletions` section, promoted to a top-level heading right under the API list (not buried in "Common patterns") because it's the first thing a reader wants to know after seeing `delta`'s new return type. Carries the action-sent → delta-returns → patch-does table from above plus a runnable example showing both the nullable-schema deletion path and the konsult-style omitted-key no-op path side by side.

Tightening passes elsewhere in the README:

- API-list entry for `delta` now reads "never *synthesizes* `null` for a missing key, but always *propagates* `null` when the caller put one in `after`" with a link to the new section. The previous "never emits `null`" claim was technically wrong.
- "Round-trip identity" widened: the property holds when `keys(after) ⊇ keys(before)` *or* when every removed key is set to `null` in `after`. The caller-driven deletion path round-trips too.
- Equality-semantics table split the "Key in `before` only" row into two — *omitted from `after`* (no synthesized null) vs *set to `null` in `after`* (propagated). Makes the asymmetry visible without reading the prose.

## Jsdoc

`delta()`'s doc-comment now leads with the same action-sent → returns → patch-does table so consumers reading it via hover/auto-complete in their IDE see the contract without having to find the README. The Recursion and Round-trip subsections were rewritten in lockstep with the README changes.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 1900 / 1900 pass (six new cases in `delta.spec.ts`, +6 from the master baseline of 1894).
- [x] Coverage 100% / 100% / 100% / 100%.
- [x] `npx biome check libs/act-patch` clean (no errors, no warnings).
- [x] `pnpm -F @rotorsoft/act-patch build` — ESM + CJS + types emit cleanly.
- [ ] CI green on PR.

Coverage: 100% statements / 100% branches / 100% functions / 100% lines.

## Stability charter impact

None. No exported function, type, or signature changes. Documentation and tests only — the test additions lock in the runtime behavior that already shipped in #830 against future regressions. `docs(act-patch):` doesn't trigger a semantic-release run.

## Follow-ups

None — this closes the gap surfaced in the follow-up discussion on #829/#830. The explicit-null path is now testable, documented at the README level, and visible in the IDE-rendered jsdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)