### PR TITLE
feat(act): per-action retry policy for ConcurrencyError (closes #739)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -12,7 +12,7 @@ Breaking changes to anything in this list require a **major** version bump and a
 
 The fluent surfaces exported from `@rotorsoft/act`:
 
-- `state(...)` — including `.init`, `.patch`, `.snap`, `.given`, `.build`
+- `state(...)` — including `.init`, `.emits`, `.patch`, `.on` (with optional `ActionOptions` second argument for per-action retry policy), `.given`, `.emit`, `.snap`, `.build`
 - `slice(...)` — including `.actions`, `.given`, `.build`
 - `projection(...)` — including `.from`, `.on`, `.build`
 - `act(...)` — including `.with`, `.build`

--- a/book/act-1111-per-action-retry.md
+++ b/book/act-1111-per-action-retry.md
@@ -1,0 +1,85 @@
+# ACT-1111 — per-action retry policy for ConcurrencyError
+
+ACT-1111 closes the gap between Act's two retry paths: reactions already declared their retry budget on the slice (`.do(handler, { maxRetries, backoff })`), but commands made callers wrap every `app.do(...)` in a copy-paste loop. Material for the error-handling chapter and a worked example of when to expand the orchestrator's contract instead of shipping a helper.
+
+**The pattern the docs printed.** Until this ticket, the `error-handling.md` page had a literal snippet captioned "Retry Pattern" — a `withRetry(action, target, payload)` loop that caught `ConcurrencyError`, ran a budget, and rethrew on exhaustion. Every Act app handling user-driven commands copied it. The framework was distributing a workaround.
+
+The temptation was to ship the workaround as a helper: extract the snippet into `withRetry(fn, opts)`, export it from the package, point the docs at the import. Half-an-hour ticket. Done.
+
+That's the wrong move, and the *why* is the part worth preserving for the book.
+
+---
+
+**The wrong turn.** Shipping `withRetry(fn, opts)` was the original scope. The argument for it was straightforward — apps already wrote the loop, the helper composes around any async call, no charter expansion. A clean caller-side primitive.
+
+What killed it was the symmetry check. Reactions don't make the caller pace retries; the slice author declares `{ maxRetries, backoff }` once on `.do(handler, options)`, and the orchestrator owns the loop. Commands had no equivalent. Same framework, two different mental models depending on whether the failure happened on the command path or the drain path.
+
+The principle the chapter should lead with: **the author of the unit of work knows its operational profile; the caller shouldn't have to.** A `transfer` action on a hot account stream contends; an `audit_ping` on a low-traffic stream doesn't. The slice author has both pieces of information at the point they declare the action. The caller has neither, and there are typically many callers per action — a tRPC mutation, a worker, a CLI tool, a forwarded-bus consumer.
+
+A caller-side helper forces every call site to remember the right wrapping. A declarative shape on the action means write-once.
+
+---
+
+**The pivot — `state.on(entry, ActionOptions)`.** The shape we landed on:
+
+```ts
+state({ HotAccount: z.object({ balance: z.number() }) })
+  .init(() => ({ balance: 0 }))
+  .emits({ Transferred: z.object({ amount: z.number() }) })
+  .on(
+    { transfer: z.object({ amount: z.number() }) },
+    { maxRetries: 5, backoff: { strategy: "exponential", baseMs: 10, maxMs: 200, jitter: true } },
+  )
+    .emit((a) => ["Transferred", { amount: a.amount }])
+  .build();
+```
+
+Backward-compatible: `state.on(entry)` keeps current behavior (`ConcurrencyError` surfaces on first conflict). Adding the second arg opts into orchestrator-owned retry. No call-site change.
+
+The orchestrator wires the loop in `event-sourcing.action()`. On `ConcurrencyError` it invalidates the cache (existing behavior), applies optional backoff, and re-runs from `load()` — which now reads fresh state because the cache invalidation forces a store round-trip. Non-`ConcurrencyError` rethrows immediately; the budget exists for one specific failure mode and nothing else.
+
+Reactions don't pay the cost. Reaction-driven actions pass `undefined` as `expectedVersion` to `Store.commit` (stream leasing already serializes them), so `ConcurrencyError` is structurally unreachable on that path. The retry loop is a free no-op for reactions.
+
+The chapter framing: the orchestrator absorbs the conflict; the caller is unchanged. Compare to the reaction side — same shape, same author-owns-policy principle, isomorphic mental model.
+
+---
+
+**The backoff rethink.** First pass of the design wrote off backoff entirely. Argument: optimistic-concurrency conflicts resolve faster with immediate retry. Bare `continue`, no delay. The original `withRetry` snippet in the docs does exactly this.
+
+Wrong, or at least overconfident. The honest picture is:
+
+- **Low contention** — two or three writers racing. Immediate retry is fine; each round eliminates one, latency stays bounded.
+- **High contention** — N writers all loaded at v10, racing. They lose in lockstep, retry instantly, re-race, lose again. CPU/DB load grows quadratically with N, the "winner" of each round is whichever writer reconnects fastest (no fairness), and late-bound writers see linear-in-position latency.
+
+The canonical OCC literature (Postgres-flavored or otherwise) is unanimous: jittered exponential backoff is the textbook pattern. Pretending it doesn't apply because Act's `ConcurrencyError` "isn't really transient" was sleight of hand — under contention, the conflict *is* the transient condition, and pacing it works.
+
+So `ActionOptions.backoff` reuses the existing `BackoffOptions` shape from the reaction side. Default omitted (immediate retry, fine at low contention); declared on hot actions where the author knows the contention profile demands pacing. Same `computeBackoffDelay(attempt, opts)` helper drives both paths — the math doesn't care whether the failure came from the command commit or the reaction handler.
+
+The teachable framing: defaults should match the common case (low contention, immediate retry); options should make the uncommon case (hot stream, jittered exponential) expressible without escape-hatching out of the framework.
+
+---
+
+**The `BackoffOptions` move.** Smaller design call but worth recording. `BackoffOptions` and `BackoffStrategy` lived in `types/reaction.ts` because reactions were the first consumer. With actions adopting them, two options surfaced:
+
+1. **New `types/backoff.ts` file** — topic-per-file, matches the existing `internal/backoff.ts` symmetry.
+2. **Move to `types/action.ts`** — `action.ts` has organically become the kitchen-sink for primitives that span layers (`Schema`, `Actor`, `Committed`, `Snapshot`, `IAct`, `Query`, `EventMeta`, `State` — none of which are action-specific).
+
+We picked (2), against the topic-per-file instinct. The reasoning the chapter should preserve: the kitchen-sink pattern was already the precedent. Either fix it everywhere (extract a `types/primitives.ts`, move a dozen types, churn every import) or stop pretending the file name describes its contents. The minor refactor wasn't worth the diff in a per-action-retry ticket; the major refactor is a separate decision.
+
+So `BackoffOptions` joined the kitchen-sink. `reaction.ts` cross-imports it. `internal/backoff.ts` retargets its import. No public-surface change — the type still imports from `@rotorsoft/act` for users.
+
+When the book covers the type taxonomy, this is the case study for "the cheap wrong fix would have been a third option."
+
+---
+
+**The escape hatch we kept.** The docs page still shows a manual `withRetry` loop, but as a footnote: *use this when you need different behavior than what's declared on the action*. Concrete example — a UI mutation that should fail fast and surface the conflict to the user, even when the action declares `maxRetries: 5` for worker callers.
+
+The principle: declarative defaults should cover the common case; manual wrapping stays available for the calls that genuinely need different policy. Don't ship a primary mechanism that has no escape.
+
+---
+
+**Connections to other chapters.**
+
+- The reactions chapter (ACT-601 backoff) is the parallel half. The book should pair them — actions and reactions both use orchestrator-owned retry loops with the same `BackoffOptions` shape; the only differences are who declares (state author vs. slice author) and where the loop lives (`event-sourcing.action()` vs. `DrainController`).
+- The concurrency-model chapter (`docs/docs/architecture/concurrency-model.md`) talks about optimistic concurrency as the user-facing failure mode; this ticket makes the standard remedy declarative. Update the "Resolution" paragraph to point at `ActionOptions` instead of the manual loop.
+- The Phase 1.1 tracker (#748) noted that #740 (`settleOnCommit` / `logBlocked`) and #741 (`replayUntilSettled`) face the same declarative-vs-helper question. The deferred decision is recorded as comments on those tickets; the principle established here ("orchestrator owns the policy when it has enough information") is the criterion for the call.

--- a/docs/docs/architecture/concurrency-model.md
+++ b/docs/docs/architecture/concurrency-model.md
@@ -42,7 +42,7 @@ caller                  framework                   store
   │  ◄───────────────────── │
 ```
 
-If two callers race on the same stream, only one wins. The loser sees `ConcurrencyError` with `expectedVersion` and `lastVersion` (the actual head). Standard pattern is to reload state and retry.
+If two callers race on the same stream, only one wins. The loser sees `ConcurrencyError` with `expectedVersion` and `lastVersion` (the actual head). The standard remedy is per-action retry policy — `state.on(entry, { maxRetries, backoff? })` — which lets the orchestrator absorb the conflict and re-run from `load()`. See [`ActionOptions` in Error Handling](../concepts/error-handling.md#retry-pattern--per-action-policy).
 
 ### Two failure modes the framework handles
 

--- a/docs/docs/concepts/error-handling.md
+++ b/docs/docs/concepts/error-handling.md
@@ -62,22 +62,55 @@ try {
 
 **Resolution:** Retry with fresh state. The cache is invalidated automatically on concurrency errors.
 
-### Retry Pattern
+### Retry Pattern — per-action policy
+
+Declare the retry budget on the action itself. The orchestrator owns the loop: on `ConcurrencyError` it invalidates the cache, applies an optional `backoff`, and re-runs from `load()`. Any other error rethrows immediately and does not consume the budget.
 
 ```typescript
-async function withRetry(action, target, payload, maxRetries = 3) {
+import { state } from "@rotorsoft/act";
+import { z } from "zod";
+
+const BankAccount = state({ BankAccount: z.object({ balance: z.number() }) })
+  .init(() => ({ balance: 0 }))
+  .emits({ Transferred: z.object({ amount: z.number() }) })
+  .on(
+    { transfer: z.object({ amount: z.number() }) },
+    {
+      maxRetries: 5,
+      backoff: { strategy: "exponential", baseMs: 10, maxMs: 200, jitter: true },
+    },
+  )
+    .emit((action) => ["Transferred", { amount: action.amount }])
+  .build();
+
+// Caller is unchanged — the retry is invisible to them.
+await app.do("transfer", target, { amount: 100 });
+```
+
+The action author knows whether the action contends for a hot stream; the caller shouldn't have to. The same call site works for low-contention actions (omit options, surface `ConcurrencyError` on first conflict) and hot-stream actions (declare a budget, retry transparently).
+
+`maxRetries` defaults to `0` (single attempt, current behavior). When `backoff` is omitted, retries run immediately — fine at low contention. On hot streams, jittered exponential backoff avoids the thundering herd of N writers re-racing in lockstep.
+
+#### When to wrap manually instead
+
+If you need different retry behavior than what the action declares — for instance, a UI mutation that should fail fast and surface to the user even on a hot action — wrap the call:
+
+```typescript
+async function withRetry(action, target, payload, maxRetries) {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await app.do(action, target, payload);
     } catch (error) {
       if (error instanceof ConcurrencyError && attempt < maxRetries) {
-        continue; // cache was invalidated, next load() gets fresh state
+        continue;
       }
       throw error;
     }
   }
 }
 ```
+
+This is an escape hatch — the declarative form on the action is the primary mechanism.
 
 ## StreamClosedError
 

--- a/docs/docs/concepts/state-management.md
+++ b/docs/docs/concepts/state-management.md
@@ -28,10 +28,11 @@ const Counter = state({ Counter: z.object({ count: z.number() }) })
 
 ### Builder Chain
 
-`state({})` → `.init()` → `.emits({})` → optional `.patch({})` → `.on({})` → optional `.given([])` → `.emit()` → `.build()`
+`state({})` → `.init()` → `.emits({})` → optional `.patch({})` → `.on({}, options?)` → optional `.given([])` → `.emit()` → `.build()`
 
 - **`.emits()`** declares events with passthrough reducers by default (`({ data }) => data`)
 - **`.patch()`** overrides only events that need custom reducers
+- **`.on(entry, options?)`** registers an action; the optional second argument is an [`ActionOptions`](./error-handling#retry-pattern--per-action-policy) for per-action retry policy (`maxRetries`, optional `backoff`). Omit for the current single-attempt behavior.
 - **`.emit("EventName")`** passes the action payload through directly as event data
 - **`.emit((action, snapshot, target) => [name, data])`** for computed event data. The handler receives:
   - `action` — the validated action payload

--- a/libs/act/src/builders/state-builder.ts
+++ b/libs/act/src/builders/state-builder.ts
@@ -7,6 +7,7 @@
 import type { ZodType } from "zod";
 import type {
   ActionHandler,
+  ActionOptions,
   GivenHandlers,
   Invariant,
   PassthroughPatchHandler,
@@ -151,15 +152,36 @@ export type ActionBuilder<
    * when the variable name matches the action name. The key becomes the
    * action name, the value the Zod schema.
    *
+   * Pass an optional second argument to declare a per-action retry
+   * policy — the orchestrator retries this action on
+   * {@link ConcurrencyError} up to `maxRetries` extra times, applying
+   * `backoff` between attempts when set. Omit the argument to keep the
+   * current single-attempt behavior (`ConcurrencyError` surfaces on
+   * first conflict).
+   *
    * @template TKey - Action name (string literal type)
    * @template TNewActions - Action payload schema type
    * @param entry - Single-key record `{ ActionName: schema }`
+   * @param options - Optional per-action retry policy
+   *   ({@link ActionOptions}).
    * @returns An object with `.given()` and `.emit()` for further configuration
    *
    * @example Simple action without invariants
    * ```typescript
    * .on({ increment: z.object({ by: z.number() }) })
    *   .emit((action) => ["Incremented", { amount: action.by }])
+   * ```
+   *
+   * @example Hot-stream action with retry + jittered exponential backoff
+   * ```typescript
+   * .on(
+   *   { transfer: z.object({ amount: z.number() }) },
+   *   {
+   *     maxRetries: 5,
+   *     backoff: { strategy: "exponential", baseMs: 10, maxMs: 200, jitter: true },
+   *   }
+   * )
+   *   .emit((action) => ["Transferred", { amount: action.amount }])
    * ```
    *
    * @example Action with business rules
@@ -180,7 +202,8 @@ export type ActionBuilder<
    * ```
    */
   on: <TKey extends string, TNewActions extends Schema>(
-    entry: ActionEntry<TKey, TNewActions>
+    entry: ActionEntry<TKey, TNewActions>,
+    options?: ActionOptions
   ) => {
     /**
      * Adds business rule invariants that must hold before the action can execute.
@@ -556,7 +579,8 @@ function action_builder<
 
   const builder: ActionBuilder<TState, TEvents, TActions, TName> = {
     on<TKey extends string, TNewActions extends Schema>(
-      entry: ActionEntry<TKey, TNewActions>
+      entry: ActionEntry<TKey, TNewActions>,
+      options?: ActionOptions
     ) {
       const keys = Object.keys(entry);
       if (keys.length !== 1) throw new Error(".on() requires exactly one key");
@@ -568,6 +592,10 @@ function action_builder<
 
       type MergedActions = TActions & { [P in TKey]: TNewActions };
       (internal.actions as Record<string, ZodType<Schema>>)[action] = schema;
+      if (options) {
+        internal.options ??= {};
+        (internal.options as Record<string, ActionOptions>)[action] = options;
+      }
 
       function given(rules: Invariant<TState>[]) {
         internal.given ??= {} as GivenHandlers<TState, Schemas>;

--- a/libs/act/src/internal/backoff.ts
+++ b/libs/act/src/internal/backoff.ts
@@ -8,7 +8,7 @@
  * @internal
  */
 
-import type { BackoffOptions } from "../types/reaction.js";
+import type { BackoffOptions } from "../types/action.js";
 
 /**
  * Compute the wall-clock delay (in ms) to wait before the next attempt on

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -37,7 +37,8 @@ import type {
   State,
   Target,
 } from "../types/index.js";
-import { validate } from "../utils.js";
+import { sleep, validate } from "../utils.js";
+import { computeBackoffDelay } from "./backoff.js";
 import { defaultCorrelator } from "./correlator.js";
 
 /**
@@ -457,7 +458,17 @@ export async function load<
 /**
  * Executes an action and emits an event to be committed by the store.
  *
- * This function validates the action, applies business invariants, emits events, and commits them to the event store.
+ * Validates the action, applies business invariants, emits events, and
+ * commits them to the event store. When the action's
+ * {@link ActionOptions} declare a retry budget, the orchestrator owns
+ * the loop on {@link ConcurrencyError}: cache is invalidated, optional
+ * `backoff` delay is applied, and the action re-runs from `load`. Any
+ * other error rethrows immediately and does not consume the budget.
+ *
+ * Reactions skip optimistic concurrency (commit below passes
+ * `undefined` as `expectedVersion` when `reactingTo` is set), so
+ * `ConcurrencyError` cannot fire on the reaction-driven path — the
+ * loop is naturally a no-op there.
  *
  * @template TState The type of state
  * @template TEvents The type of events
@@ -495,155 +506,169 @@ export async function action<
     ? payload
     : validate(action as string, payload, me.actions[action]);
 
-  const snapshot = await load(me, stream);
-  if (snapshot.event?.name === TOMBSTONE_EVENT)
-    throw new StreamClosedError(stream);
-  const expected = expectedVersion ?? snapshot.event?.version;
+  const opts = me.options?.[action];
+  const maxRetries = opts?.maxRetries ?? 0;
 
-  if (me.given) {
-    const invariants = me.given[action] || [];
-    invariants.forEach(({ valid, description }) => {
-      if (!valid(snapshot.state, actor))
-        throw new InvariantError(
-          action,
-          validated,
-          target,
-          snapshot,
-          description
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const snapshot = await load(me, stream);
+      if (snapshot.event?.name === TOMBSTONE_EVENT)
+        throw new StreamClosedError(stream);
+      const expected = expectedVersion ?? snapshot.event?.version;
+
+      if (me.given) {
+        const invariants = me.given[action] || [];
+        invariants.forEach(({ valid, description }) => {
+          if (!valid(snapshot.state, actor))
+            throw new InvariantError(
+              action,
+              validated,
+              target,
+              snapshot,
+              description
+            );
+        });
+      }
+
+      const result = me.on[action](validated, snapshot, target);
+      if (!result) return [snapshot];
+
+      // An empty array means no events were emitted
+      if (Array.isArray(result) && result.length === 0) {
+        return [snapshot];
+      }
+
+      const tuples = Array.isArray(result[0])
+        ? (result as Emitted<TEvents>[]) // array of tuples
+        : ([result] as Emitted<TEvents>[]); // single tuple
+
+      // ACT-403: warn once per process per event name when a dynamic
+      // `.emit((a) => ["X", ...])` produces a deprecated event. Static
+      // `.emit("X")` is already caught at build time by act-builder; this
+      // is the runtime safety net for the dynamic form, which the static
+      // checker can't inspect. The `_warned` set lives on the state so
+      // multiple Act instances over the same merged state share idempotency.
+      const deprecated = (me as { _deprecated?: Set<string> })._deprecated;
+      if (deprecated && deprecated.size > 0) {
+        const me_ = me as { _warned?: Set<string> };
+        const warned = me_._warned ?? (me_._warned = new Set<string>());
+        for (const [name] of tuples) {
+          const evt = name as string;
+          if (deprecated.has(evt) && !warned.has(evt)) {
+            warned.add(evt);
+            log().warn(
+              `Action "${String(action)}" emitted deprecated event "${evt}". ` +
+                `A newer version exists in the registry — update the action's ` +
+                `.emit() to target the current version. (warned once per process)`
+            );
+          }
+        }
+      }
+
+      const emitted = tuples.map(([name, data]) => ({
+        name,
+        data: skipValidation
+          ? data
+          : validate(name as string, data, me.events[name]),
+      }));
+
+      const meta: EventMeta = {
+        correlation:
+          reactingTo?.meta.correlation ||
+          correlator({
+            action: action as string,
+            state: me.name,
+            stream,
+            actor: target.actor,
+          }),
+        causation: {
+          action: {
+            name: action as string,
+            ...target,
+            // payload intentionally omitted: it can be large or contain PII,
+            // and callers correlate via the correlation id when they need it.
+          },
+          event: reactingTo
+            ? {
+                id: reactingTo.id,
+                name: reactingTo.name,
+                stream: reactingTo.stream,
+              }
+            : undefined,
+        },
+      };
+
+      let committed: Committed<TEvents, keyof TEvents>[];
+      try {
+        committed = await store().commit(
+          stream,
+          emitted,
+          meta,
+          // Reactions skip optimistic concurrency: they always append against the
+          // current head. Stream leasing already serializes concurrent reactions,
+          // and forcing version checks here would turn ordinary catch-up into
+          // spurious retries.
+          reactingTo ? undefined : expected
         );
-    });
-  }
+      } catch (error) {
+        // Invalidate cache on concurrency errors — cached state is stale
+        if (error instanceof ConcurrencyError) {
+          await cache().invalidate(stream);
+        }
+        throw error;
+      }
 
-  const result = me.on[action](validated, snapshot, target);
-  if (!result) return [snapshot];
+      let { state, patches } = snapshot;
+      const snapshots = committed.map((event) => {
+        const p = me.patch[event.name](event, state);
+        state = patch(state, p);
+        patches++;
+        // cache_hit / replayed propagate from the initial load — these
+        // post-commit snapshots all derive from the same loaded state.
+        // version advances per committed event (each is a new stream head).
+        return {
+          event,
+          state,
+          version: event.version,
+          patches,
+          snaps: snapshot.snaps,
+          patch: p,
+          cache_hit: snapshot.cache_hit,
+          replayed: snapshot.replayed,
+        };
+      });
 
-  // An empty array means no events were emitted
-  if (Array.isArray(result) && result.length === 0) {
-    return [snapshot];
-  }
+      // fire and forget snaps
+      const last = snapshots.at(-1)!;
+      const snapped = me.snap?.(last);
 
-  const tuples = Array.isArray(result[0])
-    ? (result as Emitted<TEvents>[]) // array of tuples
-    : ([result] as Emitted<TEvents>[]); // single tuple
+      // Update cache with post-commit state (reset patches if snapped).
+      // Fire-and-forget — log but don't fail the action on cache write errors
+      // (e.g., transient network failures in a custom Cache adapter).
+      cache()
+        .set<TState>(stream, {
+          state: last.state,
+          version: last.event.version,
+          event_id: last.event.id,
+          patches: snapped ? 0 : last.patches,
+          snaps: snapped ? last.snaps + 1 : last.snaps,
+        })
+        .catch((err) => log().error(err));
 
-  // ACT-403: warn once per process per event name when a dynamic
-  // `.emit((a) => ["X", ...])` produces a deprecated event. Static
-  // `.emit("X")` is already caught at build time by act-builder; this
-  // is the runtime safety net for the dynamic form, which the static
-  // checker can't inspect. The `_warned` set lives on the state so
-  // multiple Act instances over the same merged state share idempotency.
-  const deprecated = (me as { _deprecated?: Set<string> })._deprecated;
-  if (deprecated && deprecated.size > 0) {
-    const me_ = me as { _warned?: Set<string> };
-    const warned = me_._warned ?? (me_._warned = new Set<string>());
-    for (const [name] of tuples) {
-      const evt = name as string;
-      if (deprecated.has(evt) && !warned.has(evt)) {
-        warned.add(evt);
-        log().warn(
-          `Action "${String(action)}" emitted deprecated event "${evt}". ` +
-            `A newer version exists in the registry — update the action's ` +
-            `.emit() to target the current version. (warned once per process)`
-        );
+      // Persist snap to store for cold-start durability. Fire-and-forget:
+      // snap() has its own try/catch that logs failures, so the rejection
+      // can never escape — `void` is just to silence the floating-promise
+      // lint (action() doesn't await store durability for the snapshot).
+      if (snapped) void snap(last);
+
+      return snapshots;
+    } catch (error) {
+      if (!(error instanceof ConcurrencyError)) throw error;
+      if (attempt >= maxRetries) throw error;
+      if (opts?.backoff) {
+        const delayMs = computeBackoffDelay(attempt, opts.backoff);
+        if (delayMs > 0) await sleep(delayMs);
       }
     }
   }
-
-  const emitted = tuples.map(([name, data]) => ({
-    name,
-    data: skipValidation
-      ? data
-      : validate(name as string, data, me.events[name]),
-  }));
-
-  const meta: EventMeta = {
-    correlation:
-      reactingTo?.meta.correlation ||
-      correlator({
-        action: action as string,
-        state: me.name,
-        stream,
-        actor: target.actor,
-      }),
-    causation: {
-      action: {
-        name: action as string,
-        ...target,
-        // payload intentionally omitted: it can be large or contain PII,
-        // and callers correlate via the correlation id when they need it.
-      },
-      event: reactingTo
-        ? {
-            id: reactingTo.id,
-            name: reactingTo.name,
-            stream: reactingTo.stream,
-          }
-        : undefined,
-    },
-  };
-
-  let committed: Committed<TEvents, keyof TEvents>[];
-  try {
-    committed = await store().commit(
-      stream,
-      emitted,
-      meta,
-      // Reactions skip optimistic concurrency: they always append against the
-      // current head. Stream leasing already serializes concurrent reactions,
-      // and forcing version checks here would turn ordinary catch-up into
-      // spurious retries.
-      reactingTo ? undefined : expected
-    );
-  } catch (error) {
-    // Invalidate cache on concurrency errors — cached state is stale
-    if (error instanceof ConcurrencyError) {
-      await cache().invalidate(stream);
-    }
-    throw error;
-  }
-
-  let { state, patches } = snapshot;
-  const snapshots = committed.map((event) => {
-    const p = me.patch[event.name](event, state);
-    state = patch(state, p);
-    patches++;
-    // cache_hit / replayed propagate from the initial load — these
-    // post-commit snapshots all derive from the same loaded state.
-    // version advances per committed event (each is a new stream head).
-    return {
-      event,
-      state,
-      version: event.version,
-      patches,
-      snaps: snapshot.snaps,
-      patch: p,
-      cache_hit: snapshot.cache_hit,
-      replayed: snapshot.replayed,
-    };
-  });
-
-  // fire and forget snaps
-  const last = snapshots.at(-1)!;
-  const snapped = me.snap?.(last);
-
-  // Update cache with post-commit state (reset patches if snapped).
-  // Fire-and-forget — log but don't fail the action on cache write errors
-  // (e.g., transient network failures in a custom Cache adapter).
-  cache()
-    .set<TState>(stream, {
-      state: last.state,
-      version: last.event.version,
-      event_id: last.event.id,
-      patches: snapped ? 0 : last.patches,
-      snaps: snapped ? last.snaps + 1 : last.snaps,
-    })
-    .catch((err) => log().error(err));
-
-  // Persist snap to store for cold-start durability. Fire-and-forget:
-  // snap() has its own try/catch that logs failures, so the rejection
-  // can never escape — `void` is just to silence the floating-promise
-  // lint (action() doesn't await store durability for the snapshot).
-  if (snapped) void snap(last);
-
-  return snapshots;
 }

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -423,6 +423,65 @@ export type GivenHandlers<TState extends Schema, TActions extends Schemas> = {
   [TKey in keyof TActions]?: Invariant<TState>[];
 };
 
+// ---------------------------------------------------------------------------
+// Retry pacing — generic, shared by every consumer that defers retries
+// (reactions on the drain side, actions on the command side, future ops
+// primitives). The runtime delay math lives in `internal/backoff.ts`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Backoff strategy for delaying the next retry attempt after a handler
+ * throws.
+ *
+ * - `fixed` — wait `baseMs` between attempts
+ * - `linear` — wait `baseMs * (retry + 1)`
+ * - `exponential` — wait `baseMs * 2^retry`, capped at `maxMs` if provided
+ *
+ * `retry` is the attempt counter at finalize time, where `0` is the first
+ * attempt that just failed. The delay applies *before* the next attempt.
+ */
+export type BackoffStrategy = "fixed" | "linear" | "exponential";
+
+/**
+ * Retry backoff configuration.
+ *
+ * @property strategy - {@link BackoffStrategy}
+ * @property baseMs - Base delay (must be ≥ 0)
+ * @property maxMs - Optional cap; only used by `exponential`
+ * @property jitter - Multiply final delay by `0.5 + random()` (range
+ *   `[0.5, 1.5)`) to avoid thundering herds when many callers retry in
+ *   lockstep
+ */
+export type BackoffOptions = {
+  readonly strategy: BackoffStrategy;
+  readonly baseMs: number;
+  readonly maxMs?: number;
+  readonly jitter?: boolean;
+};
+
+/**
+ * Per-action retry policy, declared on `state.on(entry, options)`. The
+ * orchestrator owns the loop on the command path: on
+ * {@link ConcurrencyError} the cache is invalidated, an optional
+ * `backoff` delay is applied, and the action re-runs from `load`. Any
+ * other error rethrows immediately and does not consume the budget.
+ *
+ * No `blockOnError` field — commands surface errors to callers; they do
+ * not block streams.
+ *
+ * @property maxRetries - Additional attempts after the initial call.
+ *   Default `0` (single attempt, current behavior). Total invocations
+ *   equal `1 + maxRetries`.
+ * @property backoff - Optional retry pacing. When omitted, retries run
+ *   immediately — fine at low contention. Set to `{ strategy:
+ *   "exponential", baseMs, jitter: true }` on hot streams where many
+ *   writers contend for the same version.
+ */
+export type ActionOptions = {
+  readonly maxRetries?: number;
+  readonly backoff?: BackoffOptions;
+};
+
 /**
  * The full state definition, including schemas, handlers, and optional invariants and snapshot logic.
  * @template TState - State schema.
@@ -442,6 +501,13 @@ export type State<
   on: ActionHandlers<TState, TEvents, TActions>;
   given?: GivenHandlers<TState, TActions>;
   snap?: (snapshot: Snapshot<TState, TEvents>) => boolean;
+  /**
+   * Per-action retry policy keyed by action name. Set by
+   * `state.on(entry, options)`; consumed by the orchestrator's command
+   * path. Actions without an entry behave as if `{ maxRetries: 0 }` —
+   * `ConcurrencyError` surfaces on first conflict.
+   */
+  options?: { [TKey in keyof TActions]?: ActionOptions };
 };
 
 /**

--- a/libs/act/src/types/reaction.ts
+++ b/libs/act/src/types/reaction.ts
@@ -6,6 +6,7 @@
  */
 import type {
   Actor,
+  BackoffOptions,
   Committed,
   IAct,
   Query,
@@ -159,48 +160,19 @@ export type LaneConfig<TName extends string = string> = {
 };
 
 /**
- * Backoff strategy for delaying the next retry attempt after a reaction
- * handler throws.
- *
- * - `fixed` — wait `baseMs` between attempts
- * - `linear` — wait `baseMs * (retry + 1)`
- * - `exponential` — wait `baseMs * 2^retry`, capped at `maxMs` if provided
- *
- * `retry` is the lease's retry counter at finalize time, where `0` is the
- * first attempt that just failed. So the delay applies *before* the next
- * attempt.
- */
-export type BackoffStrategy = "fixed" | "linear" | "exponential";
-
-/**
- * Per-reaction retry backoff configuration. When set, the drain controller
- * defers the next attempt at this stream until the computed delay has
- * elapsed.
- *
- * Backoff state lives in process memory on the {@link DrainController}.
- * With N competing workers (each running its own controller), retries
- * escalate at most N× faster than configured — the shared `retry` counter
- * on the stream watermark climbs across workers, reaching the
- * `blockOnError` threshold sooner. This is intentional: per-worker pacing
- * speeds up recovery on transient per-worker faults, and poison messages
- * still get quarantined.
- *
- * @property strategy - {@link BackoffStrategy}
- * @property baseMs - Base delay (must be ≥ 0)
- * @property maxMs - Optional cap; only used by `exponential`
- * @property jitter - Multiply final delay by `0.5 + random()` (range
- *   `[0.5, 1.5)`) to avoid thundering herds when many streams retry in
- *   lockstep
- */
-export type BackoffOptions = {
-  readonly strategy: BackoffStrategy;
-  readonly baseMs: number;
-  readonly maxMs?: number;
-  readonly jitter?: boolean;
-};
-
-/**
  * Options for reaction processing.
+ *
+ * For the shared retry-pacing shape see {@link BackoffOptions} and
+ * {@link BackoffStrategy} in `./action.js`.
+ *
+ * Reaction-side note on `backoff`: backoff state lives in process memory
+ * on the {@link DrainController}. With N competing workers (each running
+ * its own controller), retries escalate at most N× faster than configured
+ * — the shared `retry` counter on the stream watermark climbs across
+ * workers, reaching the `blockOnError` threshold sooner. This is
+ * intentional: per-worker pacing speeds up recovery on transient
+ * per-worker faults, and poison messages still get quarantined.
+ *
  * @property blockOnError - Whether to block on error.
  * @property maxRetries - Maximum number of retries.
  * @property backoff - Optional retry pacing. When omitted, retries run as

--- a/libs/act/test/action-retry.spec.ts
+++ b/libs/act/test/action-retry.spec.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+import {
+  act,
+  ConcurrencyError,
+  dispose,
+  InMemoryStore,
+  state,
+  store,
+} from "../src/index.js";
+import type { EventMeta, Message, Schemas } from "../src/types/index.js";
+
+/**
+ * Subclass of `InMemoryStore` that injects {@link ConcurrencyError} on
+ * the first `failTimes` calls to `commit`, then delegates. Lets us
+ * exercise the orchestrator's per-action retry loop deterministically
+ * without racing real concurrent writers.
+ */
+class FlakyStore extends InMemoryStore {
+  attempts = 0;
+  failTimes: number;
+
+  constructor(failTimes: number) {
+    super();
+    this.failTimes = failTimes;
+  }
+
+  override async commit<E extends Schemas>(
+    stream: string,
+    msgs: Message<E, keyof E>[],
+    meta: EventMeta,
+    expectedVersion?: number
+  ) {
+    this.attempts++;
+    if (this.attempts <= this.failTimes) {
+      throw new ConcurrencyError(
+        stream,
+        -1,
+        msgs as Message<Schemas, keyof Schemas>[],
+        expectedVersion ?? -1
+      );
+    }
+    return super.commit<E>(stream, msgs, meta, expectedVersion);
+  }
+}
+
+const actor = { id: "a", name: "a" };
+const target = { stream: "counter-1", actor } as const;
+
+// Action with NO options — current single-attempt behavior.
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ by: z.number() }) })
+  .on({ increment: z.object({ by: z.number() }) })
+  .emit((a) => ["Incremented", { by: a.by }])
+  .build();
+
+// Action with retry budget but no backoff (immediate retry).
+const RetryCounter = state({ RetryCounter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ by: z.number() }) })
+  .on({ increment: z.object({ by: z.number() }) }, { maxRetries: 3 })
+  .emit((a) => ["Incremented", { by: a.by }])
+  .build();
+
+// Action with retry + backoff (paced retry).
+const PacedCounter = state({ PacedCounter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ by: z.number() }) })
+  .on(
+    { increment: z.object({ by: z.number() }) },
+    { maxRetries: 3, backoff: { strategy: "fixed", baseMs: 80 } }
+  )
+  .emit((a) => ["Incremented", { by: a.by }])
+  .build();
+
+// Action with retry + zero-delay backoff (delayMs short-circuit).
+const ZeroBackoffCounter = state({
+  ZeroBackoffCounter: z.object({ count: z.number() }),
+})
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ by: z.number() }) })
+  .on(
+    { increment: z.object({ by: z.number() }) },
+    { maxRetries: 2, backoff: { strategy: "fixed", baseMs: 0 } }
+  )
+  .emit((a) => ["Incremented", { by: a.by }])
+  .build();
+
+// Action with explicit maxRetries: 0 — same effect as no options.
+const ZeroRetryCounter = state({
+  ZeroRetryCounter: z.object({ count: z.number() }),
+})
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ by: z.number() }) })
+  .on({ increment: z.object({ by: z.number() }) }, { maxRetries: 0 })
+  .emit((a) => ["Incremented", { by: a.by }])
+  .build();
+
+describe("per-action retry policy", () => {
+  afterEach(async () => {
+    await dispose()();
+  });
+
+  describe("State.options registry", () => {
+    it("undeclared action has no options entry", () => {
+      expect(Counter.options).toBeUndefined();
+    });
+
+    it("declared action stores its options keyed by action name", () => {
+      expect(RetryCounter.options).toEqual({ increment: { maxRetries: 3 } });
+    });
+
+    it("multiple options coexist on the same state via separate .on calls", () => {
+      const Multi = state({ Multi: z.object({ count: z.number() }) })
+        .init(() => ({ count: 0 }))
+        .emits({
+          A: z.object({}),
+          B: z.object({}),
+        })
+        .on({ a: z.object({}) }, { maxRetries: 2 })
+        .emit("A")
+        .on({ b: z.object({}) })
+        .emit("B")
+        .build();
+      expect(Multi.options).toEqual({ a: { maxRetries: 2 } });
+    });
+  });
+
+  describe("no options (current behavior)", () => {
+    it("ConcurrencyError surfaces on first conflict, no retry", async () => {
+      const flaky = new FlakyStore(1);
+      store(flaky);
+      const app = act().withState(Counter).build();
+      await expect(app.do("increment", target, { by: 1 })).rejects.toThrow(
+        ConcurrencyError
+      );
+      expect(flaky.attempts).toBe(1);
+    });
+
+    it("explicit maxRetries: 0 behaves like undeclared", async () => {
+      const flaky = new FlakyStore(1);
+      store(flaky);
+      const app = act().withState(ZeroRetryCounter).build();
+      await expect(app.do("increment", target, { by: 1 })).rejects.toThrow(
+        ConcurrencyError
+      );
+      expect(flaky.attempts).toBe(1);
+    });
+  });
+
+  describe("retry policy", () => {
+    it("succeeds on second attempt after one conflict", async () => {
+      const flaky = new FlakyStore(1);
+      store(flaky);
+      const app = act().withState(RetryCounter).build();
+      const snaps = await app.do("increment", target, { by: 1 });
+      expect(flaky.attempts).toBe(2);
+      expect(snaps[0].event?.name).toBe("Incremented");
+    });
+
+    it("succeeds on fourth attempt after three conflicts (budget fully consumed)", async () => {
+      const flaky = new FlakyStore(3);
+      store(flaky);
+      const app = act().withState(RetryCounter).build();
+      const snaps = await app.do("increment", target, { by: 2 });
+      expect(flaky.attempts).toBe(4);
+      expect(snaps[0].event?.name).toBe("Incremented");
+    });
+
+    it("throws the last ConcurrencyError when the budget is exhausted", async () => {
+      const flaky = new FlakyStore(4); // 1 initial + 3 retries all fail
+      store(flaky);
+      const app = act().withState(RetryCounter).build();
+      await expect(app.do("increment", target, { by: 1 })).rejects.toThrow(
+        ConcurrencyError
+      );
+      expect(flaky.attempts).toBe(4); // budget = maxRetries(3) + 1 = 4 total attempts
+    });
+
+    it("non-ConcurrencyError bypasses the retry budget and propagates immediately", async () => {
+      // Wrap the default store, overriding commit to throw a plain Error
+      // on first call. Type-checks via the public Store interface — no
+      // narrow override of a generic base method.
+      const real = new InMemoryStore();
+      let calls = 0;
+      const boom: typeof real = Object.assign(
+        Object.create(Object.getPrototypeOf(real)) as InMemoryStore,
+        real,
+        {
+          async commit() {
+            calls++;
+            throw new Error("boom");
+          },
+        }
+      );
+      store(boom);
+      const app = act().withState(RetryCounter).build();
+      await expect(app.do("increment", target, { by: 1 })).rejects.toThrow(
+        "boom"
+      );
+      expect(calls).toBe(1); // no retry path taken
+    });
+  });
+
+  describe("backoff", () => {
+    it("paces retries using computeBackoffDelay when backoff is declared", async () => {
+      const flaky = new FlakyStore(1);
+      store(flaky);
+      const app = act().withState(PacedCounter).build();
+      const t0 = Date.now();
+      await app.do("increment", target, { by: 1 });
+      const elapsed = Date.now() - t0;
+      expect(flaky.attempts).toBe(2);
+      // Fixed backoff of 80ms between attempt 0 (failed) and attempt 1.
+      // Allow a generous lower bound to account for timer slop on slow CI.
+      expect(elapsed).toBeGreaterThanOrEqual(60);
+    });
+
+    it("skips sleep when baseMs is zero (computeBackoffDelay returns 0)", async () => {
+      const flaky = new FlakyStore(1);
+      store(flaky);
+      const app = act().withState(ZeroBackoffCounter).build();
+      const t0 = Date.now();
+      await app.do("increment", target, { by: 1 });
+      const elapsed = Date.now() - t0;
+      expect(flaky.attempts).toBe(2);
+      expect(elapsed).toBeLessThan(50); // immediate retry, no sleep
+    });
+
+    it("retries immediately when backoff is omitted", async () => {
+      const flaky = new FlakyStore(1);
+      store(flaky);
+      const app = act().withState(RetryCounter).build();
+      const t0 = Date.now();
+      await app.do("increment", target, { by: 1 });
+      const elapsed = Date.now() - t0;
+      expect(flaky.attempts).toBe(2);
+      expect(elapsed).toBeLessThan(50);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes **#739**. Adds an optional second argument to `state.on(entry, options)` for declaring a per-action retry policy on `ConcurrencyError`. The orchestrator owns the retry loop on the command path — mirrors how reactions already declare retry on `.do(handler, options)`. Action authors who know a stream is hot can declare jittered exponential backoff once, instead of every caller wrapping `app.do(...)` in a copy-paste loop.

The originally-scoped helper (`withRetry(fn, opts)`) was reframed mid-ticket to the declarative shape after a symmetry check with reactions — caller-side sugar leaves the framework with two mental models for retry depending on whether the failure happens on the command or drain path. Per-action policy unifies them. See `book/act-1111-per-action-retry.md` for the full design narrative and the rejected designs.

## What ships

### Public API

```ts
import { state } from "@rotorsoft/act";
import { z } from "zod";

const BankAccount = state({ BankAccount: z.object({ balance: z.number() }) })
  .init(() => ({ balance: 0 }))
  .emits({ Transferred: z.object({ amount: z.number() }) })
  .on(
    { transfer: z.object({ amount: z.number() }) },
    {
      maxRetries: 5,
      backoff: { strategy: "exponential", baseMs: 10, maxMs: 200, jitter: true },
    },
  )
    .emit((a) => ["Transferred", { amount: a.amount }])
  .build();

// Caller is unchanged — retry is invisible.
await app.do("transfer", target, { amount: 100 });
```

New type:

```ts
export type ActionOptions = {
  readonly maxRetries?: number;     // default 0 (current behavior, single attempt)
  readonly backoff?: BackoffOptions; // default omitted (immediate retry)
};
```

Reuses `BackoffOptions` and `BackoffStrategy` from the reaction side so action authors learn one shape across the framework.

### Orchestrator wiring

- `event-sourcing.action()` wraps load + invariants + handler + commit + cache-invalidate in a retry loop reading `me.options?.[action]`.
- Default `maxRetries: 0` preserves today's single-attempt behavior.
- Retries only `ConcurrencyError`; every other error rethrows immediately and does not consume the budget.
- `backoff` declared → `await sleep(computeBackoffDelay(attempt, opts.backoff))` between attempts (reuses the existing reaction-side helper, not a parallel implementation).
- Final attempt's `ConcurrencyError` propagates to the caller on exhaustion.
- Reactions skip optimistic concurrency (commit passes `undefined` as `expectedVersion` when `reactingTo` is set), so the retry loop is structurally a no-op for reaction-driven calls.

### Type reorganization

`BackoffOptions` / `BackoffStrategy` moved from `types/reaction.ts` to `types/action.ts`. With actions becoming a second consumer, the type genuinely isn't reaction-specific — and `action.ts` is already the de-facto home for cross-layer primitives (`Schema`, `Actor`, `Committed`, `Snapshot`, `IAct`, `Query`, `EventMeta`, `State`). No public-surface change — both types still import via `@rotorsoft/act`. `reaction.ts` cross-imports `BackoffOptions`; `internal/backoff.ts` retargets its import.

### Docs

- `docs/docs/concepts/error-handling.md` — Retry Pattern section rewritten to the declarative shape; manual loop preserved as an explicit escape hatch for "I want different behavior than what's declared" (e.g., UI mutation that should fail fast).
- `docs/docs/concepts/state-management.md` — Builder Chain shows `.on({}, options?)` with a bullet pointing at `ActionOptions`.
- `docs/docs/architecture/concurrency-model.md` — "standard pattern is to reload and retry" sentence retargeted to `ActionOptions` as the framework-provided remedy.
- `book/act-1111-per-action-retry.md` — narrative essay covering the design pivot (helper → per-action policy), the backoff rethink (immediate-retry was overconfident; jittered exponential is the canonical OCC pattern), and the `BackoffOptions` move.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2030 / 2030 passing, 100% statements / branches / functions / lines maintained
- [x] `pnpm lint` — no errors
- [x] `pnpm build` — all packages
- [x] New test file `libs/act/test/action-retry.spec.ts` — 12 cases covering:
  - registry: undeclared / single / multiple actions on one state
  - no options (current behavior on first conflict + explicit `maxRetries: 0`)
  - retry: succeed on second attempt, succeed on fourth attempt (budget fully consumed), throw on exhaustion
  - non-`ConcurrencyError` bypasses the budget and propagates immediately
  - backoff: paces retries by ≥ baseMs, `baseMs: 0` short-circuits the sleep, no-backoff means immediate retry
- [x] Existing tests pass against the refactored `action()` (smoke-checked `backoff.spec.ts`, `non-retryable.spec.ts`, `calculator.spec.ts`, `event-sourcing.spec.ts`)
- [ ] CI green
- [ ] Code review

## Stability charter impact

**Additive only.**

- `state.on(entry, options?)` — new optional second argument. `STABILITY.md` updated to call out `.on` with the `ActionOptions` arg explicitly in the `state(...)` charter entry.
- New public types `ActionOptions`, `BackoffOptions`, `BackoffStrategy` (the latter two relocated, not new — same public path via `@rotorsoft/act`).
- New optional `State.options` field — backward-compatible (consumers who don't read it see no change).

No semantics changed on `app.do(...)` or any existing surface. Default behavior (no options declared) is identical to before.

## Follow-ups

- **#740** and **#741** carry deferred-decision comments noting the same declarative-vs-helper question applies. The principle established here ("orchestrator owns the policy when it has enough information") is the criterion for those calls. Revisit after this lands so we have a concrete reference shape.
- **Type taxonomy refactor** — `types/action.ts` has organically become the kitchen-sink for cross-layer primitives. A future ticket could extract `types/primitives.ts` and rebalance; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)