### PR TITLE
feat(act-http): shared utilities for the auto-generated API (#842)

### DIFF
--- a/libs/act-http/README.md
+++ b/libs/act-http/README.md
@@ -31,6 +31,7 @@ Three independent subpath exports:
 | `@rotorsoft/act-http/receiver/express` | `webhookMiddleware` — Express middleware adapter. |
 | `@rotorsoft/act-http/receiver/fastify` | `webhookMiddleware` — Fastify `preHandler` adapter. |
 | `@rotorsoft/act-http/receiver/hono` | `webhookMiddleware` — Hono middleware adapter. |
+| `@rotorsoft/act-http/api` | `ActorExtractor` type, `ApiError` + `ERROR_MAP` + `toApiError` envelope mapping, `withIdempotency` wrapper. Shared utilities for the auto-generated API surfaces (`/trpc`, `/hono`, `/openapi` subpaths, landing under issues #843/#844/#845). |
 
 ## Quick start
 
@@ -187,6 +188,17 @@ Each framework adapter exports a single function `webhookMiddleware(options)` th
 | `/receiver/express` | `req.idempotency` | `res.status(...).json({ error: reason })` |
 | `/receiver/fastify` | `request.idempotency` | `reply.status(...).send({ error: reason })` |
 | `/receiver/hono` | `c.get("idempotency")` (typed via `Variables`) | `c.json({ error: reason }, status)` |
+
+### `/api` subpath
+
+Shared utilities consumed by every transport in the auto-generated API umbrella (act-http-api epic #835). Three concerns surfaced once, not per-transport:
+
+- **`ActorExtractor`** — type alias `(request: unknown) => Actor | Promise<Actor>`. The host-supplied closure resolving an `Actor` from an incoming request. Required on every transport (`trpc(app, { actor })`, `hono(app, { actor })`). Auth (JWT, session, API key) stays in the host; the package only asks for this function.
+- **`ApiError`** — uniform envelope `{ error, detail?, code? }` shipped over the wire by every transport. Hosts get the same shape from REST, tRPC, and OpenAPI.
+- **`ERROR_MAP`** — `as const` table mapping framework error types to `{ status, code }`. `ValidationError → 422 / VALIDATION`, `InvariantError → 409 / INVARIANT`, `ConcurrencyError → 412 / CONCURRENCY`, `StreamClosedError → 410 / STREAM_CLOSED`, `NonRetryableError → 400 / NON_RETRYABLE`.
+- **`toApiError(err) → { status, body }`** — the single mapping helper every transport calls in its error boundary. Known framework errors map per `ERROR_MAP`; everything else surfaces as 500 / `INTERNAL` (with `detail` only when the throw was an `Error` — thrown strings or objects don't leak payloads).
+- **`withIdempotency(store, key, handler)`** — wraps an action handler in an `Idempotency-Key` claim. Reuses `@rotorsoft/act-ops/idempotency` — same contract `@rotorsoft/act-http/receiver` already speaks, so one `IdempotencyStore` covers both halves of the "Act over the wire" surface. Returns `{ deduped: false, result }` on fresh claim, `{ deduped: true }` on duplicate (handler is not called).
+- **Types**: `IdempotencyResult<T>`, `ErrorMapEntry`.
 
 ### `/sse` subpath
 

--- a/libs/act-http/package.json
+++ b/libs/act-http/package.json
@@ -60,6 +60,11 @@
       "types": "./dist/@types/receiver/hono/index.d.ts",
       "import": "./dist/receiver/hono/index.js",
       "require": "./dist/receiver/hono/index.cjs"
+    },
+    "./api": {
+      "types": "./dist/@types/api/index.d.ts",
+      "import": "./dist/api/index.js",
+      "require": "./dist/api/index.cjs"
     }
   },
   "sideEffects": false,

--- a/libs/act-http/src/api/actor.ts
+++ b/libs/act-http/src/api/actor.ts
@@ -1,0 +1,20 @@
+import type { Actor } from "@rotorsoft/act";
+
+/**
+ * Extractor function the host supplies to resolve an {@link Actor}
+ * from an incoming request. The framework keeps auth out of the
+ * package — JWT vs session vs API key is the host's call — and asks
+ * for this single closure that every transport (tRPC, Hono, OpenAPI
+ * docs) composes against.
+ *
+ * The `request` argument is intentionally generic. Each transport
+ * narrows it at the call site (`IncomingMessage` for Hono, the tRPC
+ * context object for tRPC, etc.) — keeping the contract here
+ * transport-agnostic means one extractor implementation plugs into
+ * every adapter unchanged.
+ *
+ * Async is allowed so the extractor can verify a JWT against a
+ * remote JWKS endpoint without forcing every host to synchronously
+ * cache.
+ */
+export type ActorExtractor = (request: unknown) => Actor | Promise<Actor>;

--- a/libs/act-http/src/api/errors.ts
+++ b/libs/act-http/src/api/errors.ts
@@ -1,0 +1,97 @@
+import {
+  ConcurrencyError,
+  InvariantError,
+  NonRetryableError,
+  StreamClosedError,
+  ValidationError,
+} from "@rotorsoft/act";
+
+/**
+ * Uniform error envelope shipped over the wire by every act-http
+ * transport. Hosts get the same shape from REST, tRPC, and OpenAPI —
+ * a client that talks to two transports doesn't have to invent two
+ * error parsers.
+ *
+ * - `error` — the framework error name (`"ValidationError"`,
+ *   `"InvariantError"`, …). Stable identifier, safe to switch on.
+ * - `detail` — the framework's message text. Human-readable; not
+ *   parsed by clients.
+ * - `code` — a machine-readable status code from {@link ERROR_MAP}
+ *   for clients that prefer enum-style branching over name strings.
+ */
+export type ApiError = {
+  error: string;
+  detail?: string;
+  code?: string;
+};
+
+/**
+ * Status + code pair for one known framework error.
+ */
+export type ErrorMapEntry = {
+  status: number;
+  code: string;
+};
+
+/**
+ * The single table that maps framework error types to HTTP status
+ * codes and machine-readable codes. One table, three consumers
+ * (Hono, tRPC, OpenAPI) — cross-transport consistency by
+ * construction.
+ *
+ * Operators wanting different mappings wrap the generated transport
+ * rather than mutating this — the consistency is the load-bearing
+ * property, not the specific status codes.
+ */
+export const ERROR_MAP = {
+  ValidationError: { status: 422, code: "VALIDATION" },
+  InvariantError: { status: 409, code: "INVARIANT" },
+  ConcurrencyError: { status: 412, code: "CONCURRENCY" },
+  StreamClosedError: { status: 410, code: "STREAM_CLOSED" },
+  NonRetryableError: { status: 400, code: "NON_RETRYABLE" },
+} as const satisfies Record<string, ErrorMapEntry>;
+
+const lookupKnown = (err: unknown): { name: keyof typeof ERROR_MAP } | null => {
+  if (err instanceof ValidationError) return { name: "ValidationError" };
+  if (err instanceof InvariantError) return { name: "InvariantError" };
+  if (err instanceof ConcurrencyError) return { name: "ConcurrencyError" };
+  if (err instanceof StreamClosedError) return { name: "StreamClosedError" };
+  if (err instanceof NonRetryableError) return { name: "NonRetryableError" };
+  return null;
+};
+
+/**
+ * Translate an unknown thrown value into the canonical
+ * {@link ApiError} envelope plus HTTP status. Each transport's error
+ * boundary calls this once and forwards the result to the wire.
+ *
+ * Known framework errors map per {@link ERROR_MAP}. Everything else
+ * surfaces as a 500 with `code: "INTERNAL"`; the `detail` field is
+ * populated when the throw was an `Error` instance, omitted
+ * otherwise (a thrown string or object doesn't get to leak its
+ * payload to the client).
+ */
+export function toApiError(err: unknown): { status: number; body: ApiError } {
+  const known = lookupKnown(err);
+  if (known) {
+    const entry = ERROR_MAP[known.name];
+    return {
+      status: entry.status,
+      body: {
+        error: known.name,
+        detail: (err as Error).message,
+        code: entry.code,
+      },
+    };
+  }
+  if (err instanceof Error) {
+    return {
+      status: 500,
+      body: { error: "InternalError", detail: err.message, code: "INTERNAL" },
+    };
+  }
+  return {
+    status: 500,
+    body: { error: "InternalError", code: "INTERNAL" },
+  };
+}

--- a/libs/act-http/src/api/idempotency.ts
+++ b/libs/act-http/src/api/idempotency.ts
@@ -1,0 +1,44 @@
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+
+/**
+ * Result of a {@link withIdempotency} call.
+ *
+ * - `{ deduped: false, result }` — the claim was fresh; the handler
+ *   ran and produced `result`.
+ * - `{ deduped: true }` — the claim was already taken; the handler
+ *   was *not* invoked. The caller decides how to respond (typically
+ *   a 2xx with no body, matching the receiver-side convention).
+ *
+ * Note: the contract does not cache the previous response. A
+ * duplicate call returns the deduped marker only — replaying the
+ * original handler's output would require a response-caching
+ * adapter, which is out of scope here. The receiver-side convention
+ * (and the convention the generated transports follow) is "ack the
+ * duplicate; do nothing else."
+ */
+export type IdempotencyResult<T> =
+  | { deduped: false; result: T }
+  | { deduped: true };
+
+/**
+ * Wrap an action handler so the framework honors `Idempotency-Key`
+ * dedup. Acquires the key via {@link IdempotencyStore.claim}, runs
+ * the handler exactly when the claim was fresh, and skips the
+ * handler entirely on a duplicate.
+ *
+ * Reuses the contract `@rotorsoft/act-ops/idempotency` already
+ * defines for the receiver-side `Idempotency-Key` story. A single
+ * `IdempotencyStore` implementation covers both halves of the "Act
+ * over the wire" surface — receiver and generated API.
+ */
+export async function withIdempotency<T>(
+  store: IdempotencyStore,
+  key: string,
+  handler: () => Promise<T>
+): Promise<IdempotencyResult<T>> {
+  const fresh = await store.claim(key);
+  if (!fresh) {
+    return { deduped: true };
+  }
+  return { deduped: false, result: await handler() };
+}

--- a/libs/act-http/src/api/index.ts
+++ b/libs/act-http/src/api/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @packageDocumentation
+ * @module act-http/api
+ *
+ * Shared utilities for the act-http auto-generated API surfaces.
+ * Three concerns that every transport (tRPC, Hono, OpenAPI) has to
+ * address — actor extraction, error envelope mapping,
+ * `Idempotency-Key` wiring — defined once here and composed by each
+ * transport sibling subpath.
+ *
+ * - {@link ActorExtractor} — the host-supplied closure that resolves
+ *   an `Actor` from an incoming request. Auth (JWT, session, API
+ *   key) stays in the host; the package only asks for this one
+ *   function.
+ * - {@link ApiError}, {@link ERROR_MAP}, {@link toApiError} — the
+ *   uniform error envelope and the status/code mapping every
+ *   transport uses. Cross-transport consistency by construction.
+ * - {@link withIdempotency} — the helper that wraps action handlers
+ *   in an `Idempotency-Key` claim. Reuses the
+ *   `@rotorsoft/act-ops/idempotency` contract that
+ *   `@rotorsoft/act-http/receiver` already speaks, so receivers and
+ *   generated APIs share one `IdempotencyStore` implementation.
+ *
+ * Sibling subpaths in the same package consume the utilities here:
+ *
+ * - `@rotorsoft/act-http/trpc` — tRPC adapter (#843).
+ * - `@rotorsoft/act-http/hono` — Hono adapter (#844).
+ * - `@rotorsoft/act-http/openapi` — OpenAPI emitter (#845).
+ *
+ * Existing siblings unrelated to the generated-API work:
+ *
+ * - `@rotorsoft/act-http/webhook` — outbound POST delivery.
+ * - `@rotorsoft/act-http/sse` — incremental state broadcast.
+ * - `@rotorsoft/act-http/receiver` — inbound webhook ingestion.
+ */
+
+export type { ActorExtractor } from "./actor.js";
+export {
+  type ApiError,
+  ERROR_MAP,
+  type ErrorMapEntry,
+  toApiError,
+} from "./errors.js";
+export { type IdempotencyResult, withIdempotency } from "./idempotency.js";

--- a/libs/act-http/test/api/errors.spec.ts
+++ b/libs/act-http/test/api/errors.spec.ts
@@ -1,0 +1,140 @@
+import {
+  ConcurrencyError,
+  InvariantError,
+  NonRetryableError,
+  StreamClosedError,
+  ValidationError,
+} from "@rotorsoft/act";
+import { describe, expect, it } from "vitest";
+import { ERROR_MAP, toApiError } from "../../src/api/index.js";
+
+describe("ERROR_MAP", () => {
+  it("declares one entry per recognized framework error", () => {
+    expect(Object.keys(ERROR_MAP).sort()).toEqual([
+      "ConcurrencyError",
+      "InvariantError",
+      "NonRetryableError",
+      "StreamClosedError",
+      "ValidationError",
+    ]);
+  });
+
+  it("uses the expected HTTP status + code per entry", () => {
+    expect(ERROR_MAP.ValidationError).toEqual({
+      status: 422,
+      code: "VALIDATION",
+    });
+    expect(ERROR_MAP.InvariantError).toEqual({
+      status: 409,
+      code: "INVARIANT",
+    });
+    expect(ERROR_MAP.ConcurrencyError).toEqual({
+      status: 412,
+      code: "CONCURRENCY",
+    });
+    expect(ERROR_MAP.StreamClosedError).toEqual({
+      status: 410,
+      code: "STREAM_CLOSED",
+    });
+    expect(ERROR_MAP.NonRetryableError).toEqual({
+      status: 400,
+      code: "NON_RETRYABLE",
+    });
+  });
+});
+
+describe("toApiError", () => {
+  it("maps ValidationError to 422 + VALIDATION", () => {
+    const err = new ValidationError("doIt", { foo: "bar" }, {
+      issues: [],
+      name: "ZodError",
+    } as unknown as import("zod").ZodError);
+    const result = toApiError(err);
+    expect(result.status).toBe(422);
+    expect(result.body).toMatchObject({
+      error: "ValidationError",
+      code: "VALIDATION",
+    });
+    expect(result.body.detail).toBe(err.message);
+  });
+
+  it("maps InvariantError to 409 + INVARIANT", () => {
+    const err = new InvariantError(
+      "doIt",
+      // biome-ignore lint/suspicious/noExplicitAny: placeholder payload for the mapping test
+      { foo: "bar" } as any,
+      { stream: "s", actor: { id: "1", name: "u" } },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal snapshot stand-in for the mapping test
+      {} as any,
+      "guard tripped"
+    );
+    const result = toApiError(err);
+    expect(result.status).toBe(409);
+    expect(result.body.error).toBe("InvariantError");
+    expect(result.body.code).toBe("INVARIANT");
+    expect(result.body.detail).toBe(err.message);
+  });
+
+  it("maps ConcurrencyError to 412 + CONCURRENCY", () => {
+    const err = new ConcurrencyError("order-1", 1, [], 2);
+    const result = toApiError(err);
+    expect(result.status).toBe(412);
+    expect(result.body).toMatchObject({
+      error: "ConcurrencyError",
+      code: "CONCURRENCY",
+    });
+    expect(result.body.detail).toBe(err.message);
+  });
+
+  it("maps StreamClosedError to 410 + STREAM_CLOSED", () => {
+    const err = new StreamClosedError("order-1");
+    const result = toApiError(err);
+    expect(result.status).toBe(410);
+    expect(result.body).toMatchObject({
+      error: "StreamClosedError",
+      code: "STREAM_CLOSED",
+    });
+    expect(result.body.detail).toBe(err.message);
+  });
+
+  it("maps NonRetryableError to 400 + NON_RETRYABLE", () => {
+    const err = new NonRetryableError("permanent failure");
+    const result = toApiError(err);
+    expect(result.status).toBe(400);
+    expect(result.body).toMatchObject({
+      error: "NonRetryableError",
+      code: "NON_RETRYABLE",
+    });
+    expect(result.body.detail).toBe(err.message);
+  });
+
+  it("maps an unknown Error to 500 + INTERNAL with detail", () => {
+    const err = new Error("oops");
+    const result = toApiError(err);
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({
+      error: "InternalError",
+      detail: "oops",
+      code: "INTERNAL",
+    });
+  });
+
+  it("maps a non-Error throw to 500 + INTERNAL without detail", () => {
+    const result = toApiError("a string was thrown");
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({
+      error: "InternalError",
+      code: "INTERNAL",
+    });
+    expect(result.body.detail).toBeUndefined();
+  });
+
+  it("handles null / undefined throws as 500 without detail", () => {
+    expect(toApiError(null).status).toBe(500);
+    expect(toApiError(null).body.detail).toBeUndefined();
+    expect(toApiError(undefined).body).toEqual({
+      error: "InternalError",
+      code: "INTERNAL",
+    });
+  });
+});

--- a/libs/act-http/test/api/idempotency.spec.ts
+++ b/libs/act-http/test/api/idempotency.spec.ts
@@ -1,0 +1,63 @@
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import { describe, expect, it, vi } from "vitest";
+import { withIdempotency } from "../../src/api/index.js";
+
+const makeStore = (claimImpl: IdempotencyStore["claim"]): IdempotencyStore => ({
+  claim: vi.fn<IdempotencyStore["claim"]>(claimImpl),
+});
+
+describe("withIdempotency", () => {
+  it("runs the handler and returns the result on a fresh claim", async () => {
+    const handler = vi.fn().mockResolvedValue({ ok: true, snapshot: 7 });
+    const store = makeStore(() => true);
+
+    const out = await withIdempotency(store, "key-1", handler);
+
+    expect(out).toEqual({ deduped: false, result: { ok: true, snapshot: 7 } });
+    expect(vi.mocked(store.claim)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(store.claim)).toHaveBeenCalledWith("key-1");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the handler and returns { deduped: true } on a duplicate claim", async () => {
+    const handler = vi.fn().mockResolvedValue("never returned");
+    const store = makeStore(() => false);
+
+    const out = await withIdempotency(store, "key-1", handler);
+
+    expect(out).toEqual({ deduped: true });
+    expect(vi.mocked(store.claim)).toHaveBeenCalledTimes(1);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("awaits an async claim implementation", async () => {
+    const handler = vi.fn().mockResolvedValue("ran");
+    const store = makeStore(async () => true);
+
+    const out = await withIdempotency(store, "key-async", handler);
+
+    expect(out).toEqual({ deduped: false, result: "ran" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits an async claim that reports duplicate", async () => {
+    const handler = vi.fn();
+    const store = makeStore(async () => false);
+
+    const out = await withIdempotency(store, "key-async-dup", handler);
+
+    expect(out).toEqual({ deduped: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("propagates handler rejections after a fresh claim", async () => {
+    const handler = vi.fn().mockRejectedValue(new Error("handler boom"));
+    const store = makeStore(() => true);
+
+    await expect(withIdempotency(store, "key-throw", handler)).rejects.toThrow(
+      "handler boom"
+    );
+    expect(vi.mocked(store.claim)).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/act-http/tsconfig.build.json
+++ b/libs/act-http/tsconfig.build.json
@@ -11,6 +11,9 @@
       "path": "../act/tsconfig.build.json"
     },
     {
+      "path": "../act-ops/tsconfig.build.json"
+    },
+    {
       "path": "../act-patch/tsconfig.build.json"
     }
   ],

--- a/libs/act-http/tsup.config.ts
+++ b/libs/act-http/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "src/receiver/express/index.ts",
     "src/receiver/fastify/index.ts",
     "src/receiver/hono/index.ts",
+    "src/api/index.ts",
   ],
   format: ["esm", "cjs"],
   dts: false,


### PR DESCRIPTION
## Summary

- Adds a new `@rotorsoft/act-http/api` subpath exporting the three cross-cutting helpers every transport in the act-http-api epic composes against
- Folds the work into the existing `@rotorsoft/act-http` package rather than spinning up `@rotorsoft/act-api` — HTTP integrations belong in one home next to `webhook`, `sse`, and `receiver`
- Unblocks #843 (tRPC), #844 (Hono), and #845 (OpenAPI), which each consume the utilities here

## What's exported

- **`ActorExtractor`** — type alias for the host-supplied closure that resolves an `Actor` from a request. Auth (JWT, session, API key) stays in the host; the package only asks for this function. Required on every transport.
- **`ApiError` + `ERROR_MAP` + `toApiError(err)`** — uniform error envelope and status/code mapping. `ValidationError → 422`, `InvariantError → 409`, `ConcurrencyError → 412`, `StreamClosedError → 410`, `NonRetryableError → 400`; unknown errors → `500 / INTERNAL`. The `detail` field is populated only when the throw was an `Error` instance (thrown strings/objects don't leak payloads).
- **`withIdempotency(store, key, handler)`** — wraps an action handler in an `Idempotency-Key` claim via `@rotorsoft/act-ops/idempotency`. Same contract `@rotorsoft/act-http/receiver` already speaks, so receiver and generated API share one `IdempotencyStore` implementation. Returns `{ deduped: false, result }` on fresh claim, `{ deduped: true }` on duplicate (handler not called).

## What this isn't

- No new package (`@rotorsoft/act-api` was the original plan; folded into `@rotorsoft/act-http/api` per the simpler design).
- No builder pattern (`api(app).trpc()`) — the transports are direct functions: `trpc(app, options)`, `hono(app, options)`, `openapi(app, options)`. This sub just provides the utilities they share.
- No response caching — duplicate idempotent calls return the deduped marker, not a cached previous result. Matches the receiver-side convention (and what `@rotorsoft/act-ops/idempotency` actually guarantees).

## Test plan

- [x] 100% coverage on the new files: 24 stmts / 16 branches / 3 funcs / 19 lines (`npx vitest run --coverage test/api`)
- [x] All 169 existing `@rotorsoft/act-http` tests still pass — 15 new + 154 existing
- [x] `pnpm -F @rotorsoft/act-http build` produces `dist/api/index.{js,cjs}` plus type declarations
- [x] Biome lint clean on the new files (`npx biome check libs/act-http/src/api libs/act-http/test/api`)
- [ ] (Verifier) Confirm the `/api` subpath is importable from outside the package after publish

Closes #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)