### PR TITLE
feat(act): encryptor port + in-memory encryptor adapter (#860)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -30,17 +30,19 @@ The runtime surface returned from `act(...).build()`:
 
 The signatures, return shapes, and behavioral contracts of these methods are stable. Additive new methods on `IAct` are not breaking. Changing the meaning of an existing call (e.g., what `settle()` guarantees) is.
 
-### Store, Cache, and Logger adapter contracts
+### Store, Cache, Logger, and Encryptor adapter contracts
 
-The `Store`, `Cache`, and `Logger` interfaces in `libs/act/src/types/` define what an adapter must implement. The contracts are **executable** — [`@rotorsoft/act-tck`](https://www.npmjs.com/package/@rotorsoft/act-tck) exposes `runStoreTck`, `runCacheTck`, and `runLoggerTck` that exercise every method on each interface against any factory you point them at. If your adapter passes the TCK, it honors the contract; if the contract changes in a way that affects you, the TCK fails first.
+The `Store`, `Cache`, `Logger`, and `Encryptor` interfaces in `libs/act/src/types/` define what an adapter must implement. The first three contracts are **executable** — [`@rotorsoft/act-tck`](https://www.npmjs.com/package/@rotorsoft/act-tck) exposes `runStoreTck`, `runCacheTck`, and `runLoggerTck` that exercise every method on each interface against any factory you point them at. If your adapter passes the TCK, it honors the contract; if the contract changes in a way that affects you, the TCK fails first. (The `Encryptor` port is small enough — 3 methods — that operators typically write their own adapter; the built-in `InMemoryEncryptor` doubles as the reference.)
 
 Once 1.0 ships:
 
-- Adding a **required** method to `Store`, `Cache`, or `Logger` is a breaking change.
+- Adding a **required** method to `Store`, `Cache`, `Logger`, or `Encryptor` is a breaking change.
 - Adding an **optional** method (with a default fallback in the orchestrator) is not. Optional surface is gated behind a `Capabilities` flag in the TCK so existing adapters keep passing until they opt in.
 - Changing the semantics of an existing method (return shape, error contract, ordering guarantees) is breaking.
 
 In-tree adapters are validated against the TCK across multiple backend versions in [`.github/workflows/conformance.yml`](.github/workflows/conformance.yml) — PostgreSQL 14/15/16/17 and `@libsql/client` pinned + latest. A regression in any cell surfaces before it reaches users.
+
+The `encryptor()` port is opt-in by wiring — unlike `store()` / `cache()` / `log()`, there is no built-in default. When unwired, `encryptor()` returns `undefined` and the sensitive-data path (`.sensitive({...})` declarations, `app.forget(...)`) treats sensitive fields as plaintext-and-metadata-only. This "no default" semantic is part of the covered contract — changing it (e.g. installing a default adapter implicitly) would be breaking.
 
 We will be explicit in release notes when this surface changes.
 

--- a/libs/act/src/adapters/in-memory-encryptor.ts
+++ b/libs/act/src/adapters/in-memory-encryptor.ts
@@ -1,0 +1,195 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  hkdfSync,
+  randomBytes,
+} from "node:crypto";
+import type { Encryptor } from "../types/ports.js";
+
+const MASTER_KEY_BYTES = 32;
+const MIN_SALT_BYTES = 16;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const MIN_MAX_ENTRIES = 1_000;
+const MAX_MAX_ENTRIES = 10_000_000;
+const DEFAULT_MAX_ENTRIES = 100_000;
+
+/**
+ * Options for the in-process default {@link InMemoryEncryptor}.
+ */
+export type InMemoryEncryptorOptions = {
+  /**
+   * 32-byte (256-bit) master key. Required, Buffer only — string overload
+   * is deliberately not exposed to avoid base64/hex encoding ambiguity and
+   * accidental hardcoded keys in source. Generate via `crypto.randomBytes(32)`
+   * and pass through whatever secret-management layer the host already runs
+   * (env var, KMS-decrypted secret, Vault read, etc.).
+   */
+  masterKey: Buffer;
+
+  /**
+   * HKDF salt used in the per-stream key derivation. At least 16 bytes when
+   * supplied. Defaults to a fresh `crypto.randomBytes(16)` at construction —
+   * deterministic operation across process restarts requires passing the
+   * same salt explicitly.
+   */
+  salt?: Buffer;
+
+  /**
+   * Maximum number of derived per-stream keys cached in process memory.
+   * Default `100_000`. Validated `[1_000, 10_000_000]`. Below 1k thrashes
+   * (the cache evicts faster than streams reuse it); above 10M is over a
+   * gigabyte of cached keys — well past any business-app workload.
+   */
+  maxEntries?: number;
+};
+
+/**
+ * Default in-tree {@link Encryptor} adapter.
+ *
+ * AES-256-GCM with a 12-byte random IV per encryption and a 16-byte
+ * authentication tag. Per-stream keys are derived once per process via
+ * HKDF-SHA-256 over `(masterKey, salt, stream)` and cached LRU-style; the
+ * HKDF cost (~10μs) amortizes away after the first use per stream.
+ *
+ * **Single-process only.** The shredded-stream set lives in process memory,
+ * which is the load-bearing security mechanism — even if a stream's key is
+ * re-derived later (the master key is still present), the cache consults the
+ * `shredded` set on every decrypt and returns `undefined`. Multi-process
+ * deployments need a durable encryptor (KMS / Vault); use this one in
+ * single-node deployments, tests, and as the reference implementation when
+ * writing a custom adapter.
+ *
+ * Ciphertext format: `base64(iv || ct || tag)`. The framework treats the
+ * return value of {@link InMemoryEncryptor.encrypt} as opaque; consumers
+ * never parse it directly.
+ */
+export class InMemoryEncryptor implements Encryptor {
+  private readonly _masterKey: Buffer;
+  private readonly _salt: Buffer;
+  private readonly _maxEntries: number;
+  private readonly _keyCache: Map<string, Buffer>;
+  private readonly _shredded: Set<string>;
+
+  constructor(options: InMemoryEncryptorOptions) {
+    if (!Buffer.isBuffer(options.masterKey)) {
+      throw new TypeError(
+        "InMemoryEncryptor: masterKey must be a Buffer (use crypto.randomBytes(32) or Buffer.from(...))"
+      );
+    }
+    if (options.masterKey.length !== MASTER_KEY_BYTES) {
+      throw new RangeError(
+        `InMemoryEncryptor: masterKey must be exactly ${MASTER_KEY_BYTES} bytes (256 bits), got ${options.masterKey.length}`
+      );
+    }
+    if (options.salt !== undefined) {
+      if (!Buffer.isBuffer(options.salt)) {
+        throw new TypeError("InMemoryEncryptor: salt must be a Buffer");
+      }
+      if (options.salt.length < MIN_SALT_BYTES) {
+        throw new RangeError(
+          `InMemoryEncryptor: salt must be at least ${MIN_SALT_BYTES} bytes, got ${options.salt.length}`
+        );
+      }
+    }
+    const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    if (
+      !Number.isInteger(maxEntries) ||
+      maxEntries < MIN_MAX_ENTRIES ||
+      maxEntries > MAX_MAX_ENTRIES
+    ) {
+      throw new RangeError(
+        `InMemoryEncryptor: maxEntries must be an integer in [${MIN_MAX_ENTRIES}, ${MAX_MAX_ENTRIES}], got ${maxEntries}`
+      );
+    }
+
+    this._masterKey = options.masterKey;
+    this._salt = options.salt ?? randomBytes(MIN_SALT_BYTES);
+    this._maxEntries = maxEntries;
+    this._keyCache = new Map();
+    this._shredded = new Set();
+  }
+
+  /**
+   * Derive (or fetch from cache) the per-stream key. LRU: a cache hit
+   * promotes the entry to most-recently-used so the eviction order tracks
+   * actual access patterns.
+   */
+  private deriveKey(stream: string): Buffer {
+    const cached = this._keyCache.get(stream);
+    if (cached !== undefined) {
+      // Reinsert to mark most-recently-used.
+      this._keyCache.delete(stream);
+      this._keyCache.set(stream, cached);
+      return cached;
+    }
+    const derived = Buffer.from(
+      hkdfSync(
+        "sha256",
+        this._masterKey,
+        this._salt,
+        Buffer.from(stream, "utf8"),
+        MASTER_KEY_BYTES
+      )
+    );
+    if (this._keyCache.size >= this._maxEntries) {
+      // Map iteration order is insertion-order; the first key is the
+      // least-recently-used. Size is bounded below by maxEntries >= 1000
+      // here, so the iterator always yields a value — the `as string`
+      // cast asserts the contract instead of a defensive null check that
+      // can't be tested.
+      const oldest = this._keyCache.keys().next().value as string;
+      this._keyCache.delete(oldest);
+    }
+    this._keyCache.set(stream, derived);
+    return derived;
+  }
+
+  async encrypt(stream: string, plaintext: string): Promise<string> {
+    const key = this.deriveKey(stream);
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const enc = Buffer.concat([
+      cipher.update(plaintext, "utf8"),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    return Buffer.concat([iv, enc, tag]).toString("base64");
+  }
+
+  async decrypt(
+    stream: string,
+    ciphertext: string
+  ): Promise<string | undefined> {
+    if (this._shredded.has(stream)) {
+      return undefined;
+    }
+    const buf = Buffer.from(ciphertext, "base64");
+    if (buf.length < IV_BYTES + TAG_BYTES) {
+      throw new RangeError(
+        `InMemoryEncryptor: ciphertext too short (${buf.length} bytes); must be at least ${IV_BYTES + TAG_BYTES}`
+      );
+    }
+    const iv = buf.subarray(0, IV_BYTES);
+    const tag = buf.subarray(buf.length - TAG_BYTES);
+    const enc = buf.subarray(IV_BYTES, buf.length - TAG_BYTES);
+    const key = this.deriveKey(stream);
+    const decipher = createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAuthTag(tag);
+    // GCM throws on auth tag mismatch — a tampered ciphertext or wrong key.
+    // Surface as Error so the read path treats it as a data-integrity issue,
+    // distinct from the shredded case (which returns undefined).
+    const dec = Buffer.concat([decipher.update(enc), decipher.final()]);
+    return dec.toString("utf8");
+  }
+
+  async shred(stream: string): Promise<void> {
+    this._keyCache.delete(stream);
+    this._shredded.add(stream);
+  }
+
+  async dispose(): Promise<void> {
+    this._keyCache.clear();
+    this._shredded.clear();
+  }
+}

--- a/libs/act/src/adapters/index.ts
+++ b/libs/act/src/adapters/index.ts
@@ -1,3 +1,7 @@
 export { ConsoleLogger } from "./console-logger.js";
 export { InMemoryCache } from "./in-memory-cache.js";
+export {
+  InMemoryEncryptor,
+  type InMemoryEncryptorOptions,
+} from "./in-memory-encryptor.js";
 export { InMemoryStore } from "./in-memory-store.js";

--- a/libs/act/src/ports.ts
+++ b/libs/act/src/ports.ts
@@ -7,6 +7,7 @@ import type {
   Cache,
   Disposable,
   Disposer,
+  Encryptor,
   Logger,
   Store,
 } from "./types/index.js";
@@ -210,6 +211,52 @@ const _cache = port(function cache(adapter?: Cache) {
 export const cache = ((adapter?: Cache): Cache => {
   return scoped.getStore()?.cache ?? _cache(adapter);
 }) as (adapter?: Cache) => Cache;
+
+// ---------------------------------------------------------------------------
+// Ports: encryptor (no default)
+// ---------------------------------------------------------------------------
+
+/**
+ * Gets or injects the singleton encryptor — the sensitive-data port (#566).
+ *
+ * **No default.** Unlike `store()` / `cache()` / `log()`, calling `encryptor()`
+ * before any adapter has been wired returns `undefined`. The framework treats
+ * `.sensitive({...})` declarations as metadata-only in that state — sensitive
+ * fields stay plaintext in `events.data` (consumed only by OpenAPI as
+ * `x-sensitive` and by loggers for redaction). `app.forget(stream)` throws
+ * when called without an encryptor because there's no mechanism to make the
+ * plaintext unreadable.
+ *
+ * To enable encryption + crypto-shredding, wire an adapter before building
+ * any Act instance:
+ *
+ * ```typescript
+ * import { encryptor } from "@rotorsoft/act";
+ * import { InMemoryEncryptor } from "@rotorsoft/act";
+ * import { randomBytes } from "node:crypto";
+ *
+ * encryptor(new InMemoryEncryptor({
+ *   masterKey: Buffer.from(process.env.ENCRYPTOR_MASTER_KEY!, "base64"),
+ * }));
+ * ```
+ *
+ * The wired adapter is registered for graceful shutdown alongside the
+ * standard ports, so `dispose()()` clears the key cache and the shredded
+ * set during teardown.
+ *
+ * @param adapter - Optional encryptor implementation to inject
+ * @returns The wired encryptor, or `undefined` if none has been wired yet
+ *
+ * @see {@link Encryptor} for the port contract
+ * @see {@link InMemoryEncryptor} for the in-tree adapter
+ */
+export function encryptor(adapter?: Encryptor): Encryptor | undefined {
+  if (adapter && !adapters.has("encryptor")) {
+    adapters.set("encryptor", adapter);
+    log().info(`[act] + encryptor:${adapter.constructor.name}`);
+  }
+  return adapters.get("encryptor") as Encryptor | undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Disposal

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -1038,3 +1038,57 @@ export interface Cache extends Disposable {
   invalidate(stream: string): Promise<void>;
   clear(): Promise<void>;
 }
+
+// ---------------------------------------------------------------------------
+// Encryptor
+// ---------------------------------------------------------------------------
+
+/**
+ * Port for stream-scoped symmetric encryption + crypto-shredding.
+ *
+ * Sensitive-data handling (`act-ops` sensitive epic #566) works by intercepting
+ * commit and load in the orchestrator: when an encryptor is wired AND a state
+ * has declared `.sensitive({...})`, the framework calls {@link Encryptor.encrypt}
+ * on each declared field at commit and {@link Encryptor.decrypt} at load. The
+ * Store sees ciphertext as opaque JSON-string field values and does not know
+ * there's PII.
+ *
+ * Erasure is then a single operation: {@link Encryptor.shred} deletes the
+ * stream's encryption key. Subsequent decrypts on that stream return
+ * `undefined`; the framework substitutes `"[REDACTED]"` for the field value
+ * before the read path hands the event to reducers/handlers/projections.
+ *
+ * Unlike `Store`, `Cache`, and `Logger`, the framework ships **no default**
+ * encryptor — `.sensitive(...)` declarations are metadata-only when no
+ * encryptor is wired (consumed by OpenAPI as `x-sensitive`, by loggers for
+ * redaction). Operators opt into encryption by wiring an adapter.
+ *
+ * The default in-tree adapter is `InMemoryEncryptor` (AES-256-GCM with
+ * HKDF-SHA-256 per-stream key derivation). Production deployments wire KMS-,
+ * Vault-, or file-backed adapters; the port is small enough (3 methods) that
+ * operators write their own.
+ */
+export interface Encryptor extends Disposable {
+  /**
+   * Encrypt a sensitive field value using the stream's key. Returns a
+   * self-describing ciphertext string (the in-tree default uses base64
+   * `iv || ct || tag`). The framework treats the return value as opaque.
+   */
+  encrypt(stream: string, plaintext: string): Promise<string>;
+
+  /**
+   * Decrypt a sensitive field value. Returns `undefined` when the stream's
+   * key has been shredded (the framework substitutes `"[REDACTED]"` for the
+   * field). Throws on authentication failure (tampered ciphertext, wrong
+   * key) — that's a data-integrity error, not erasure.
+   */
+  decrypt(stream: string, ciphertext: string): Promise<string | undefined>;
+
+  /**
+   * Delete the stream's encryption key — crypto-shredding. Irreversible
+   * by contract: the port deliberately exposes no `restore()` or `undo()`
+   * because the security property depends on absoluteness. Idempotent:
+   * shredding an already-shredded stream is a no-op.
+   */
+  shred(stream: string): Promise<void>;
+}

--- a/libs/act/test/encryptor-port.spec.ts
+++ b/libs/act/test/encryptor-port.spec.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock config so the registration info log doesn't crowd test output.
+vi.mock("../src/config.js", () => ({
+  config: vi.fn().mockReturnValue({
+    env: "development",
+    logLevel: "fatal",
+    logSingleLine: true,
+  }),
+}));
+
+describe("encryptor() port", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns undefined before any adapter is wired", async () => {
+    const { encryptor } = await import("../src/ports.js");
+    expect(encryptor()).toBeUndefined();
+  });
+
+  it("registers and returns the wired adapter", async () => {
+    const { encryptor } = await import("../src/ports.js");
+    const { InMemoryEncryptor } = await import(
+      "../src/adapters/in-memory-encryptor.js"
+    );
+    const adapter = new InMemoryEncryptor({ masterKey: randomBytes(32) });
+    const returned = encryptor(adapter);
+    expect(returned).toBe(adapter);
+    expect(encryptor()).toBe(adapter);
+  });
+
+  it("ignores subsequent wires (first wins, like other ports)", async () => {
+    const { encryptor } = await import("../src/ports.js");
+    const { InMemoryEncryptor } = await import(
+      "../src/adapters/in-memory-encryptor.js"
+    );
+    const first = new InMemoryEncryptor({ masterKey: randomBytes(32) });
+    const second = new InMemoryEncryptor({ masterKey: randomBytes(32) });
+    encryptor(first);
+    const returned = encryptor(second);
+    expect(returned).toBe(first);
+    expect(encryptor()).toBe(first);
+  });
+
+  it("is disposed during disposeAndExit", async () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const { dispose, encryptor } = await import("../src/ports.js");
+    const { InMemoryEncryptor } = await import(
+      "../src/adapters/in-memory-encryptor.js"
+    );
+    const adapter = new InMemoryEncryptor({ masterKey: randomBytes(32) });
+    const disposeSpy = vi.spyOn(adapter, "dispose");
+    encryptor(adapter);
+    await dispose()();
+    expect(disposeSpy).toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("returns undefined again after disposal (singleton cleared)", async () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const { dispose, encryptor } = await import("../src/ports.js");
+    const { InMemoryEncryptor } = await import(
+      "../src/adapters/in-memory-encryptor.js"
+    );
+    encryptor(new InMemoryEncryptor({ masterKey: randomBytes(32) }));
+    expect(encryptor()).toBeDefined();
+    await dispose()();
+    expect(encryptor()).toBeUndefined();
+    exitSpy.mockRestore();
+  });
+});

--- a/libs/act/test/in-memory-encryptor.spec.ts
+++ b/libs/act/test/in-memory-encryptor.spec.ts
@@ -1,0 +1,283 @@
+import { randomBytes } from "node:crypto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryEncryptor } from "../src/adapters/in-memory-encryptor.js";
+
+const KEY32 = (): Buffer => randomBytes(32);
+const SALT16 = (): Buffer => randomBytes(16);
+
+describe("InMemoryEncryptor — constructor validation", () => {
+  it("rejects a missing masterKey", () => {
+    expect(
+      () =>
+        new InMemoryEncryptor({
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid
+          masterKey: undefined as any,
+        })
+    ).toThrow(TypeError);
+  });
+
+  it("rejects a non-Buffer masterKey (string)", () => {
+    expect(
+      () =>
+        new InMemoryEncryptor({
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid
+          masterKey: "not-a-buffer" as any,
+        })
+    ).toThrow(/Buffer/);
+  });
+
+  it("rejects a masterKey shorter than 32 bytes", () => {
+    expect(() => new InMemoryEncryptor({ masterKey: randomBytes(16) })).toThrow(
+      /32 bytes/
+    );
+  });
+
+  it("rejects a masterKey longer than 32 bytes", () => {
+    expect(() => new InMemoryEncryptor({ masterKey: randomBytes(48) })).toThrow(
+      /32 bytes/
+    );
+  });
+
+  it("rejects a non-Buffer salt", () => {
+    expect(
+      () =>
+        new InMemoryEncryptor({
+          masterKey: KEY32(),
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid
+          salt: "not-a-buffer" as any,
+        })
+    ).toThrow(/salt/);
+  });
+
+  it("rejects a salt shorter than 16 bytes", () => {
+    expect(
+      () => new InMemoryEncryptor({ masterKey: KEY32(), salt: randomBytes(8) })
+    ).toThrow(/16 bytes/);
+  });
+
+  it("accepts a 16-byte salt", () => {
+    expect(
+      () => new InMemoryEncryptor({ masterKey: KEY32(), salt: randomBytes(16) })
+    ).not.toThrow();
+  });
+
+  it("accepts a larger-than-16-byte salt", () => {
+    expect(
+      () => new InMemoryEncryptor({ masterKey: KEY32(), salt: randomBytes(32) })
+    ).not.toThrow();
+  });
+
+  it("rejects maxEntries below 1000", () => {
+    expect(
+      () => new InMemoryEncryptor({ masterKey: KEY32(), maxEntries: 999 })
+    ).toThrow(/maxEntries/);
+  });
+
+  it("rejects maxEntries above 10000000", () => {
+    expect(
+      () =>
+        new InMemoryEncryptor({ masterKey: KEY32(), maxEntries: 10_000_001 })
+    ).toThrow(/maxEntries/);
+  });
+
+  it("rejects non-integer maxEntries", () => {
+    expect(
+      () => new InMemoryEncryptor({ masterKey: KEY32(), maxEntries: 1500.5 })
+    ).toThrow(/maxEntries/);
+  });
+
+  it("accepts maxEntries at the boundary [1000, 10000000]", () => {
+    expect(
+      () => new InMemoryEncryptor({ masterKey: KEY32(), maxEntries: 1_000 })
+    ).not.toThrow();
+    expect(
+      () =>
+        new InMemoryEncryptor({ masterKey: KEY32(), maxEntries: 10_000_000 })
+    ).not.toThrow();
+  });
+});
+
+describe("InMemoryEncryptor — encrypt/decrypt round-trip", () => {
+  let encryptor: InMemoryEncryptor;
+  const masterKey = KEY32();
+  const salt = SALT16();
+
+  beforeEach(() => {
+    encryptor = new InMemoryEncryptor({ masterKey, salt });
+  });
+
+  it("encrypts then decrypts a plaintext to itself", async () => {
+    const plaintext = "user@example.com";
+    const ciphertext = await encryptor.encrypt("stream-1", plaintext);
+    expect(ciphertext).not.toBe(plaintext);
+    expect(ciphertext.length).toBeGreaterThan(0);
+    const decrypted = await encryptor.decrypt("stream-1", ciphertext);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("produces different ciphertexts for the same plaintext (random IV)", async () => {
+    const a = await encryptor.encrypt("stream-1", "same-plaintext");
+    const b = await encryptor.encrypt("stream-1", "same-plaintext");
+    expect(a).not.toBe(b);
+  });
+
+  it("isolates streams — each gets its own derived key", async () => {
+    const ciphertext = await encryptor.encrypt("stream-A", "secret");
+    // Decrypting with a different stream re-derives a different key,
+    // so the GCM auth tag check fails.
+    await expect(encryptor.decrypt("stream-B", ciphertext)).rejects.toThrow();
+  });
+
+  it("handles empty plaintext", async () => {
+    const ciphertext = await encryptor.encrypt("stream-1", "");
+    const decrypted = await encryptor.decrypt("stream-1", ciphertext);
+    expect(decrypted).toBe("");
+  });
+
+  it("handles unicode plaintext", async () => {
+    const plaintext = "héllo 世界 🌍";
+    const ciphertext = await encryptor.encrypt("stream-1", plaintext);
+    const decrypted = await encryptor.decrypt("stream-1", ciphertext);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("handles large plaintext (1MB)", async () => {
+    const plaintext = "x".repeat(1_000_000);
+    const ciphertext = await encryptor.encrypt("stream-1", plaintext);
+    const decrypted = await encryptor.decrypt("stream-1", ciphertext);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("throws on tampered ciphertext (auth tag mismatch)", async () => {
+    const ciphertext = await encryptor.encrypt("stream-1", "secret");
+    // Flip a byte in the middle of the ciphertext (avoid IV at start).
+    const buf = Buffer.from(ciphertext, "base64");
+    buf[20] = buf[20] ^ 0xff;
+    const tampered = buf.toString("base64");
+    await expect(encryptor.decrypt("stream-1", tampered)).rejects.toThrow();
+  });
+
+  it("rejects ciphertext shorter than IV+tag (28 bytes)", async () => {
+    const tooShort = Buffer.from("short").toString("base64");
+    await expect(encryptor.decrypt("stream-1", tooShort)).rejects.toThrow(
+      /too short/
+    );
+  });
+});
+
+describe("InMemoryEncryptor — shred semantics", () => {
+  it("returns undefined on decrypt after shred (no throw)", async () => {
+    const encryptor = new InMemoryEncryptor({ masterKey: KEY32() });
+    const ciphertext = await encryptor.encrypt("user-1", "pii");
+    await encryptor.shred("user-1");
+    const result = await encryptor.decrypt("user-1", ciphertext);
+    expect(result).toBeUndefined();
+  });
+
+  it("is idempotent — shredding twice is a no-op", async () => {
+    const encryptor = new InMemoryEncryptor({ masterKey: KEY32() });
+    await encryptor.encrypt("user-1", "pii");
+    await encryptor.shred("user-1");
+    await expect(encryptor.shred("user-1")).resolves.toBeUndefined();
+    // Still returns undefined after second shred
+    const ciphertext = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const result = await encryptor.decrypt("user-1", ciphertext);
+    expect(result).toBeUndefined();
+  });
+
+  it("only shreds the targeted stream — others remain decryptable", async () => {
+    const encryptor = new InMemoryEncryptor({ masterKey: KEY32() });
+    const a = await encryptor.encrypt("user-1", "alice");
+    const b = await encryptor.encrypt("user-2", "bob");
+    await encryptor.shred("user-1");
+    expect(await encryptor.decrypt("user-1", a)).toBeUndefined();
+    expect(await encryptor.decrypt("user-2", b)).toBe("bob");
+  });
+
+  it("permanently shreds even if the key would re-derive (side-channel)", async () => {
+    // Same master + salt → same derived key in principle, but the shredded
+    // set short-circuits decrypt. This is the security guarantee.
+    const masterKey = KEY32();
+    const salt = SALT16();
+    const encryptor = new InMemoryEncryptor({ masterKey, salt });
+    const ciphertext = await encryptor.encrypt("user-1", "secret");
+    await encryptor.shred("user-1");
+    // Encrypting again into the same stream is allowed (a new HKDF derive),
+    // but old ciphertexts stay unreadable on this encryptor instance.
+    const result = await encryptor.decrypt("user-1", ciphertext);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("InMemoryEncryptor — LRU key cache", () => {
+  it("evicts the least-recently-used stream when the cache is full", async () => {
+    const encryptor = new InMemoryEncryptor({
+      masterKey: KEY32(),
+      maxEntries: 1_000,
+    });
+    // Encrypt across 1_001 distinct streams — should not throw despite
+    // exceeding the configured cap. The cache evicts; functionality
+    // continues because the next encrypt re-derives the key.
+    for (let i = 0; i < 1_002; i++) {
+      await encryptor.encrypt(`s${i}`, "x");
+    }
+    // The first stream should have been evicted; encrypting again
+    // exercises the re-derivation branch.
+    const ciphertext = await encryptor.encrypt("s0", "back-again");
+    const decrypted = await encryptor.decrypt("s0", ciphertext);
+    expect(decrypted).toBe("back-again");
+  });
+
+  it("promotes a hit to most-recently-used", async () => {
+    const encryptor = new InMemoryEncryptor({
+      masterKey: KEY32(),
+      maxEntries: 1_000,
+    });
+    // Warm 1000 streams.
+    for (let i = 0; i < 1_000; i++) {
+      await encryptor.encrypt(`s${i}`, "x");
+    }
+    // Touch s0 — should promote it to MRU.
+    await encryptor.encrypt("s0", "touched");
+    // Add one more stream — evicts oldest (s1, not s0).
+    await encryptor.encrypt("s1000", "fresh");
+    // s0 should still round-trip without re-derivation surprise.
+    const ciphertext = await encryptor.encrypt("s0", "still-here");
+    expect(await encryptor.decrypt("s0", ciphertext)).toBe("still-here");
+  });
+});
+
+describe("InMemoryEncryptor — dispose", () => {
+  it("clears caches without throwing", async () => {
+    const encryptor = new InMemoryEncryptor({ masterKey: KEY32() });
+    await encryptor.encrypt("user-1", "secret");
+    await encryptor.shred("user-2");
+    await expect(encryptor.dispose()).resolves.toBeUndefined();
+  });
+
+  it("dispose is idempotent", async () => {
+    const encryptor = new InMemoryEncryptor({ masterKey: KEY32() });
+    await encryptor.dispose();
+    await expect(encryptor.dispose()).resolves.toBeUndefined();
+  });
+});
+
+describe("InMemoryEncryptor — default salt", () => {
+  it("uses a generated salt when none is supplied", async () => {
+    const encryptor = new InMemoryEncryptor({ masterKey: KEY32() });
+    // The instance is functional — round-trip works without a caller-supplied salt.
+    const ciphertext = await encryptor.encrypt("stream-1", "data");
+    const decrypted = await encryptor.decrypt("stream-1", ciphertext);
+    expect(decrypted).toBe("data");
+  });
+
+  it("two instances with the same masterKey but no salt produce different ciphertexts", async () => {
+    const masterKey = KEY32();
+    const a = new InMemoryEncryptor({ masterKey });
+    const b = new InMemoryEncryptor({ masterKey });
+    const ctA = await a.encrypt("stream-1", "data");
+    // Decrypting A's ciphertext with B's instance fails (different salt
+    // → different derived key → auth tag mismatch).
+    await expect(b.decrypt("stream-1", ctA)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- New `Encryptor` port in `libs/act/src/types/ports.ts` — `encrypt` / `decrypt` / `shred`, extends `Disposable`
- New `encryptor()` singleton in `libs/act/src/ports.ts` — **no default**, returns `Encryptor | undefined` until wired. Hooks into the existing disposal registry.
- Default in-tree adapter `InMemoryEncryptor` under `libs/act/src/adapters/` — AES-256-GCM, HKDF-SHA-256 per-stream key derivation, LRU-bounded key cache, shredded-stream side-channel
- 35 tests, 100% coverage on the new files (statements, branches, functions, lines)
- `STABILITY.md` updated — Encryptor + no-default semantic of `encryptor()` are now charter-covered, additive on every existing contract

## Why no default

Unlike `store()` / `cache()` / `log()`, calling `encryptor()` before any adapter has been wired returns `undefined`. The framework treats `.sensitive({...})` declarations as metadata-only in that state (consumed by OpenAPI as `x-sensitive` and by loggers for redaction). `app.forget(stream)` throws when called without an encryptor wired — silently no-op'ing would be worse than a clear error because operators would believe they erased data when they didn't.

Apps that don't care about sensitive-data handling pay nothing — the orchestrator checks `encryptor() !== undefined` at the interception boundary (foundation #855 lands the interception itself), so the cost surface for apps without `.sensitive(...)` declarations is zero.

## Why this design specifically

- **No `pii` column, no Store contract changes.** The framework encrypts in-place in the existing `data` field at commit and decrypts at load. The Store sees plain JSON (or ciphertext-as-JSON-string-values when wired) and never knows there's PII. This avoids the previous design's mistake of pushing complexity onto every adapter author.
- **`shred` is irreversible by contract.** No `restore()` or `undo()`. The shredded set is consulted on every decrypt; even if the master key + salt could re-derive the per-stream key in principle, decrypt returns `undefined` for shredded streams.
- **Strict constructor validation.** 32-byte `Buffer` masterKey (no string overload to avoid base64/hex encoding ambiguity), 16+ byte salt, integer `maxEntries` in `[1_000, 10_000_000]`. Out-of-range values throw at construction.
- **AES-256-GCM only on the in-tree adapter.** Algorithm is not configurable — operators needing a different algorithm ship their own encryptor. The framework refuses to expose configurable weak modes on the default.

## Test plan

- [x] 35 tests passing, 100% coverage on `in-memory-encryptor.ts` and the new `encryptor()` port code
- [x] Constructor validation branches (every throw path exercised)
- [x] encrypt/decrypt round-trip with empty plaintext, unicode, and 1 MB payloads
- [x] Multi-stream isolation: different streams produce non-interchangeable ciphertexts
- [x] Shred semantics: returns `undefined` on decrypt (vs tampered ciphertext which throws); idempotent; only affects the targeted stream; permanent even when key could re-derive
- [x] LRU eviction at the configured `maxEntries` boundary; hit promotes to MRU
- [x] Default-salt path produces functional encryptor, but instances with the same masterKey + auto-salt are not interchangeable (different salts)
- [x] Port: `undefined` when unwired, returns wired adapter, ignores subsequent wires (first wins), disposed during `disposeAndExit`, `undefined` again after disposal

Closes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)