### PR TITLE
feat(act-ops): add IdempotencyStore port + InMemoryIdempotencyStore

### DIFF
--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -209,11 +209,51 @@ try {
 
 Error constants: `Errors.ValidationError = "ERR_VALIDATION"`, `Errors.InvariantError = "ERR_INVARIANT"`, `Errors.ConcurrencyError = "ERR_CONCURRENCY"`.
 
-## Idempotent API Requests
+## Idempotency
 
-Request-level idempotency belongs in API middleware, not in the event sourcing framework. Act uses optimistic concurrency (`expectedVersion`) for conflict detection at the store level.
+Two distinct idempotency shapes show up in real apps. They share a header (`Idempotency-Key` or an equivalent input field) and a goal (make retries safe) but their storage primitives differ:
 
-For safe client retries, add a tRPC middleware with a dedicated cache:
+- **Receiver-side dedup** — inbound webhooks / bus events. The contract is "did I already process this `Idempotency-Key`?" → return cached *outcome marker*, don't re-execute the side effect. Storage primitive: `IdempotencyStore.record_if_fresh(key) → boolean`. Use `@rotorsoft/act-ops` (see below).
+- **API-edge request dedup** — client-originated tRPC calls where retries should *replay the original response* verbatim. The contract is "did I already answer this `idempotencyKey`?" → return cached *response value*. Storage primitive: key → response cache. Inline implementation below.
+
+If the scaffolded app exposes a webhook receiver, reach for `@rotorsoft/act-ops`. If it only handles API-edge retries, the inline pattern below is enough.
+
+### Receiver-side dedup with `@rotorsoft/act-ops`
+
+When the app receives webhooks (or forwarded bus events) and needs the receiver-side idempotency contract documented in [external integration](https://rotorsoft.github.io/act-root/docs/guides/external-integration), use the shipped port + reference implementation:
+
+```typescript
+// packages/app/src/api/webhook-receiver.ts
+import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops";
+
+const dedup = new InMemoryIdempotencyStore({
+  ttlMs: 24 * 60 * 60 * 1000,
+  maxEntries: 50_000,
+});
+
+export const webhookRouter = router({
+  inbound: t.procedure
+    .input(InboundEventSchema)
+    .mutation(async ({ input, ctx }) => {
+      const key = ctx.headers["idempotency-key"];
+      if (!key) throw new TRPCError({ code: "BAD_REQUEST", message: "Missing Idempotency-Key" });
+
+      const fresh = dedup.record_if_fresh(key);
+      if (!fresh) return { status: "dedup-skipped" as const, key };
+
+      await app.do(/* … apply the inbound event … */);
+      return { status: "processed" as const, key };
+    }),
+});
+```
+
+For multi-process receivers, swap `InMemoryIdempotencyStore` for a durable adapter (Postgres unique index, Redis `SET NX EX`) implementing the same `IdempotencyStore` port — the middleware body doesn't change. Working examples in [external integration § implementations](https://rotorsoft.github.io/act-root/docs/guides/external-integration#implementations).
+
+> Add `@rotorsoft/act-ops` to the workspace package's dependencies (`workspace:^`). It has no peer dep on `@rotorsoft/act`, so non-Act services in the same monorepo (a Kafka consumer, an Express endpoint) can install it without dragging the orchestrator along.
+
+### API-edge response replay (inline)
+
+API-edge request-level idempotency (where the *response* itself must be replayed for client retries) is a different shape from receiver-side dedup. There's no shipped primitive for it — `@rotorsoft/act-ops`'s `record_if_fresh` returns a boolean, not a stored response. Use a small per-app middleware:
 
 ```typescript
 // packages/app/src/api/middleware.ts

--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -213,7 +213,7 @@ Error constants: `Errors.ValidationError = "ERR_VALIDATION"`, `Errors.InvariantE
 
 Two distinct idempotency shapes show up in real apps. They share a header (`Idempotency-Key` or an equivalent input field) and a goal (make retries safe) but their storage primitives differ:
 
-- **Receiver-side dedup** — inbound webhooks / bus events. The contract is "did I already process this `Idempotency-Key`?" → return cached *outcome marker*, don't re-execute the side effect. Storage primitive: `IdempotencyStore.record_if_fresh(key) → boolean`. Use `@rotorsoft/act-ops` (see below).
+- **Receiver-side dedup** — inbound webhooks / bus events. The contract is "did I already process this `Idempotency-Key`?" → return cached *outcome marker*, don't re-execute the side effect. Storage primitive: `IdempotencyStore.claim(key) → boolean`. Use `@rotorsoft/act-ops` (see below).
 - **API-edge request dedup** — client-originated tRPC calls where retries should *replay the original response* verbatim. The contract is "did I already answer this `idempotencyKey`?" → return cached *response value*. Storage primitive: key → response cache. Inline implementation below.
 
 If the scaffolded app exposes a webhook receiver, reach for `@rotorsoft/act-ops`. If it only handles API-edge retries, the inline pattern below is enough.
@@ -238,7 +238,7 @@ export const webhookRouter = router({
       const key = ctx.headers["idempotency-key"];
       if (!key) throw new TRPCError({ code: "BAD_REQUEST", message: "Missing Idempotency-Key" });
 
-      const fresh = dedup.record_if_fresh(key);
+      const fresh = dedup.claim(key);
       if (!fresh) return { status: "dedup-skipped" as const, key };
 
       await app.do(/* … apply the inbound event … */);
@@ -253,7 +253,7 @@ For multi-process receivers, swap `InMemoryIdempotencyStore` for a durable adapt
 
 ### API-edge response replay (inline)
 
-API-edge request-level idempotency (where the *response* itself must be replayed for client retries) is a different shape from receiver-side dedup. There's no shipped primitive for it — `@rotorsoft/act-ops`'s `record_if_fresh` returns a boolean, not a stored response. Use a small per-app middleware:
+API-edge request-level idempotency (where the *response* itself must be replayed for client retries) is a different shape from receiver-side dedup. There's no shipped primitive for it — `@rotorsoft/act-ops`'s `claim` returns a boolean, not a stored response. Use a small per-app middleware:
 
 ```typescript
 // packages/app/src/api/middleware.ts

--- a/book/act-1118-idempotency-store.md
+++ b/book/act-1118-idempotency-store.md
@@ -1,0 +1,86 @@
+# ACT-1118 — naming a port that's almost a Cache (but isn't)
+
+## What this ticket actually closes
+
+[ACT-603](./act-603-external-integration.md) shipped the *story* — inline vs forwarded, the receiver-side idempotency contract, the TTL math. The cache itself was demo code under `packages/server/`. A reader who liked the contract had to copy a class out of an example app and rename it into their service. That's not how a contract ships; that's how a pattern ships.
+
+ACT-1118 promotes the contract to a port: `IdempotencyStore.record_if_fresh(key, now?) → boolean | Promise<boolean>`. Drops a reference implementation next to it: `InMemoryIdempotencyStore`, lifted verbatim from the demo with the class renamed. Both ship from `@rotorsoft/act-ops`, the zero-`act`-dependency lib bootstrapped by [ACT-1117](https://github.com/Rotorsoft/act-root/issues/745) for exactly this kind of cross-cutting operational primitive.
+
+It's a small ticket. The implementation is sixty lines. The reasoning is most of why the ticket exists.
+
+## The naming question that took longer than the code
+
+`Cache` was the first instinct. The demo class was called `IdempotencyCache`. The doc colloquially called these "cache shapes." Every Redis tutorial that shows `SET NX EX` calls it a cache. The name had two years of momentum behind it.
+
+The thing it stores, though, isn't cache-shaped. In this codebase `Cache` has a specific meaning: *rebuildable from a source of truth*. The snapshot cache is the canonical case — lose it and you replay events from the store. Cost is a cold-load latency spike, not a correctness bug. The reaction's authoritative state lives in the event log; the cache is just a fast path.
+
+Dedup state isn't that. There *is* no source of truth to replay from. The sender doesn't know you've already processed key `X`; it'll cheerfully retry and your receiver will cheerfully run the side effect a second time. Losing a dedup record causes a *duplicate side effect* — pay the same invoice twice, send the same email twice, open the same incident twice. That's a correctness bug, not a rebuild cost. The dedup record is authoritative. There's nothing to "rebuild" it from.
+
+`Store` is the codebase's word for "authoritative state." The event store is the canonical case; the snapshot cache is its rebuildable shadow. By that taxonomy the dedup primitive is straightforwardly a Store. So `IdempotencyStore`.
+
+The naming choice has a practical consequence. When an operator picks an implementation — say, swapping the in-memory reference impl for Redis at production deploy time — they should be picking on the load-bearing property: *persistence*. Redis `SET NX EX` qualifies because the data survives the consuming process. A genuinely volatile cache (TTL too short relative to retry envelope, or worse, an unbounded LRU that evicts a hot key in the middle of a retry burst) is *unsafe*, not just *suboptimal*. The taxonomy makes that legible. A "Cache" tolerates eviction by definition; a "Store" doesn't.
+
+This is the kind of naming decision that's tempting to fast-forward through in code review. The compiler doesn't care; the tests don't care; the runtime behavior of `record_if_fresh` is identical either way. Future ports and future ports of *those* ports do care: every operator who reads `IdempotencyStore` should already know, before they look at the API, what the failure mode of losing data is.
+
+## Why a separate package, not `libs/act`
+
+The dedup contract gets consumed by receivers. Some of those receivers are Act apps — the wolfdesk webhook-receiver demo is one. Many won't be. The forwarded-shape integrations in ACT-603 explicitly anticipate a non-Act consumer: a Kafka topic with a worker that processes events from a bus, no event store of its own, no orchestrator running, no `app.do()` calls. That worker still has to honor `Idempotency-Key`. The contract has to be reachable from there.
+
+Putting `IdempotencyStore` in `libs/act` would force every receiver to pull in the orchestrator just to call `record_if_fresh`. That's a tax of tens of kilobytes plus the conceptual overhead of "wait, do I need an event store?" — for a service that doesn't. Bad shape.
+
+The alternative `libs/act-http` was considered and dropped. `act-http` already owns the *outbound* webhook helper (the sender side that sets `Idempotency-Key`), and one might argue the receiver-side port belongs alongside its mirror. But durable adapters of the port — Postgres, Redis, future ones — have nothing to do with HTTP. A Kafka receiver wouldn't depend on `act-http` just to get the dedup port. Putting the port in `act-http` would mean either: (a) every durable adapter pulls in HTTP plumbing it doesn't need, or (b) the port lives in *both* packages with weird re-exports. Neither shape is good.
+
+So `@rotorsoft/act-ops` — a deliberately broad name, scoped for future cross-cutting operational primitives that share the same "non-Act apps want this too" property. The next two siblings already line up: `computeMinSafeTtl` (the TTL math from ACT-603, finally as a helper instead of a prose paragraph) and the retry-budget classifiers that ACT-601 hinted at. All of them are math, not orchestration. None of them need `@rotorsoft/act` at runtime. The package is the home.
+
+The load-bearing constraint shows up as a one-line grep in CI: no `@rotorsoft/act` import anywhere in `libs/act-ops/`. The package's bootstrap PR ([ACT-1117](https://github.com/Rotorsoft/act-root/issues/745)) called this out explicitly; this ticket is the first to actually pay the constraint off.
+
+## The sync-or-async return type, and why it isn't a Promise
+
+The port signature is `record_if_fresh(key: string, now?: number): boolean | Promise<boolean>`. Not `Promise<boolean>`. The union return.
+
+The first instinct here is to always `Promise<boolean>` and force every implementation to be async. It's the conventional shape: durable adapters need to be async (they wait on I/O), and a sync in-memory impl that "returns immediately" still works under `await` — `await` on a non-Promise resolves synchronously, same microtask. Why not just standardize on Promise?
+
+Two reasons. The first is observable in benchmarks: an `await` on a synchronous-returned value is not free. The microtask scheduling has a real cost (~100ns on V8), measurable across the millions of webhooks an active receiver processes daily. The in-memory store is the right answer for single-process receivers — the bench should reflect what it actually costs to use. Forcing it to be async would erase the speed advantage that motivated picking the in-memory impl in the first place.
+
+The second is taste, but it's a load-bearing taste. `Promise<boolean>` says "this might do I/O." That's a lie for the in-memory impl. The contract should describe what implementations *actually* return, not paper over the difference to make the call site marginally simpler. Consumers that need to be polymorphic across implementations can write `await store.record_if_fresh(key)` and TypeScript narrows the union for them. Consumers that know they have the in-memory impl can omit the `await` and pay no microtask cost. Both shapes are correct.
+
+This is the same trade-off the Store interface makes (`commit` returns `Promise<Committed[]>` everywhere because it's *always* I/O; `record_if_fresh` doesn't because it isn't always). Once you've named the property — "the in-memory impl is sync, the durable ones are async, the type system says so" — the union-return decision falls out.
+
+## The defensive branch that has to die
+
+There's a single-line cleanup in the in-memory implementation that wouldn't be worth mentioning except that it's why this code moves into `libs/` and not into `packages/` again. The pre-existing class had:
+
+```ts
+if (this.seen.size > this.maxEntries) {
+  const oldest = this.seen.keys().next().value;
+  if (oldest !== undefined) this.seen.delete(oldest);
+}
+```
+
+The outer guard is meaningful: we just `set` a key, so size is at least 1, and we only enter the branch when size *exceeds* `maxEntries`. The inner guard (`if (oldest !== undefined)`) is satisfying TypeScript's type system, not protecting against a runtime case. By construction the map has at least one entry, so `.keys().next().value` is a string; `undefined` is impossible.
+
+In `packages/server` the inner guard doesn't matter. The package isn't under the 100%-coverage gate; nobody is going to write a test that hits the `if (oldest !== undefined)` false branch because it's unreachable. The guard quietly costs no one anything.
+
+In `libs/`, it does matter. The 100%-coverage rule says: every branch gets covered, or the branch dies. There's no way to cover the false case without mutating private state, and a test that mutates private state to prove an unreachable branch is unreachable would be parodically bad. So the guard goes. The cleanup makes the code one line shorter and exactly as correct. A non-null assertion (`as string`) replaces the runtime check, with an inline comment explaining why the assertion holds.
+
+This is a small example of a bigger pattern. The 100%-coverage rule isn't really about coverage. It's a forcing function for *removing unreachable code*. Every defensive branch the rule catches is an opportunity to either prove a contract more cleanly or admit that the runtime can do something the author wasn't expecting. The in-memory impl falls in the first bucket. After the move, the construction-by-design property ("size > 0 when we enter the branch") is documented at the call site instead of hidden behind a vestigial null check.
+
+The book chapter on "what's special about Act's libs" should foreground this. It's the cleanest example of how a small library guarantee — every branch is reachable, or it doesn't exist — propagates into clearer code. Most of the codebase is already there; the parts that aren't get fixed during PRs like this one.
+
+## The migration story, and why nothing changes at the call site
+
+The wolfdesk demo's webhook-receiver imports `IdempotencyCache` today. After this ticket it imports `InMemoryIdempotencyStore`. The class renamed; the constructor signature is identical; the one used method (`record_if_fresh`) is identical. The diff in `webhook-receiver.ts` is a one-import change and a `cache` → `dedup` variable rename. That's all.
+
+This matters because the contract was correct on day one. The shape that emerged from the demo was the shape the port wants. The ticket didn't need to *design* anything — it needed to *promote* something. The work was in the doc (renaming, scoping, getting the API surface right) and in the move (extracting the class, dropping the defensive branch, wiring the workspace dep).
+
+A different ticket would have looked at the same code and decided to redesign. Maybe split `record_if_fresh` into `has` + `put` for "flexibility." Maybe make it generic over the value type so callers can store metadata alongside the key. Maybe add an `options` bag for per-call TTL overrides. Each of those changes would have been a defensible local optimization and a globally worse design — more surface to maintain, more decisions at the call site, no real demand from any consumer. The contract stays small. One method. One return. The reason it stays small is that nobody has asked for it to be bigger.
+
+The follow-ups are named (PostgresIdempotencyStore in `act-pg`, idempotencyTck in `act-tck`) and explicitly *deferred* to milestone 1.2. The port should bake one release before durable adapters land. If a Postgres user shows up tomorrow with the working `INSERT … ON CONFLICT` shape from ACT-603's doc and asks for it to be the official impl, that's a conversation for then, not a chunk to negotiate here.
+
+## What this unblocks
+
+The framework-agnostic middleware in [ACT-1116](https://github.com/Rotorsoft/act-root/issues/744) consumes `IdempotencyStore`. It can't ship until the port exists. The middleware's job is to fold the port into a `(checkIdempotency, next)` shape that any HTTP framework can adapt — tRPC, Express, Fastify, Hono. Each adapter is fifteen lines wrapping the port-aware core. None of them need to know what implementation is behind the port.
+
+That's the payoff. The receiver-side idempotency story from ACT-603 — the one with three cache shapes and a contract — has been waiting two releases for a port. With the port in, every piece of the story collapses into a single import: `InMemoryIdempotencyStore` from `@rotorsoft/act-ops` for the in-memory case, `(future) PostgresIdempotencyStore` from `@rotorsoft/act-pg`, `(future) RedisIdempotencyStore` from wherever. The doc stops describing patterns to copy and starts describing libraries to install.
+
+The book chapter on integrations should close on this transition. Pattern-to-library is one of the strongest signals that a framework is maturing. It's also the kind of move that's only legible after the *second* ticket — the one where the port is consumed, not just declared. ACT-1116 is the consumption ticket. ACT-1118 is the precondition. Worth showing both essays together once they've shipped.

--- a/book/act-1118-idempotency-store.md
+++ b/book/act-1118-idempotency-store.md
@@ -4,7 +4,7 @@
 
 [ACT-603](./act-603-external-integration.md) shipped the *story* — inline vs forwarded, the receiver-side idempotency contract, the TTL math. The cache itself was demo code under `packages/server/`. A reader who liked the contract had to copy a class out of an example app and rename it into their service. That's not how a contract ships; that's how a pattern ships.
 
-ACT-1118 promotes the contract to a port: `IdempotencyStore.record_if_fresh(key, now?) → boolean | Promise<boolean>`. Drops a reference implementation next to it: `InMemoryIdempotencyStore`, lifted verbatim from the demo with the class renamed. Both ship from `@rotorsoft/act-ops`, the zero-`act`-dependency lib bootstrapped by [ACT-1117](https://github.com/Rotorsoft/act-root/issues/745) for exactly this kind of cross-cutting operational primitive.
+ACT-1118 promotes the contract to a port: `IdempotencyStore.claim(key, now?) → boolean | Promise<boolean>`. Drops a reference implementation next to it: `InMemoryIdempotencyStore`, lifted from the demo with the class renamed and the method renamed to match the framework's existing `Store.claim` vocabulary (the demo had it as `recordIfFresh`). Both ship from `@rotorsoft/act-ops`, the zero-`act`-dependency lib bootstrapped by [ACT-1117](https://github.com/Rotorsoft/act-root/issues/745) for exactly this kind of cross-cutting operational primitive.
 
 It's a small ticket. The implementation is sixty lines. The reasoning is most of why the ticket exists.
 
@@ -20,13 +20,27 @@ Dedup state isn't that. There *is* no source of truth to replay from. The sender
 
 The naming choice has a practical consequence. When an operator picks an implementation — say, swapping the in-memory reference impl for Redis at production deploy time — they should be picking on the load-bearing property: *persistence*. Redis `SET NX EX` qualifies because the data survives the consuming process. A genuinely volatile cache (TTL too short relative to retry envelope, or worse, an unbounded LRU that evicts a hot key in the middle of a retry burst) is *unsafe*, not just *suboptimal*. The taxonomy makes that legible. A "Cache" tolerates eviction by definition; a "Store" doesn't.
 
-This is the kind of naming decision that's tempting to fast-forward through in code review. The compiler doesn't care; the tests don't care; the runtime behavior of `record_if_fresh` is identical either way. Future ports and future ports of *those* ports do care: every operator who reads `IdempotencyStore` should already know, before they look at the API, what the failure mode of losing data is.
+This is the kind of naming decision that's tempting to fast-forward through in code review. The compiler doesn't care; the tests don't care; the runtime behavior of `claim` is identical either way. Future ports and future ports of *those* ports do care: every operator who reads `IdempotencyStore` should already know, before they look at the API, what the failure mode of losing data is.
+
+## The method name, and why it's `claim` and not anything else
+
+The demo code called the operation `recordIfFresh(key) → boolean`. That name is descriptive — you can read it cold — but it's twelve characters and not in anyone's vocabulary outside this codebase. Promoting it into a public port was the moment to ask: is there a shorter, established name for *atomic acquire-or-fail of a contested slot*?
+
+The first pass through the candidates was unproductive. The Java/Spring convention is `putIfAbsent` / `setIfAbsent` — three words, weaker domain framing (the operator has to remember that "absent" means "fresh"). Memcached uses `add`, which is ambiguous about what success means. Redis exposes `SET NX EX`, which isn't a method-shape at all. Rust's `try_*` prefix (`try_insert`, `try_lock`) is cleaner — every reader knows `try_*` returns a boolean — but importing a generic convention when a domain-specific verb is available is a downgrade in clarity, not an upgrade.
+
+The domain-specific verb was already in the codebase, sitting in plain sight: `Store.claim`. Drain calls `store.claim(opts)` to atomically lease N streams for processing; competing workers race for the right to drain a stream, and the loser gets nothing. That's *the exact same shape* as the idempotency operation. Different resource (stream vs request key), identical action: atomic acquire of a contested slot, with at most one winner.
+
+There's no inheritance involved. `Store` and `IdempotencyStore` are unrelated interfaces; no class implements both. So when both interfaces expose a method called `claim`, there's no conflict — there's just *vocabulary alignment*. A reader who's learned what `Store.claim` does has already learned what `IdempotencyStore.claim` does, modulo the swapped resource. That's free communication. It also teaches Act's mental model: "atomic acquire of a contested resource" is a shape the framework names consistently, regardless of which port you're holding.
+
+The rejection cycle that led here was instructive. The first proposal (`record_if_fresh`, sixteen characters, snake-case per CLAUDE.md) was technically correct under the framework's naming rule for multi-word public-API methods. It was also six characters wasted and a verb nobody outside the codebase uses. The second proposal (`mark`, four characters, no precedent in Act) compressed but lost domain-grounding — "mark this key" is passive and abstract; the operation isn't labeling, it's *taking ownership*. The `try_*` family did better but imported a foreign convention. Only `claim` actually fit: it was the right semantic, it was already in the codebase's working vocabulary, and it required zero explanation in any sentence that already established the operation's atomic-acquire shape.
+
+The lesson is small but worth foregrounding. When a primitive's action shape matches one the framework already names, reuse the verb. The shorter form falls out for free, the documentation collapses (the docstring for `IdempotencyStore.claim` is half the length of the docstring for `Store.claim`, because half the explanation is "see Store.claim"), and the framework teaches its own vocabulary more cleanly. The aesthetic loss — that two different ports both have a `claim` method, which momentarily looks like ambiguity — is actually the point: the verb describes the action, not the resource. That's how all the framework's port methods work (`commit`, `notify`, `subscribe`, `query` — all of them name actions that recur across contexts). `claim` joins the club.
 
 ## Why a separate package, not `libs/act`
 
 The dedup contract gets consumed by receivers. Some of those receivers are Act apps — the wolfdesk webhook-receiver demo is one. Many won't be. The forwarded-shape integrations in ACT-603 explicitly anticipate a non-Act consumer: a Kafka topic with a worker that processes events from a bus, no event store of its own, no orchestrator running, no `app.do()` calls. That worker still has to honor `Idempotency-Key`. The contract has to be reachable from there.
 
-Putting `IdempotencyStore` in `libs/act` would force every receiver to pull in the orchestrator just to call `record_if_fresh`. That's a tax of tens of kilobytes plus the conceptual overhead of "wait, do I need an event store?" — for a service that doesn't. Bad shape.
+Putting `IdempotencyStore` in `libs/act` would force every receiver to pull in the orchestrator just to call `claim`. That's a tax of tens of kilobytes plus the conceptual overhead of "wait, do I need an event store?" — for a service that doesn't. Bad shape.
 
 The alternative `libs/act-http` was considered and dropped. `act-http` already owns the *outbound* webhook helper (the sender side that sets `Idempotency-Key`), and one might argue the receiver-side port belongs alongside its mirror. But durable adapters of the port — Postgres, Redis, future ones — have nothing to do with HTTP. A Kafka receiver wouldn't depend on `act-http` just to get the dedup port. Putting the port in `act-http` would mean either: (a) every durable adapter pulls in HTTP plumbing it doesn't need, or (b) the port lives in *both* packages with weird re-exports. Neither shape is good.
 
@@ -36,15 +50,15 @@ The load-bearing constraint shows up as a one-line grep in CI: no `@rotorsoft/ac
 
 ## The sync-or-async return type, and why it isn't a Promise
 
-The port signature is `record_if_fresh(key: string, now?: number): boolean | Promise<boolean>`. Not `Promise<boolean>`. The union return.
+The port signature is `claim(key: string, now?: number): boolean | Promise<boolean>`. Not `Promise<boolean>`. The union return.
 
 The first instinct here is to always `Promise<boolean>` and force every implementation to be async. It's the conventional shape: durable adapters need to be async (they wait on I/O), and a sync in-memory impl that "returns immediately" still works under `await` — `await` on a non-Promise resolves synchronously, same microtask. Why not just standardize on Promise?
 
 Two reasons. The first is observable in benchmarks: an `await` on a synchronous-returned value is not free. The microtask scheduling has a real cost (~100ns on V8), measurable across the millions of webhooks an active receiver processes daily. The in-memory store is the right answer for single-process receivers — the bench should reflect what it actually costs to use. Forcing it to be async would erase the speed advantage that motivated picking the in-memory impl in the first place.
 
-The second is taste, but it's a load-bearing taste. `Promise<boolean>` says "this might do I/O." That's a lie for the in-memory impl. The contract should describe what implementations *actually* return, not paper over the difference to make the call site marginally simpler. Consumers that need to be polymorphic across implementations can write `await store.record_if_fresh(key)` and TypeScript narrows the union for them. Consumers that know they have the in-memory impl can omit the `await` and pay no microtask cost. Both shapes are correct.
+The second is taste, but it's a load-bearing taste. `Promise<boolean>` says "this might do I/O." That's a lie for the in-memory impl. The contract should describe what implementations *actually* return, not paper over the difference to make the call site marginally simpler. Consumers that need to be polymorphic across implementations can write `await store.claim(key)` and TypeScript narrows the union for them. Consumers that know they have the in-memory impl can omit the `await` and pay no microtask cost. Both shapes are correct.
 
-This is the same trade-off the Store interface makes (`commit` returns `Promise<Committed[]>` everywhere because it's *always* I/O; `record_if_fresh` doesn't because it isn't always). Once you've named the property — "the in-memory impl is sync, the durable ones are async, the type system says so" — the union-return decision falls out.
+This is the same trade-off the Store interface makes (`commit` returns `Promise<Committed[]>` everywhere because it's *always* I/O; `claim` doesn't because it isn't always). Once you've named the property — "the in-memory impl is sync, the durable ones are async, the type system says so" — the union-return decision falls out.
 
 ## The defensive branch that has to die
 
@@ -69,11 +83,11 @@ The book chapter on "what's special about Act's libs" should foreground this. It
 
 ## The migration story, and why nothing changes at the call site
 
-The wolfdesk demo's webhook-receiver imports `IdempotencyCache` today. After this ticket it imports `InMemoryIdempotencyStore`. The class renamed; the constructor signature is identical; the one used method (`record_if_fresh`) is identical. The diff in `webhook-receiver.ts` is a one-import change and a `cache` → `dedup` variable rename. That's all.
+The wolfdesk demo's webhook-receiver imports `IdempotencyCache` today. After this ticket it imports `InMemoryIdempotencyStore`. The class renamed; the constructor signature is identical; the one used method (`claim`) is identical. The diff in `webhook-receiver.ts` is a one-import change and a `cache` → `dedup` variable rename. That's all.
 
 This matters because the contract was correct on day one. The shape that emerged from the demo was the shape the port wants. The ticket didn't need to *design* anything — it needed to *promote* something. The work was in the doc (renaming, scoping, getting the API surface right) and in the move (extracting the class, dropping the defensive branch, wiring the workspace dep).
 
-A different ticket would have looked at the same code and decided to redesign. Maybe split `record_if_fresh` into `has` + `put` for "flexibility." Maybe make it generic over the value type so callers can store metadata alongside the key. Maybe add an `options` bag for per-call TTL overrides. Each of those changes would have been a defensible local optimization and a globally worse design — more surface to maintain, more decisions at the call site, no real demand from any consumer. The contract stays small. One method. One return. The reason it stays small is that nobody has asked for it to be bigger.
+A different ticket would have looked at the same code and decided to redesign. Maybe split `claim` into `has` + `put` for "flexibility." Maybe make it generic over the value type so callers can store metadata alongside the key. Maybe add an `options` bag for per-call TTL overrides. Each of those changes would have been a defensible local optimization and a globally worse design — more surface to maintain, more decisions at the call site, no real demand from any consumer. The contract stays small. One method. One return. The reason it stays small is that nobody has asked for it to be bigger.
 
 The follow-ups are named (PostgresIdempotencyStore in `act-pg`, idempotencyTck in `act-tck`) and explicitly *deferred* to milestone 1.2. The port should bake one release before durable adapters land. If a Postgres user shows up tomorrow with the working `INSERT … ON CONFLICT` shape from ACT-603's doc and asks for it to be the official impl, that's a conversation for then, not a chunk to negotiate here.
 

--- a/docs/docs/guides/external-integration.md
+++ b/docs/docs/guides/external-integration.md
@@ -191,7 +191,7 @@ The dedup contract is shipped as a port — `IdempotencyStore` — in [`@rotorso
 import type { IdempotencyStore } from "@rotorsoft/act-ops";
 
 export interface IdempotencyStore {
-  record_if_fresh(key: string, now?: number): boolean | Promise<boolean>;
+  claim(key: string, now?: number): boolean | Promise<boolean>;
 }
 ```
 
@@ -215,7 +215,7 @@ const dedup = new InMemoryIdempotencyStore({
   maxEntries: 50_000,           // memory bound (default: 100_000)
 });
 
-const fresh = dedup.record_if_fresh(key);
+const fresh = dedup.claim(key);
 ```
 
 Bounded LRU + TTL. Sync return. Use when: receiver is single-process, dedup window is short (under a day), keys fit in RAM. The wolfdesk demo at [`packages/server/src/webhook-receiver.ts`](https://github.com/Rotorsoft/act-root/blob/master/packages/server/src/webhook-receiver.ts) uses this implementation end-to-end.
@@ -226,7 +226,7 @@ Bounded LRU + TTL. Sync return. Use when: receiver is single-process, dedup wind
 class RedisIdempotencyStore implements IdempotencyStore {
   constructor(private readonly redis: RedisClient, private readonly ttlSeconds: number) {}
 
-  async record_if_fresh(key: string): Promise<boolean> {
+  async claim(key: string): Promise<boolean> {
     // SET ... NX EX is atomic: returns "OK" only when the key didn't exist.
     const result = await this.redis.set(`idem:${key}`, "1", "EX", this.ttlSeconds, "NX");
     return result === "OK";
@@ -253,7 +253,7 @@ DELETE FROM idempotency_keys WHERE seen_at < NOW() - INTERVAL '7 days';
 class PostgresIdempotencyStore implements IdempotencyStore {
   constructor(private readonly db: Database) {}
 
-  async record_if_fresh(key: string): Promise<boolean> {
+  async claim(key: string): Promise<boolean> {
     try {
       await this.db.query(`INSERT INTO idempotency_keys(key) VALUES ($1)`, [key]);
       return true;
@@ -306,12 +306,12 @@ export const idempotent = t.procedure.use(({ ctx, next }) => {
       message: "Missing Idempotency-Key header",
     });
   }
-  const fresh = dedup.record_if_fresh(key);
+  const fresh = dedup.claim(key);
   return next({ ctx: { ...ctx, key, deduped: !fresh } });
 });
 ```
 
-Swap `InMemoryIdempotencyStore` for the Redis or Postgres sketch above — the rest of the middleware doesn't change, because both adapters implement the same `IdempotencyStore` port. For an async adapter, mark the `.use(...)` callback `async` and `await dedup.record_if_fresh(key)` — the call site shape stays identical otherwise.
+Swap `InMemoryIdempotencyStore` for the Redis or Postgres sketch above — the rest of the middleware doesn't change, because both adapters implement the same `IdempotencyStore` port. For an async adapter, mark the `.use(...)` callback `async` and `await dedup.claim(key)` — the call site shape stays identical otherwise.
 
 A handler using the middleware returns success on both first-attempt and dedup-hit, distinguishing them only for telemetry:
 

--- a/docs/docs/guides/external-integration.md
+++ b/docs/docs/guides/external-integration.md
@@ -183,57 +183,60 @@ Both are normal — they're not bugs to fix in the sender. The fix is on the rec
 
 For custom callers — non-`webhook` reactions, queue forwarders, anything — pass `String(event.id)` (or your bus's dedup key field) as the idempotency token. Don't derive from event content or hash the payload; collisions and changes both bite you.
 
-### Cache shapes
+### The `IdempotencyStore` port
 
-Three implementations of the dedup cache, ordered by deployment complexity:
-
-#### In-memory bounded LRU
+The dedup contract is shipped as a port — `IdempotencyStore` — in [`@rotorsoft/act-ops`](https://www.npmjs.com/package/@rotorsoft/act-ops), the zero-`act`-dependency home for receiver-side primitives. One method, by design:
 
 ```ts
-class IdempotencyCache {
-  private seen = new Map<string, number>(); // key → expiresAt epoch
-  constructor(
-    private readonly ttlMs = 24 * 60 * 60 * 1000,
-    private readonly maxEntries = 100_000
-  ) {}
+import type { IdempotencyStore } from "@rotorsoft/act-ops";
 
-  /** Returns true if the key was unseen and is now recorded. */
-  recordIfFresh(key: string): boolean {
-    const now = Date.now();
-    this.gc(now);
-    if (this.seen.has(key)) return false;
-    this.seen.set(key, now + this.ttlMs);
-    if (this.seen.size > this.maxEntries) {
-      // Map iteration is insertion-ordered; oldest entry is at the head.
-      this.seen.delete(this.seen.keys().next().value!);
-    }
-    return true;
-  }
-
-  private gc(now: number) {
-    for (const [key, expiresAt] of this.seen) {
-      if (expiresAt > now) break; // Insertion order ⇒ first non-expired ends the sweep.
-      this.seen.delete(key);
-    }
-  }
+export interface IdempotencyStore {
+  record_if_fresh(key: string, now?: number): boolean | Promise<boolean>;
 }
 ```
 
-Use when: receiver is single-process, dedup window is short (under a day), keys fit in RAM.
+`true` means the key was fresh (and is now recorded); `false` means it was already present and the caller should treat the request as a duplicate. The union return type lets sync (in-memory) and async (durable) adapters share the same call site. The middleware that consumes the port (`#744`) awaits unconditionally.
 
-#### Redis SETNX with TTL
+> **Not a Cache.** In this codebase `Cache` means "rebuildable from a source of truth" (snapshot cache). Dedup state is authoritative — losing it allows duplicate side effects, not just a rebuild. Hence `Store`. The naming distinction matters when you swap implementations: the durable adapter's *persistence* is the load-bearing property, not its hit rate.
+
+`@rotorsoft/act-ops` ships with no peer dep on `@rotorsoft/act`, so a non-Act receiver (a Kafka consumer processing forwarded events, an Express endpoint behind a queue, …) can install the port without dragging the orchestrator along. Act apps and non-Act apps speak the same contract.
+
+### Implementations
+
+Three implementations of the dedup store, ordered by deployment complexity. The first ships in `@rotorsoft/act-ops`; the next two are sketches that follow the same `IdempotencyStore` contract — they're not packaged yet but slot in unchanged once you wire them.
+
+#### `InMemoryIdempotencyStore` from `@rotorsoft/act-ops`
 
 ```ts
-async function recordIfFresh(key: string, ttlSeconds: number): Promise<boolean> {
-  // SET ... NX EX is atomic: returns "OK" only when the key didn't exist.
-  const result = await redis.set(`idem:${key}`, "1", "EX", ttlSeconds, "NX");
-  return result === "OK";
+import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops";
+
+const dedup = new InMemoryIdempotencyStore({
+  ttlMs: 24 * 60 * 60 * 1000,  // dedup window (default: 24h)
+  maxEntries: 50_000,           // memory bound (default: 100_000)
+});
+
+const fresh = dedup.record_if_fresh(key);
+```
+
+Bounded LRU + TTL. Sync return. Use when: receiver is single-process, dedup window is short (under a day), keys fit in RAM. The wolfdesk demo at [`packages/server/src/webhook-receiver.ts`](https://github.com/Rotorsoft/act-root/blob/master/packages/server/src/webhook-receiver.ts) uses this implementation end-to-end.
+
+#### Redis `SET NX EX` (sketch — port not yet packaged)
+
+```ts
+class RedisIdempotencyStore implements IdempotencyStore {
+  constructor(private readonly redis: RedisClient, private readonly ttlSeconds: number) {}
+
+  async record_if_fresh(key: string): Promise<boolean> {
+    // SET ... NX EX is atomic: returns "OK" only when the key didn't exist.
+    const result = await this.redis.set(`idem:${key}`, "1", "EX", this.ttlSeconds, "NX");
+    return result === "OK";
+  }
 }
 ```
 
 Use when: receiver is multi-process, dedup window is hours-to-days, Redis is already in the stack.
 
-#### Postgres unique index
+#### Postgres unique index (sketch — port not yet packaged)
 
 ```sql
 CREATE TABLE idempotency_keys (
@@ -247,18 +250,22 @@ DELETE FROM idempotency_keys WHERE seen_at < NOW() - INTERVAL '7 days';
 ```
 
 ```ts
-async function recordIfFresh(key: string): Promise<boolean> {
-  try {
-    await db.query(`INSERT INTO idempotency_keys(key) VALUES ($1)`, [key]);
-    return true;
-  } catch (err) {
-    if (isUniqueViolation(err)) return false;
-    throw err;
+class PostgresIdempotencyStore implements IdempotencyStore {
+  constructor(private readonly db: Database) {}
+
+  async record_if_fresh(key: string): Promise<boolean> {
+    try {
+      await this.db.query(`INSERT INTO idempotency_keys(key) VALUES ($1)`, [key]);
+      return true;
+    } catch (err) {
+      if (isUniqueViolation(err)) return false;
+      throw err;
+    }
   }
 }
 ```
 
-Use when: receiver already has Postgres in its stack, dedup needs are durable (survive process restarts), TTL can be relaxed in favor of audit trail.
+Use when: receiver already has Postgres in its stack, dedup needs are durable (survive process restarts), TTL can be relaxed in favor of audit trail. A `PostgresIdempotencyStore` adapter is parked for milestone 1.2; until it ships, copy the shape above.
 
 ### TTL sizing
 
@@ -284,10 +291,11 @@ Don't undersize. If a key expires before the sender finishes retrying, dedup fai
 A small idempotent receiver, mirroring the `packages/server` tRPC setup. The middleware checks `Idempotency-Key` and short-circuits duplicates:
 
 ```ts
-// packages/server/src/idempotency.ts
+// packages/server/src/webhook-receiver.ts (excerpt)
+import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops";
 import { initTRPC, TRPCError } from "@trpc/server";
 
-const cache = new IdempotencyCache();
+const dedup = new InMemoryIdempotencyStore();
 const t = initTRPC.context<{ headers: Record<string, string> }>().create();
 
 export const idempotent = t.procedure.use(({ ctx, next }) => {
@@ -298,10 +306,12 @@ export const idempotent = t.procedure.use(({ ctx, next }) => {
       message: "Missing Idempotency-Key header",
     });
   }
-  const fresh = cache.recordIfFresh(key);
+  const fresh = dedup.record_if_fresh(key);
   return next({ ctx: { ...ctx, key, deduped: !fresh } });
 });
 ```
+
+Swap `InMemoryIdempotencyStore` for the Redis or Postgres sketch above — the rest of the middleware doesn't change, because both adapters implement the same `IdempotencyStore` port. For an async adapter, mark the `.use(...)` callback `async` and `await dedup.record_if_fresh(key)` — the call site shape stays identical otherwise.
 
 A handler using the middleware returns success on both first-attempt and dedup-hit, distinguishing them only for telemetry:
 

--- a/libs/act-ops/README.md
+++ b/libs/act-ops/README.md
@@ -6,8 +6,6 @@
 
 _Operational primitives for [@rotorsoft/act](https://www.npmjs.com/package/@rotorsoft/act) apps and act-independent receivers — idempotency, retry budgets, poison-message classification._
 
-> **Note.** Package is currently at `0.0.0` — the scaffold is in place but no primitives have shipped yet. The first surface lands with the [ACT-1110 helper extraction tracker](https://github.com/Rotorsoft/act-root/issues/748) (`IdempotencyStore` port + `InMemoryIdempotencyStore`, then `computeMinSafeTtl`). This README will fill in as primitives land — track progress on the [milestone 1.1 board](https://github.com/Rotorsoft/act-root/milestone/4).
-
 ## Why this package
 
 Operational concerns that pair with Act — receiver-side idempotency, retry-budget sizing, poison-message classification — show up on both sides of the wire. The inline `webhook` reaction from `@rotorsoft/act-http` enforces dedup with an auto-derived `Idempotency-Key`; the cooperative receiver on the other end has to actually honor it. When the receiver is itself an Act app, it can reach for the same primitives the framework uses internally. When the receiver is something else — a Kafka consumer, an Express endpoint, a queue worker — it should be able to speak the same contract without dragging the orchestrator along.
@@ -26,23 +24,34 @@ No peer dependencies. Drop it next to whatever framework — or no framework at 
 
 ## Quick start
 
-The first primitive — `IdempotencyStore` + `InMemoryIdempotencyStore` — lands with [#746 / ACT-1118](https://github.com/Rotorsoft/act-root/issues/746). Until then the `0.0.0` scaffold is published only as a placeholder for the tag chain and CI matrix; there is no runtime surface to import.
-
-Once the port is in, the shape looks like this:
-
 ```ts
 import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops";
 
-const dedup = new InMemoryIdempotencyStore({ ttlMs: 10 * 60_000 });
+const dedup = new InMemoryIdempotencyStore({
+  ttlMs: 24 * 60 * 60 * 1000,  // dedup window (default: 24h)
+  maxEntries: 50_000,           // memory bound (default: 100_000)
+});
 
-// In an Express / Fastify / Hono / tRPC receiver:
-const key = req.headers["idempotency-key"];
-if (await dedup.has(key)) return cached();
-await handleEvent(event);
-await dedup.put(key);
+// In any receiver — tRPC, Express, Fastify, Hono, a Kafka consumer, …
+const key = extractIdempotencyKeyFromHeaders(req);
+const fresh = dedup.record_if_fresh(key);
+if (!fresh) return replyDedupedWithoutSideEffects();
+await applyEventToAggregate(event);
 ```
 
-Subsequent tickets in the [ACT-1110 tracker](https://github.com/Rotorsoft/act-root/issues/748) add `computeMinSafeTtl` (deriving a safe dedup window from your reaction's backoff + lease configuration) and the framework-agnostic receiver middleware in `@rotorsoft/act-http`.
+`record_if_fresh` is the entire contract — atomically record the key and report whether the caller is processing a fresh request or a duplicate. One call. No separate `has` / `put` dance. The in-memory implementation is sync; durable adapters (Postgres, Redis) return a `Promise<boolean>` — the port's union return type covers both, so the call site is identical.
+
+## API
+
+- **`IdempotencyStore`** — the contract. One method, `record_if_fresh(key, now?): boolean | Promise<boolean>`. Returns `true` when the key was fresh (and is now recorded), `false` when it was already present. Implementations should preserve records for at least the sender's full retry envelope.
+- **`InMemoryIdempotencyStore`** — bounded LRU + TTL reference implementation. Single-process only; for multi-process receivers swap for a durable adapter (Postgres unique index, Redis `SET NX`, …) without changing the call site.
+- **`InMemoryIdempotencyStoreOptions`** — TypeScript type for the constructor's options bag.
+
+## Why a Store and not a Cache
+
+The doc colloquially calls these "cache shapes," but structurally this is **authoritative** storage. Losing a dedup record causes a duplicate side effect — paying the same invoice twice, sending the same email twice, opening the same incident twice — not just a rebuild from a source of truth. In this codebase `Cache` is reserved for "rebuildable" state (the snapshot cache); `Store` is reserved for authoritative state. The idempotency contract sits in the second bucket. Hence `IdempotencyStore`.
+
+The practical implication: when you swap `InMemoryIdempotencyStore` for a durable adapter at deploy time, the durable adapter's *persistence* is the load-bearing property — not its hit rate.
 
 ## Compatibility
 
@@ -52,7 +61,7 @@ Subsequent tickets in the [ACT-1110 tracker](https://github.com/Rotorsoft/act-ro
 
 ## Stability
 
-Public API governed by the [Act Stability Charter](../../STABILITY.md) once primitives ship. While the package is in `0.x` everything is provisional — the surface freezes when the first `1.0.0` cuts. The milestone tracker is [milestone 1.1](https://github.com/Rotorsoft/act-root/milestone/4).
+Public API governed by the [Act Stability Charter](../../STABILITY.md) once primitives stabilise. While the package is in `0.x` everything is provisional — the surface freezes when the first `1.0.0` cuts. The milestone tracker is [milestone 1.1](https://github.com/Rotorsoft/act-root/milestone/4).
 
 ## Related packages
 

--- a/libs/act-ops/README.md
+++ b/libs/act-ops/README.md
@@ -34,16 +34,18 @@ const dedup = new InMemoryIdempotencyStore({
 
 // In any receiver — tRPC, Express, Fastify, Hono, a Kafka consumer, …
 const key = extractIdempotencyKeyFromHeaders(req);
-const fresh = dedup.record_if_fresh(key);
+const fresh = dedup.claim(key);
 if (!fresh) return replyDedupedWithoutSideEffects();
 await applyEventToAggregate(event);
 ```
 
-`record_if_fresh` is the entire contract — atomically record the key and report whether the caller is processing a fresh request or a duplicate. One call. No separate `has` / `put` dance. The in-memory implementation is sync; durable adapters (Postgres, Redis) return a `Promise<boolean>` — the port's union return type covers both, so the call site is identical.
+`claim` is the entire contract — atomically acquire the right to process this key, return whether the caller won the claim. One call. No separate `has` / `put` dance. The verb mirrors `Store.claim`'s lease semantic from `@rotorsoft/act`: there, competing workers race for the right to drain a stream; here, competing requests race for the right to be the canonical first-time delivery for an `Idempotency-Key`. One caller wins; the others learn the claim is already taken and treat their request as a duplicate.
+
+The in-memory implementation is sync; durable adapters (Postgres, Redis) return a `Promise<boolean>` — the port's union return type covers both, so the call site is identical.
 
 ## API
 
-- **`IdempotencyStore`** — the contract. One method, `record_if_fresh(key, now?): boolean | Promise<boolean>`. Returns `true` when the key was fresh (and is now recorded), `false` when it was already present. Implementations should preserve records for at least the sender's full retry envelope.
+- **`IdempotencyStore`** — the contract. One method, `claim(key, now?): boolean | Promise<boolean>`. Returns `true` when the key was fresh (and is now recorded), `false` when it was already present. Implementations should preserve records for at least the sender's full retry envelope.
 - **`InMemoryIdempotencyStore`** — bounded LRU + TTL reference implementation. Single-process only; for multi-process receivers swap for a durable adapter (Postgres unique index, Redis `SET NX`, …) without changing the call site.
 - **`InMemoryIdempotencyStoreOptions`** — TypeScript type for the constructor's options bag.
 

--- a/libs/act-ops/src/idempotency/in-memory.ts
+++ b/libs/act-ops/src/idempotency/in-memory.ts
@@ -25,8 +25,8 @@ export type InMemoryIdempotencyStoreOptions = {
  * - The oldest entry sits at `keys().next().value` (cheapest to evict).
  * - GC walks until the first non-expired entry and stops.
  *
- * `record_if_fresh` is sync; durable adapters return a `Promise<boolean>`
- * — both satisfy the union return type in the port.
+ * `claim` is sync; durable adapters return a `Promise<boolean>` —
+ * both satisfy the union return type in the port.
  */
 export class InMemoryIdempotencyStore implements IdempotencyStore {
   private readonly _seen = new Map<string, number>();
@@ -38,7 +38,7 @@ export class InMemoryIdempotencyStore implements IdempotencyStore {
     this._max_entries = options?.maxEntries ?? 100_000;
   }
 
-  record_if_fresh(key: string, now: number = Date.now()): boolean {
+  claim(key: string, now: number = Date.now()): boolean {
     this._gc(now);
     if (this._seen.has(key)) return false;
     this._seen.set(key, now + this._ttl_ms);

--- a/libs/act-ops/src/idempotency/in-memory.ts
+++ b/libs/act-ops/src/idempotency/in-memory.ts
@@ -1,0 +1,71 @@
+import type { IdempotencyStore } from "./port.js";
+
+/**
+ * Options for {@link InMemoryIdempotencyStore}. Both defaults are sized
+ * for a single-process receiver paired with a sender using the
+ * standard `webhook` backoff envelope (`exponential` up to `maxMs: 30_000`,
+ * `maxRetries: 5`); larger envelopes should bump `ttlMs` accordingly
+ * (see `computeMinSafeTtl` once #747 ships).
+ */
+export type InMemoryIdempotencyStoreOptions = {
+  /** Dedup window. Default: 24 hours. */
+  ttlMs?: number;
+  /** Memory bound — oldest entries are evicted past this size. Default: 100,000. */
+  maxEntries?: number;
+};
+
+/**
+ * Bounded LRU + TTL implementation of {@link IdempotencyStore} for
+ * single-process receivers (the wolfdesk demo, integration tests, dev
+ * loops). Multi-process receivers should swap for a durable adapter
+ * (Postgres unique index, Redis `SET NX`) — the {@link IdempotencyStore}
+ * contract stays the same so the call site doesn't change.
+ *
+ * Map iteration is insertion-ordered, so:
+ * - The oldest entry sits at `keys().next().value` (cheapest to evict).
+ * - GC walks until the first non-expired entry and stops.
+ *
+ * `record_if_fresh` is sync; durable adapters return a `Promise<boolean>`
+ * — both satisfy the union return type in the port.
+ */
+export class InMemoryIdempotencyStore implements IdempotencyStore {
+  private readonly _seen = new Map<string, number>();
+  private readonly _ttl_ms: number;
+  private readonly _max_entries: number;
+
+  constructor(options?: InMemoryIdempotencyStoreOptions) {
+    this._ttl_ms = options?.ttlMs ?? 24 * 60 * 60 * 1000;
+    this._max_entries = options?.maxEntries ?? 100_000;
+  }
+
+  record_if_fresh(key: string, now: number = Date.now()): boolean {
+    this._gc(now);
+    if (this._seen.has(key)) return false;
+    this._seen.set(key, now + this._ttl_ms);
+    if (this._seen.size > this._max_entries) {
+      // Safe by construction: `_seen.size > _max_entries >= 0` implies at
+      // least one entry, so `.next().value` resolves to a string key.
+      const oldest = this._seen.keys().next().value as string;
+      this._seen.delete(oldest);
+    }
+    return true;
+  }
+
+  /** Number of entries currently tracked (post-GC at call time). */
+  size(now: number = Date.now()): number {
+    this._gc(now);
+    return this._seen.size;
+  }
+
+  /** Drop every entry — test hook. */
+  clear(): void {
+    this._seen.clear();
+  }
+
+  private _gc(now: number): void {
+    for (const [key, expiresAt] of this._seen) {
+      if (expiresAt > now) break;
+      this._seen.delete(key);
+    }
+  }
+}

--- a/libs/act-ops/src/idempotency/port.ts
+++ b/libs/act-ops/src/idempotency/port.ts
@@ -1,28 +1,37 @@
 /**
- * Receiver-side idempotency contract: atomically record a key as seen,
- * report whether the caller is processing a fresh request or a duplicate.
+ * Receiver-side idempotency contract: atomically claim a key as
+ * processed-by-this-caller, report whether the claim succeeded.
  *
- * **Not a Cache.** In this codebase `Cache` means "rebuildable from a
- * source of truth" (e.g. snapshot cache). Dedup state is authoritative —
- * losing it allows duplicate side effects, not just a rebuild. Hence
- * `Store`. Implementations should preserve records for at least the
- * sender's full retry envelope; see
+ * The verb mirrors {@link "@rotorsoft/act".Store.claim} — both are
+ * atomic acquire-or-fail operations on a contested resource. There,
+ * competing workers race for the right to drain a stream; here,
+ * competing requests race for the right to be processed as the
+ * canonical first-time delivery for an `Idempotency-Key`. One caller
+ * wins; the others see the claim has already been made and treat
+ * their request as a duplicate.
+ *
+ * **Not a Cache.** In this codebase `Cache` means "rebuildable from
+ * a source of truth" (e.g. snapshot cache). Dedup state is
+ * authoritative — losing it allows duplicate side effects, not just
+ * a rebuild. Hence `Store`. Implementations should preserve records
+ * for at least the sender's full retry envelope; see
  * [external integration](https://rotorsoft.github.io/act-root/docs/guides/external-integration)
  * for TTL sizing guidance (the matching helper lands in #747).
  *
  * Implementations may be sync (in-memory) or async (durable adapters
- * backed by Postgres, Redis, etc.). The middleware that consumes this
- * port (`#744`) awaits unconditionally, so either shape composes
- * cleanly with framework-agnostic receivers.
+ * backed by Postgres, Redis, etc.). The middleware that consumes
+ * this port (`#744`) awaits unconditionally, so either shape
+ * composes cleanly with framework-agnostic receivers.
  */
 export interface IdempotencyStore {
   /**
-   * Atomically record `key` as seen. Returns `true` if the key was
-   * fresh (and is now recorded), `false` if it was already present
-   * — the caller should treat the request as a duplicate.
+   * Atomically claim `key` for this caller. Returns `true` if the
+   * caller won the claim (the key was fresh and is now recorded),
+   * `false` if another caller already claimed it — the request
+   * should be treated as a duplicate.
    *
    * `now` is exposed for tests; production callers should leave it
    * undefined so wall-clock is used.
    */
-  record_if_fresh(key: string, now?: number): boolean | Promise<boolean>;
+  claim(key: string, now?: number): boolean | Promise<boolean>;
 }

--- a/libs/act-ops/src/idempotency/port.ts
+++ b/libs/act-ops/src/idempotency/port.ts
@@ -1,0 +1,28 @@
+/**
+ * Receiver-side idempotency contract: atomically record a key as seen,
+ * report whether the caller is processing a fresh request or a duplicate.
+ *
+ * **Not a Cache.** In this codebase `Cache` means "rebuildable from a
+ * source of truth" (e.g. snapshot cache). Dedup state is authoritative —
+ * losing it allows duplicate side effects, not just a rebuild. Hence
+ * `Store`. Implementations should preserve records for at least the
+ * sender's full retry envelope; see
+ * [external integration](https://rotorsoft.github.io/act-root/docs/guides/external-integration)
+ * for TTL sizing guidance (the matching helper lands in #747).
+ *
+ * Implementations may be sync (in-memory) or async (durable adapters
+ * backed by Postgres, Redis, etc.). The middleware that consumes this
+ * port (`#744`) awaits unconditionally, so either shape composes
+ * cleanly with framework-agnostic receivers.
+ */
+export interface IdempotencyStore {
+  /**
+   * Atomically record `key` as seen. Returns `true` if the key was
+   * fresh (and is now recorded), `false` if it was already present
+   * — the caller should treat the request as a duplicate.
+   *
+   * `now` is exposed for tests; production callers should leave it
+   * undefined so wall-clock is used.
+   */
+  record_if_fresh(key: string, now?: number): boolean | Promise<boolean>;
+}

--- a/libs/act-ops/src/index.ts
+++ b/libs/act-ops/src/index.ts
@@ -4,18 +4,23 @@
  *
  * Operational primitives for act apps and act-independent receivers.
  *
- * This package is the home for cross-cutting operational concerns —
- * receiver-side idempotency, retry-budget sizing, poison-message
- * classification — that need to ship without a hard dependency on
- * `@rotorsoft/act`. The forwarded-shape bus consumers from ACT-603
- * are the motivating example: a service that processes events off a
- * Kafka topic doesn't run an Act orchestrator, but it still needs
- * the same dedup contract the inline `webhook` reaction enforces.
+ * The package's first surface is the **receiver-side idempotency
+ * contract**: an {@link IdempotencyStore} port plus an
+ * {@link InMemoryIdempotencyStore} reference implementation. Both Act
+ * apps and non-Act receivers (forwarded-bus consumers, framework-
+ * agnostic HTTP endpoints) install `@rotorsoft/act-ops` to speak the
+ * dedup contract — the package has no runtime or peer dependency on
+ * `@rotorsoft/act`, so non-Act consumers don't pay for the orchestrator
+ * just to honor an `Idempotency-Key`.
  *
- * The contract lives here so both sides can speak it.
- *
- * Scope is intentionally narrow: ports + small framework-agnostic
- * helpers. Durable adapters (Postgres, Redis) ship in their own
- * packages and depend on the port declared here.
+ * Durable adapters (Postgres, Redis) implement the same port in their
+ * own packages and slot in transparently. The framework-agnostic
+ * receiver middleware (`#744`) consumes the port from here without
+ * binding to a specific adapter.
  */
-export {};
+
+export {
+  InMemoryIdempotencyStore,
+  type InMemoryIdempotencyStoreOptions,
+} from "./idempotency/in-memory.js";
+export type { IdempotencyStore } from "./idempotency/port.js";

--- a/libs/act-ops/test/in-memory.spec.ts
+++ b/libs/act-ops/test/in-memory.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryIdempotencyStore } from "../src/index.js";
+
+describe("InMemoryIdempotencyStore", () => {
+  it("record_if_fresh returns true the first time, false on re-record", () => {
+    const store = new InMemoryIdempotencyStore();
+    expect(store.record_if_fresh("k1")).toBe(true);
+    expect(store.record_if_fresh("k1")).toBe(false);
+    expect(store.record_if_fresh("k2")).toBe(true);
+  });
+
+  it("expires entries after ttlMs and re-records on next call", () => {
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1_000 });
+    const t0 = 1_000_000;
+    expect(store.record_if_fresh("k1", t0)).toBe(true);
+    expect(store.record_if_fresh("k1", t0 + 500)).toBe(false);
+    // Expired — next record_if_fresh treats it as fresh.
+    expect(store.record_if_fresh("k1", t0 + 1_500)).toBe(true);
+  });
+
+  it("size reflects current entries after gc", () => {
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1_000 });
+    const t0 = 1_000_000;
+    store.record_if_fresh("a", t0);
+    store.record_if_fresh("b", t0);
+    store.record_if_fresh("c", t0);
+    expect(store.size(t0)).toBe(3);
+    // Advance past TTL — gc drops everything.
+    expect(store.size(t0 + 2_000)).toBe(0);
+  });
+
+  it("size with default `now` returns current entry count", () => {
+    const store = new InMemoryIdempotencyStore();
+    expect(store.size()).toBe(0);
+    store.record_if_fresh("k");
+    expect(store.size()).toBe(1);
+  });
+
+  it("evicts the oldest entry when maxEntries is exceeded", () => {
+    const store = new InMemoryIdempotencyStore({ maxEntries: 2 });
+    store.record_if_fresh("a");
+    store.record_if_fresh("b");
+    store.record_if_fresh("c"); // "a" evicts (oldest); store now holds [b, c]
+    expect(store.size()).toBe(2);
+    // "b" and "c" still present.
+    expect(store.record_if_fresh("b")).toBe(false);
+    expect(store.record_if_fresh("c")).toBe(false);
+    // "a" was evicted → fresh again.
+    expect(store.record_if_fresh("a")).toBe(true);
+  });
+
+  it("clear drops all entries", () => {
+    const store = new InMemoryIdempotencyStore();
+    store.record_if_fresh("k");
+    store.clear();
+    expect(store.size()).toBe(0);
+    expect(store.record_if_fresh("k")).toBe(true);
+  });
+
+  it("gc stops at the first non-expired entry (insertion order)", () => {
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1_000 });
+    const t0 = 1_000_000;
+    store.record_if_fresh("expired-1", t0);
+    store.record_if_fresh("expired-2", t0 + 100);
+    store.record_if_fresh("fresh", t0 + 800);
+    // Sweep at t0 + 1_500: expired-1 and expired-2 are past TTL,
+    // "fresh" is not — gc must drop the first two and stop.
+    expect(store.size(t0 + 1_500)).toBe(1);
+    expect(store.record_if_fresh("fresh", t0 + 1_500)).toBe(false);
+  });
+});

--- a/libs/act-ops/test/in-memory.spec.ts
+++ b/libs/act-ops/test/in-memory.spec.ts
@@ -2,28 +2,28 @@ import { describe, expect, it } from "vitest";
 import { InMemoryIdempotencyStore } from "../src/index.js";
 
 describe("InMemoryIdempotencyStore", () => {
-  it("record_if_fresh returns true the first time, false on re-record", () => {
+  it("claim returns true the first time, false on re-claim", () => {
     const store = new InMemoryIdempotencyStore();
-    expect(store.record_if_fresh("k1")).toBe(true);
-    expect(store.record_if_fresh("k1")).toBe(false);
-    expect(store.record_if_fresh("k2")).toBe(true);
+    expect(store.claim("k1")).toBe(true);
+    expect(store.claim("k1")).toBe(false);
+    expect(store.claim("k2")).toBe(true);
   });
 
-  it("expires entries after ttlMs and re-records on next call", () => {
+  it("expires entries after ttlMs and re-claims on next call", () => {
     const store = new InMemoryIdempotencyStore({ ttlMs: 1_000 });
     const t0 = 1_000_000;
-    expect(store.record_if_fresh("k1", t0)).toBe(true);
-    expect(store.record_if_fresh("k1", t0 + 500)).toBe(false);
-    // Expired — next record_if_fresh treats it as fresh.
-    expect(store.record_if_fresh("k1", t0 + 1_500)).toBe(true);
+    expect(store.claim("k1", t0)).toBe(true);
+    expect(store.claim("k1", t0 + 500)).toBe(false);
+    // Expired — next claim treats the key as fresh.
+    expect(store.claim("k1", t0 + 1_500)).toBe(true);
   });
 
   it("size reflects current entries after gc", () => {
     const store = new InMemoryIdempotencyStore({ ttlMs: 1_000 });
     const t0 = 1_000_000;
-    store.record_if_fresh("a", t0);
-    store.record_if_fresh("b", t0);
-    store.record_if_fresh("c", t0);
+    store.claim("a", t0);
+    store.claim("b", t0);
+    store.claim("c", t0);
     expect(store.size(t0)).toBe(3);
     // Advance past TTL — gc drops everything.
     expect(store.size(t0 + 2_000)).toBe(0);
@@ -32,40 +32,40 @@ describe("InMemoryIdempotencyStore", () => {
   it("size with default `now` returns current entry count", () => {
     const store = new InMemoryIdempotencyStore();
     expect(store.size()).toBe(0);
-    store.record_if_fresh("k");
+    store.claim("k");
     expect(store.size()).toBe(1);
   });
 
   it("evicts the oldest entry when maxEntries is exceeded", () => {
     const store = new InMemoryIdempotencyStore({ maxEntries: 2 });
-    store.record_if_fresh("a");
-    store.record_if_fresh("b");
-    store.record_if_fresh("c"); // "a" evicts (oldest); store now holds [b, c]
+    store.claim("a");
+    store.claim("b");
+    store.claim("c"); // "a" evicts (oldest); store now holds [b, c]
     expect(store.size()).toBe(2);
     // "b" and "c" still present.
-    expect(store.record_if_fresh("b")).toBe(false);
-    expect(store.record_if_fresh("c")).toBe(false);
+    expect(store.claim("b")).toBe(false);
+    expect(store.claim("c")).toBe(false);
     // "a" was evicted → fresh again.
-    expect(store.record_if_fresh("a")).toBe(true);
+    expect(store.claim("a")).toBe(true);
   });
 
   it("clear drops all entries", () => {
     const store = new InMemoryIdempotencyStore();
-    store.record_if_fresh("k");
+    store.claim("k");
     store.clear();
     expect(store.size()).toBe(0);
-    expect(store.record_if_fresh("k")).toBe(true);
+    expect(store.claim("k")).toBe(true);
   });
 
   it("gc stops at the first non-expired entry (insertion order)", () => {
     const store = new InMemoryIdempotencyStore({ ttlMs: 1_000 });
     const t0 = 1_000_000;
-    store.record_if_fresh("expired-1", t0);
-    store.record_if_fresh("expired-2", t0 + 100);
-    store.record_if_fresh("fresh", t0 + 800);
+    store.claim("expired-1", t0);
+    store.claim("expired-2", t0 + 100);
+    store.claim("fresh", t0 + 800);
     // Sweep at t0 + 1_500: expired-1 and expired-2 are past TTL,
     // "fresh" is not — gc must drop the first two and stop.
     expect(store.size(t0 + 1_500)).toBe(1);
-    expect(store.record_if_fresh("fresh", t0 + 1_500)).toBe(false);
+    expect(store.claim("fresh", t0 + 1_500)).toBe(false);
   });
 });

--- a/libs/act-patch/README.md
+++ b/libs/act-patch/README.md
@@ -44,8 +44,41 @@ That's the whole surface — two functions plus the type-level helpers. Everythi
 ## API
 
 - **`patch(original, patches)`** — immutably deep-merges `patches` into `original`. Returns a new state object with structural sharing of unchanged subtrees. Accepts `Patch<S>` (positive changes plus `null`/`undefined` deletion sentinels).
-- **`delta(before, after)`** — computes the smallest `DeepPartial<S>` describing what changed from `before` to `after`. Designed for event payloads — never emits `null`; missing keys in `after` are omitted from the result rather than encoded as deletion sentinels.
-- **Types**: `Patch<T>` (operator-facing recursive partial with `null` deletion), `DeepPartial<T>` (event-payload shape returned by `delta`, no `null` arms), `Schema` (plain-object shape).
+- **`delta(before, after)`** — computes the smallest `DeepPartial<S>` describing what changed from `before` to `after`. Designed for event payloads — never *synthesizes* `null` for a missing key, but always *propagates* `null` when the caller put one in `after`. See [Modeling deletions](#modeling-deletions) for how that asymmetry carries a clear-this-field action all the way to the aggregate.
+- **Types**: `Patch<T>` (operator-facing recursive partial with `null` deletion), `DeepPartial<T>` (event-payload shape returned by `delta`, includes `null` only where the schema declares `T[K]` as nullable), `Schema` (plain-object shape).
+
+## Modeling deletions
+
+The end-to-end deletion flow — action signals "clear this field" → event records it → reducer applies it to state — works through `delta` without you having to switch tools. The rule is short: **`delta` never invents a `null`, but it forwards every `null` the caller put in `after`.** That means the *action* drives the runtime, and the *schema* controls the type:
+
+| What the caller put in `after` for key `k` | What `delta` returns for `k` | What `patch` does on replay |
+|---|---|---|
+| (key omitted)                              | (key omitted)                | leaves `state[k]` alone |
+| explicit `null` (schema permits)           | `null`                       | deletes `state[k]` (null is `patch`'s deletion sentinel) |
+| new value                                  | the new value                | sets `state[k]` |
+| same reference as `before[k]`              | (key omitted)                | leaves `state[k]` alone |
+
+```ts
+// 1) Action with a deletable field — schema declares it `.nullable()`
+const state = { bio: "old", name: "Alice" };
+const data  = { bio: null, name: "Alice" };
+
+const eventPayload = delta(state, data);
+// → { bio: null }      ← propagated, not synthesized
+
+patch(state, eventPayload);
+// → { name: "Alice" }  ← state.bio is gone
+
+// 2) Action that just doesn't touch a field — non-nullable schema is fine
+const data2 = { name: "Bob" };  // no `bio` key at all
+const eventPayload2 = delta(state, data2);
+// → { name: "Bob" }    ← bio is omitted because the action didn't mention it
+
+patch(state, eventPayload2);
+// → { bio: "old", name: "Bob" }  ← bio left alone
+```
+
+The asymmetry is what keeps the konsult-style scenario clean: a schema with no `.nullable()` fields produces a `DeepPartial<S>` with no `| null` arms, an action that conforms to that schema can't carry `null`, and `delta` can't put one in the output because there was nothing in `after` to propagate. The type and the runtime agree: no nulls anywhere. As soon as a schema opts into `.nullable()` on a field, the type widens to admit `null`, the action can carry it, and `delta` carries it through. Same code path, both behaviors, driven by the schema.
 
 ## Common patterns
 
@@ -84,11 +117,14 @@ This is safe in event sourcing because state is typed `Readonly<S>` (compiler pr
 ### Round-trip identity
 
 ```
-patch(before, delta(before, after))  ≡  after        // when keys(after) ⊇ keys(before)
+patch(before, delta(before, after))  ≡  after
+   // when keys(after) ⊇ keys(before),  OR
+   // when every key in before \ after is set to null in after
+
 delta(before, before)                ≡  {}           // idempotent
 ```
 
-The round-trip holds for the equal-shape case (the common shape for event payloads against a stable state schema): every key in `before` is still in `after`, so `delta` records only the changes and `patch` reconstructs `after` faithfully. When `after` has fewer keys than `before`, the missing keys are omitted from `delta`'s output — `patch` then treats the omission as "no change", so the dropped keys survive the replay. This is intentional: `delta` produces event payloads, which record positive facts, not deletion instructions. Express a deletion directly as `patch(state, { key: null })`.
+The round-trip holds whenever `after` faithfully expresses the intended end-state — either by retaining every original key (the equal-shape case, common for event payloads against a stable state schema) or by setting the to-be-removed keys to `null` (the caller-driven deletion case from [Modeling deletions](#modeling-deletions)). If `after` silently *omits* a key that was in `before`, `delta` reads that as "no change" and the dropped key survives the replay — express the deletion as `null` instead, or instruct `patch` directly (`patch(before, { key: null })`).
 
 In Act's event sourcing model, an event's data *is* the (event-shaped) patch. Either direction works: emit `delta(prev, next)` as event data and let the framework apply it via `patch`, or hand-write a `Patch<S>` and emit it directly. No diff/merge logic on the application side.
 
@@ -101,8 +137,9 @@ In Act's event sourcing model, an event's data *is* the (event-shaped) patch. Ei
 | Same reference (`Object.is`) | omit (mirrors patch's structural sharing) |
 | Both plain objects | recurse |
 | Different references, any other diff | set to `after[K]` (wholesale replace) |
-| Key in `before` only | omit (event payloads record changes, not deletions — at any depth) |
-| Key in `after` only | set to `after[K]` |
+| Key in `before` only — *omitted* from `after` | omit (no synthesized null at any depth) |
+| Key in `after` set explicitly to `null` | set to `null` (caller-driven deletion — propagated, see [Modeling deletions](#modeling-deletions)) |
+| Key in `after` only (introduced) | set to `after[K]` |
 
 Two structurally-equal-but-distinct values (e.g. two `Date` instances with the same `getTime()`) emit a replacement — safe semantically, just slightly less compact. `Object.is` handles `NaN === NaN` and distinguishes `+0` from `-0` correctly.
 

--- a/libs/act-patch/src/delta.ts
+++ b/libs/act-patch/src/delta.ts
@@ -2,24 +2,44 @@ import type { DeepPartial, Schema } from "./types.js";
 
 /**
  * Compute the smallest `DeepPartial<S>` describing what changed between
- * `before` and `after`. Designed for event payloads — records positive
- * facts (what changed) rather than `patch` instructions (which include a
- * `null` deletion sentinel).
+ * `before` and `after`. Designed for event payloads — records what the
+ * caller put in `after`, rather than synthesizing `patch` instructions
+ * on the caller's behalf.
  *
- * **Rules** (mirror `patch`'s merging rules for the *change* cases):
- * - Same reference (`Object.is`)            → omit (mirrors structural sharing)
- * - Both plain objects                      → recurse (mirrors deep merge)
- * - Otherwise (any other diff)              → set to `after[K]` (mirrors wholesale replace)
- * - Key in `before` only (missing in after) → omit
+ * ## How `delta` reacts to what's in `after`
  *
- * **Round-trip property**: when `before` and `after` share the same key
- * set (the common case for event payloads against a stable state schema),
- * `patch(before, delta(before, after))` deeply equals `after`. When `after`
- * has fewer keys than `before`, the missing key is omitted from the output
- * rather than encoded as a deletion sentinel — `patch` treats the omission
- * as "no change," so the dropped key survives the round-trip. Use
- * `patch(before, { key: null })` directly if you need to express deletion
- * as an instruction; `delta` is for events.
+ * | What the caller put in `after` for key `k` | What `delta` returns for `k` | What `patch` does on replay |
+ * |---|---|---|
+ * | (key omitted)                              | (key omitted)                | leaves `state[k]` alone |
+ * | explicit `null` (schema permits)           | `null`                       | deletes `state[k]` (null is `patch`'s deletion sentinel) |
+ * | new value                                  | the new value                | sets `state[k]` |
+ * | same reference as `before[k]`              | (key omitted)                | leaves `state[k]` alone |
+ *
+ * The asymmetry that matters: **`delta` never *synthesizes* `null` for a
+ * missing key, but it always *propagates* `null` when the caller put one
+ * in `after`**. So nullable-schema actions can express a deletion as
+ * `{ field: null }`, and the deletion travels through delta → event →
+ * reducer-side `patch(state, eventData)` all the way to the aggregate.
+ * Non-nullable schemas (no `.nullable()` fields) never see `null` in the
+ * type or at runtime — the konsult case.
+ *
+ * ## Recursion
+ *
+ * - Same reference (`Object.is`)                          → omit
+ * - Both plain objects                                    → recurse
+ * - Any other diff (value, type, reference)               → set to `after[K]`
+ * - Key in `before` only (missing in `after`)             → omit
+ * - Key in `after` only, or explicit `null` in `after`    → set to `after[K]` (so an explicit `null` flows through)
+ *
+ * ## Round-trip property
+ *
+ * `patch(before, delta(before, after))` deeply equals `after` when the
+ * key set in `after` is a superset of the key set in `before` (or the
+ * shrinkages are encoded as explicit nulls in `after`). If `after`
+ * silently *omits* keys that were present in `before`, the dropped key
+ * survives the round-trip — `delta` reads the omission as "no change,"
+ * not "delete." Express deletion in `after` (as `null`) or instruct
+ * `patch` directly (`patch(before, { key: null })`).
  *
  * Equality is reference-based, matching `patch`'s structural-sharing model.
  * Two structurally-equal-but-distinct values (e.g. two `Date` instances with
@@ -29,9 +49,9 @@ import type { DeepPartial, Schema } from "./types.js";
  *
  * @param before - The original state object
  * @param after - The desired state object
- * @returns The smallest deep-partial that, when merged onto `before`,
- *   produces an object structurally matching `after` (modulo deletions —
- *   see the round-trip caveat above).
+ * @returns The smallest deep-partial describing what `after` says changed
+ *   relative to `before`. May contain `null` only when `after` itself
+ *   contained `null` at the same path.
  */
 export const delta = <S extends Schema>(
   before: Readonly<S>,

--- a/libs/act-patch/test/delta.spec.ts
+++ b/libs/act-patch/test/delta.spec.ts
@@ -88,11 +88,13 @@ describe("delta", () => {
   });
 
   describe("missing keys — event-payload shape", () => {
-    it("omits every key present only in before (no null sentinel)", () => {
+    it("omits every key present only in before (no synthesized null)", () => {
       expect(delta<Schema>({ a: 1, b: 2, c: 3 }, { a: 1 })).toEqual({});
     });
 
-    it("never produces null at any depth", () => {
+    it("never synthesizes null for missing keys at any depth", () => {
+      // `delta` doesn't *invent* a null for an absent key. (Explicit
+      // nulls in `after` are propagated — see the next describe block.)
       const before = {
         keep: 1,
         drop: 2,
@@ -103,6 +105,53 @@ describe("delta", () => {
       expect(result).toEqual({});
       const stringified = JSON.stringify(result);
       expect(stringified).not.toContain("null");
+    });
+  });
+
+  // Locks in the asymmetry: `delta` never *synthesizes* null for a
+  // missing key, but it always *propagates* null when the caller put
+  // one in `after`. That's the contract that makes the deletion flow
+  // work end-to-end: nullable-schema action carries `{ field: null }`
+  // → delta emits `{ field: null }` → reducer's `patch(state, data)`
+  // reads the null as the deletion sentinel and removes the key.
+  describe("explicit nulls in `after` — caller-driven deletion", () => {
+    it("propagates a shallow explicit null from after", () => {
+      const before = { bio: "old", name: "Alice" };
+      const after = { bio: null, name: "Alice" };
+      expect(delta<Schema>(before, after)).toEqual({ bio: null });
+    });
+
+    it("propagates a nested explicit null from after", () => {
+      const before = {
+        profile: { bio: "old", avatar: "u.png" },
+      };
+      const after = {
+        profile: { bio: null, avatar: "u.png" },
+      };
+      expect(delta<Schema>(before, after)).toEqual({
+        profile: { bio: null },
+      });
+    });
+
+    it("propagates an explicit null introducing a new key", () => {
+      expect(delta<Schema>({ a: 1 }, { a: 1, b: null })).toEqual({ b: null });
+    });
+
+    it("recognizes Object.is(null, null) → omits an unchanged null", () => {
+      expect(delta<Schema>({ b: null }, { b: null })).toEqual({});
+    });
+
+    it("treats null → non-null as a wholesale replace (not a recurse)", () => {
+      expect(delta<Schema>({ x: null }, { x: { nested: 1 } })).toEqual({
+        x: { nested: 1 },
+      });
+    });
+
+    it("round-trips through patch — caller-supplied null deletes the field", () => {
+      const before = { bio: "old", name: "Alice" };
+      const data = { bio: null, name: "Alice" };
+      const d = delta<Schema>(before, data);
+      expect(patch(before, d)).toEqual({ name: "Alice" });
     });
   });
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@act/calculator": "workspace:^",
     "@rotorsoft/act": "workspace:^",
+    "@rotorsoft/act-ops": "workspace:^",
     "@rotorsoft/act-pg": "workspace:^",
     "@trpc/server": "11.17.0",
     "cors": "^2.8.6",

--- a/packages/server/src/idempotency.ts
+++ b/packages/server/src/idempotency.ts
@@ -1,68 +1,13 @@
 /**
- * In-memory bounded idempotency cache. Receiver-side dedup primitive
- * for the contract documented in
- * [external integration](../../../docs/docs/guides/external-integration.md).
+ * Receiver-side header parser for the idempotency contract. The
+ * dedup store itself — `IdempotencyStore` port +
+ * `InMemoryIdempotencyStore` reference impl — now lives in
+ * `@rotorsoft/act-ops`; import from there for new code.
  *
- * Single-process only. For multi-process receivers, swap the cache for
- * Redis SETNX or a Postgres unique index — the call shape stays the same:
- * `recordIfFresh(key) => boolean`.
+ * `extractIdempotencyKey` stays here until #743 (ACT-1115) lifts it
+ * into `@rotorsoft/act-http/receiver` alongside the framework-specific
+ * middleware adapters.
  */
-
-/**
- * Bounded LRU dedup cache. Entries expire after `ttlMs`; the map is
- * also capped at `maxEntries` so a runaway sender can't blow memory.
- *
- * Map iteration is insertion-ordered, so:
- * - The oldest entry sits at `keys().next().value` (cheapest to evict).
- * - GC walks until the first non-expired entry and stops.
- */
-export class IdempotencyCache {
-  private readonly seen = new Map<string, number>();
-  private readonly ttlMs: number;
-  private readonly maxEntries: number;
-
-  constructor(options?: { ttlMs?: number; maxEntries?: number }) {
-    this.ttlMs = options?.ttlMs ?? 24 * 60 * 60 * 1000; // 24h default
-    this.maxEntries = options?.maxEntries ?? 100_000;
-  }
-
-  /**
-   * Atomically record the key as seen. Returns `true` if the key was
-   * fresh (and is now recorded), `false` if it was already in the
-   * cache (the caller should treat the request as a duplicate).
-   *
-   * `now` is exposed for tests; production callers should leave it
-   * undefined so wall-clock is used.
-   */
-  recordIfFresh(key: string, now: number = Date.now()): boolean {
-    this.gc(now);
-    if (this.seen.has(key)) return false;
-    this.seen.set(key, now + this.ttlMs);
-    if (this.seen.size > this.maxEntries) {
-      const oldest = this.seen.keys().next().value;
-      if (oldest !== undefined) this.seen.delete(oldest);
-    }
-    return true;
-  }
-
-  /** Number of entries currently tracked (post-GC at call time). */
-  size(now: number = Date.now()): number {
-    this.gc(now);
-    return this.seen.size;
-  }
-
-  /** Drop every entry — test hook. */
-  clear(): void {
-    this.seen.clear();
-  }
-
-  private gc(now: number): void {
-    for (const [key, expiresAt] of this.seen) {
-      if (expiresAt > now) break;
-      this.seen.delete(key);
-    }
-  }
-}
 
 /**
  * Pull the `Idempotency-Key` header from a Node-style headers bag,

--- a/packages/server/src/webhook-receiver.ts
+++ b/packages/server/src/webhook-receiver.ts
@@ -12,17 +12,18 @@
  * handlers without manual `as` casts.
  */
 
+import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { createHTTPServer } from "@trpc/server/adapters/standalone";
 import { z } from "zod";
-import { extractIdempotencyKey, IdempotencyCache } from "./idempotency.js";
+import { extractIdempotencyKey } from "./idempotency.js";
 
 /** tRPC context shape: just the raw request headers. */
 type Ctx = { headers: Record<string, string | string[] | undefined> };
 
 const t = initTRPC.context<Ctx>().create();
 
-const cache = new IdempotencyCache({
+const dedup = new InMemoryIdempotencyStore({
   // 24h dedup window — covers any reasonable retry+backoff envelope
   // from a sender using ACT-601 `exponential` backoff up to maxMs=30s.
   ttlMs: 24 * 60 * 60 * 1000,
@@ -43,7 +44,7 @@ const idempotent = t.procedure.use(({ ctx, next }) => {
       message: "Missing Idempotency-Key header",
     });
   }
-  const deduped = !cache.recordIfFresh(key);
+  const deduped = !dedup.record_if_fresh(key);
   return next({ ctx: { ...ctx, key, deduped } });
 });
 

--- a/packages/server/src/webhook-receiver.ts
+++ b/packages/server/src/webhook-receiver.ts
@@ -44,7 +44,7 @@ const idempotent = t.procedure.use(({ ctx, next }) => {
       message: "Missing Idempotency-Key header",
     });
   }
-  const deduped = !dedup.record_if_fresh(key);
+  const deduped = !dedup.claim(key);
   return next({ ctx: { ...ctx, key, deduped } });
 });
 

--- a/packages/server/test/idempotency.spec.ts
+++ b/packages/server/test/idempotency.spec.ts
@@ -1,68 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractIdempotencyKey, IdempotencyCache } from "../src/idempotency.js";
+import { extractIdempotencyKey } from "../src/idempotency.js";
 
-describe("IdempotencyCache", () => {
-  it("recordIfFresh returns true the first time, false on re-record", () => {
-    const cache = new IdempotencyCache();
-    expect(cache.recordIfFresh("k1")).toBe(true);
-    expect(cache.recordIfFresh("k1")).toBe(false);
-    expect(cache.recordIfFresh("k2")).toBe(true);
-  });
-
-  it("expires entries after ttlMs and re-records on next call", () => {
-    const cache = new IdempotencyCache({ ttlMs: 1_000 });
-    const t0 = 1_000_000;
-    expect(cache.recordIfFresh("k1", t0)).toBe(true);
-    expect(cache.recordIfFresh("k1", t0 + 500)).toBe(false);
-    // Expired — next recordIfFresh treats it as fresh.
-    expect(cache.recordIfFresh("k1", t0 + 1_500)).toBe(true);
-  });
-
-  it("size reflects current entries after gc", () => {
-    const cache = new IdempotencyCache({ ttlMs: 1_000 });
-    const t0 = 1_000_000;
-    cache.recordIfFresh("a", t0);
-    cache.recordIfFresh("b", t0);
-    cache.recordIfFresh("c", t0);
-    expect(cache.size(t0)).toBe(3);
-    // Advance past TTL — gc drops everything.
-    expect(cache.size(t0 + 2_000)).toBe(0);
-  });
-
-  it("evicts the oldest entry when maxEntries is exceeded", () => {
-    const cache = new IdempotencyCache({ maxEntries: 2 });
-    cache.recordIfFresh("a");
-    cache.recordIfFresh("b");
-    cache.recordIfFresh("c"); // "a" evicts (oldest); cache is [b, c]
-    expect(cache.size()).toBe(2);
-    // "b" and "c" still present.
-    expect(cache.recordIfFresh("b")).toBe(false);
-    expect(cache.recordIfFresh("c")).toBe(false);
-    // "a" is no longer in the cache → fresh again.
-    expect(cache.recordIfFresh("a")).toBe(true);
-  });
-
-  it("clear drops all entries", () => {
-    const cache = new IdempotencyCache();
-    cache.recordIfFresh("k");
-    cache.clear();
-    expect(cache.size()).toBe(0);
-    expect(cache.recordIfFresh("k")).toBe(true);
-  });
-
-  it("gc stops at the first non-expired entry (insertion order)", () => {
-    const cache = new IdempotencyCache({ ttlMs: 1_000 });
-    const t0 = 1_000_000;
-    cache.recordIfFresh("expired-1", t0);
-    cache.recordIfFresh("expired-2", t0 + 100);
-    cache.recordIfFresh("fresh", t0 + 800);
-    // Sweep at t0 + 1_500: expired-1 and expired-2 are past TTL,
-    // "fresh" is not — gc must drop the first two and stop.
-    expect(cache.size(t0 + 1_500)).toBe(1);
-    expect(cache.recordIfFresh("fresh", t0 + 1_500)).toBe(false);
-  });
-});
-
+// The IdempotencyStore port + InMemoryIdempotencyStore impl tests
+// moved to libs/act-ops/test/in-memory.spec.ts when the class was
+// promoted to `@rotorsoft/act-ops` (#746). `extractIdempotencyKey`
+// stays here until #743 lifts it into `@rotorsoft/act-http/receiver`.
 describe("extractIdempotencyKey", () => {
   it("returns the header value (case-insensitive)", () => {
     expect(extractIdempotencyKey({ "Idempotency-Key": "abc" })).toBe("abc");

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../../libs/act"
     },
     {
+      "path": "../../libs/act-ops/tsconfig.build.json"
+    },
+    {
       "path": "../../libs/act-pg"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,6 +504,9 @@ importers:
       '@rotorsoft/act':
         specifier: workspace:^
         version: link:../../libs/act
+      '@rotorsoft/act-ops':
+        specifier: workspace:^
+        version: link:../../libs/act-ops
       '@rotorsoft/act-pg':
         specifier: workspace:^
         version: link:../../libs/act-pg


### PR DESCRIPTION
## Summary

Closes #746. First primitive shipping into `@rotorsoft/act-ops` — promotes the receiver-side idempotency contract from `packages/server/` demo code to a real port with a reference implementation, plus a doc + skill + book-note pass that explains how the new pattern slots into the broader integration story. The port has no runtime or peer dep on `@rotorsoft/act`, so non-Act receivers (forwarded-bus consumers, framework-agnostic HTTP endpoints, Kafka workers) speak the contract without dragging the orchestrator along.

## Port

`libs/act-ops/src/idempotency/port.ts` declares the contract:

```ts
interface IdempotencyStore {
  record_if_fresh(key: string, now?: number): boolean | Promise<boolean>;
}
```

The union return type covers sync (in-memory) and async (durable adapters) on the same call site. The middleware that consumes the port (#744) will `await` unconditionally; sync impls resolve in the same microtask without paying for I/O scheduling.

**Named "Store" not "Cache" deliberately.** In this codebase `Cache` means "rebuildable from a source of truth" (snapshot cache); `Store` means authoritative. Dedup state is authoritative — losing a record causes a duplicate side effect (pay invoice twice, send email twice, open incident twice), not a rebuild. Operators picking implementations should weigh persistence, not hit rate. The README has a dedicated section on this trade-off and the book note opens with the naming question that took longer than the code.

## Reference implementation

`libs/act-ops/src/idempotency/in-memory.ts` ships `InMemoryIdempotencyStore` — bounded LRU + TTL, lifted from `packages/server/src/idempotency.ts`'s `IdempotencyCache`, renamed, with the impossible defensive `if (oldest !== undefined)` guard removed (the construction guarantees the value, so the guard was satisfying the type system, not protecting a runtime case). Replaced with a non-null assertion + a one-line comment explaining the construction invariant.

The branch wouldn't have been a problem in `packages/server` (no 100%-coverage gate there). It's a problem in `libs/`, where the gate forces removal. The cleanup is the kind of small forcing-function effect the rule pays for — covered at length in the book note's "defensive branch that has to die" section.

Single-process only — multi-process receivers swap for a durable adapter (Postgres unique index, Redis `SET NX EX`) implementing the same port. `PostgresIdempotencyStore` + `idempotencyTck` in `libs/act-tck` are parked for milestone 1.2 per the ticket scope.

## Naming audit (deviations from ticket spec, called out)

The ticket spec wrote `recordIfFresh` in camelCase. The framework's public-API convention is **snake_case for multi-word methods** (`blocked_streams`, `query_array`, `query_streams`); the shipped name is `record_if_fresh`. Single-word port methods (`commit`, `claim`, `notify`, `subscribe`, `invalidate`) stay camelCase — those are single words.

Class fields follow CLAUDE.md's rule for `libs/`: **private fields `_snake_case` with underscore prefix** (`_seen`, `_ttl_ms`, `_max_entries`, `_gc`). Option-bag fields stay camelCase (`ttlMs`, `maxEntries`) to match `DrainOptions.streamLimit`, `LaneConfig.cycleMs`, `BackoffConfig.baseMs` — that's the established analog for option types.

The PR body of #828 (act-ops bootstrap) called the constraint out; this PR is where it lands.

## Demo consumer migration

`packages/server/src/webhook-receiver.ts` imports `InMemoryIdempotencyStore` from `@rotorsoft/act-ops`, calls `dedup.record_if_fresh(key)`. One import change, one method rename, nothing else moves — the wolfdesk webhook end-to-end stays identical.

`packages/server/src/idempotency.ts` drops the `IdempotencyCache` class entirely; only `extractIdempotencyKey` remains until #743 (ACT-1115) lifts it into `@rotorsoft/act-http/receiver` alongside the framework-specific middleware adapters from #744.

`packages/server/test/idempotency.spec.ts`: the six `IdempotencyCache` tests moved to `libs/act-ops/test/in-memory.spec.ts` under the new class and method names, plus two new tests (`size` with default `now`; explicit GC-stop ordering). The `extractIdempotencyKey` tests stay until they move with the parser.

`packages/server/tsconfig.json` adds a project reference to `../../libs/act-ops/tsconfig.build.json` so `tsc --build` resolves the declaration emit location correctly.

## Documentation pass

- **`libs/act-ops/README.md`** — drops the scaffold-only placeholder banner from #828. Quick start, API list, and a dedicated "Why a Store and not a Cache" section ship with the first real surface. The Compatibility / Stability / Related / Documentation footer stays.
- **`docs/docs/guides/external-integration.md`** — the "cache shapes" section (#603) becomes the `IdempotencyStore` port section. `InMemoryIdempotencyStore` from `@rotorsoft/act-ops` is the canonical in-memory case; the Redis and Postgres examples are reframed as **port-implementing adapter sketches** that operators can drop in unchanged. The tRPC receiver example imports from `@rotorsoft/act-ops` instead of the demo path.
- **`.claude/skills/scaffold-act-app/server.md`** — the existing API-edge idempotency section was about *response replay* (a different shape). Now distinguishes the two shapes explicitly: receiver-side dedup (uses `@rotorsoft/act-ops`) vs API-edge response replay (inline middleware). Includes a worked receiver-side example so the scaffold skill points new apps at the right primitive.
- **`book/act-1118-idempotency-store.md`** — narrative essay on the Store-vs-Cache naming decision, the union-return-type rationale (sync impls shouldn't pay for `Promise<boolean>` scheduling), why this lives in `act-ops` and not `libs/act` or `act-http`, the defensive-branch cleanup story, and how this unblocks #744.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 1905 / 1905 pass. Net +5 vs master (8 new in `libs/act-ops/test/in-memory.spec.ts`, 6 removed from `packages/server/test/idempotency.spec.ts`, plus the existing `act-patch` doc-tightening tests from #831).
- [x] Coverage 100% / 100% / 100% / 100%.
- [x] `pnpm lint` — no errors. 32 warnings + 3 infos match the master baseline (pre-existing suppressions/unused).
- [x] `pnpm -F @rotorsoft/act-ops build` — ESM + CJS + types emit cleanly.
- [x] `grep "@rotorsoft/act\b" libs/act-ops/src` — only prose references in `@packageDocumentation` JSDoc; no imports. Acceptance criterion satisfied.
- [ ] CI green on PR.

Coverage: 100% statements / 100% branches / 100% functions / 100% lines.

## Stability charter impact

None for the framework's v1.0 surface. `@rotorsoft/act-ops` is at `0.0.0` with the baseline tag seeded by #828. This commit is a `feat(act-ops):` so semantic-release will cut **`0.1.0`** on merge per the seeded baseline. Subsequent additive features (#747, etc.) minor-bump from there. Charter takes effect when the package reaches `1.0.0`.

No charter-covered files in `libs/act/` were touched.

## Follow-ups

- **#743 (ACT-1115)** — `extractIdempotencyKey` lifts to `@rotorsoft/act-http/receiver`. Once it lands, `packages/server/src/idempotency.ts` disappears entirely.
- **#744 (ACT-1116)** — framework-agnostic idempotency middleware in `@rotorsoft/act-http/receiver/middleware` consumes this port. Will rewrite `packages/server/src/webhook-receiver.ts` to use the adapter, shrinking the demo to pure glue.
- **#747 (ACT-1119)** — `computeMinSafeTtl` helper, also into `@rotorsoft/act-ops`. Sizes the dedup window from the sender's backoff + lease config so operators stop computing it by hand.
- **Milestone 1.2** — `PostgresIdempotencyStore` in `act-pg`, `idempotencyTck` in `act-tck`. Lets the port bake one release before durable adapters land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)