### PR TITLE
feat(act): pii_isolation Store contract — capability + forget_pii + TCK (#868)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -37,7 +37,7 @@ The `Store`, `Cache`, and `Logger` interfaces in `libs/act/src/types/` define wh
 Once 1.0 ships:
 
 - Adding a **required** method to `Store`, `Cache`, or `Logger` is a breaking change.
-- Adding an **optional** method (with a default fallback in the orchestrator) is not. Optional surface is gated behind a `Capabilities` flag in the TCK so existing adapters keep passing until they opt in.
+- Adding an **optional** method (with a default fallback in the orchestrator) is not. Optional surface is gated behind a `Capabilities` flag in the TCK so existing adapters keep passing until they opt in. Current capability-gated additions: `notify`, `restore`, `pii_isolation` (sensitive-data epic #566 — adapters supporting the `pii` field on commit/load plus `forget_pii(stream)`).
 - Changing the semantics of an existing method (return shape, error contract, ordering guarantees) is breaking.
 
 In-tree adapters are validated against the TCK across multiple backend versions in [`.github/workflows/conformance.yml`](.github/workflows/conformance.yml) — PostgreSQL 14/15/16/17 and `@libsql/client` pinned + latest. A regression in any cell surfaces before it reaches users.

--- a/libs/act-tck/src/store-tck.ts
+++ b/libs/act-tck/src/store-tck.ts
@@ -50,6 +50,15 @@ export type StoreCapabilities = {
    * rollback on mid-iteration throw.
    */
   readonly restore?: boolean;
+  /**
+   * Adapter supports sensitive-data isolation (#566): accepts the
+   * optional `pii` field on commit messages, returns it on load
+   * outputs, and implements {@link Store.forget_pii}. When `true`,
+   * the TCK runs the PII isolation suite — commit-with-pii
+   * round-trip, commit-without-pii passthrough, `forget_pii` happy
+   * path, idempotency, and isolation across streams.
+   */
+  readonly pii_isolation?: boolean;
 };
 
 /**
@@ -2117,6 +2126,174 @@ export const runStoreTck = (options: StoreTckOptions): void => {
         );
         // One callback per event; values monotonic.
         expect(calls).toEqual([1, 2]);
+      });
+    });
+
+    // PII isolation — sensitive-data epic (#566). Same `skipIf` pattern as
+    // restore: gated on `caps.pii_isolation`, exercises commit-with-pii
+    // round-trip, the no-pii passthrough, `forget_pii` happy path +
+    // idempotency, and isolation across streams.
+    describe.skipIf(!caps.pii_isolation)("pii_isolation (capability)", () => {
+      it("commits and loads pii alongside data", async () => {
+        const s = `pii-roundtrip-${uid()}`;
+        const committed = await store.commit<CounterEvents>(
+          s,
+          [
+            {
+              name: "Incremented",
+              data: { amount: 1 },
+              pii: { email: "u@example.com", name: "Ursula" },
+            },
+          ],
+          makeMeta({ stream: s })
+        );
+        expect(committed).toHaveLength(1);
+        expect(committed[0].pii).toEqual({
+          email: "u@example.com",
+          name: "Ursula",
+        });
+
+        // Re-read via query to confirm the adapter persists pii.
+        const seen: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            seen.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(seen).toHaveLength(1);
+        expect(seen[0].pii).toEqual({ email: "u@example.com", name: "Ursula" });
+        // Non-pii fields untouched.
+        expect(seen[0].data).toEqual({ amount: 1 });
+      });
+
+      it("passes through events without pii (pii is null or undefined on load)", async () => {
+        const s = `pii-none-${uid()}`;
+        await store.commit<CounterEvents>(s, [inc(1)], makeMeta({ stream: s }));
+        const seen: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            seen.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(seen).toHaveLength(1);
+        // Either undefined or null is acceptable — adapters that store
+        // `pii TEXT NULL` round-trip as null; in-memory may return
+        // undefined for the missing key. Both forms mean "no PII."
+        expect(seen[0].pii == null).toBe(true);
+      });
+
+      it("wipes pii for every event on the stream via forget_pii", async () => {
+        const s = `pii-forget-${uid()}`;
+        await store.commit<CounterEvents>(
+          s,
+          [
+            {
+              name: "Incremented",
+              data: { amount: 1 },
+              pii: { email: "a@example.com" },
+            },
+            {
+              name: "Incremented",
+              data: { amount: 2 },
+              pii: { email: "b@example.com" },
+            },
+          ],
+          makeMeta({ stream: s })
+        );
+
+        const forget = store.forget_pii;
+        expect(forget).toBeDefined();
+        const wiped = await forget!.call(store, s);
+        expect(wiped).toBe(2);
+
+        const seen: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            seen.push(e);
+          },
+          { stream: s, stream_exact: true }
+        );
+        expect(seen).toHaveLength(2);
+        // PII is gone — adapters return null. Data is intact.
+        for (const e of seen) {
+          expect(e.pii == null).toBe(true);
+          expect(e.data).toBeDefined();
+        }
+      });
+
+      it("is idempotent — second forget_pii returns 0, no error", async () => {
+        const s = `pii-forget-idem-${uid()}`;
+        await store.commit<CounterEvents>(
+          s,
+          [
+            {
+              name: "Incremented",
+              data: { amount: 1 },
+              pii: { email: "u@example.com" },
+            },
+          ],
+          makeMeta({ stream: s })
+        );
+        const forget = store.forget_pii!;
+        const first = await forget.call(store, s);
+        expect(first).toBe(1);
+        const second = await forget.call(store, s);
+        expect(second).toBe(0);
+      });
+
+      it("only wipes the targeted stream — siblings untouched", async () => {
+        const sA = `pii-iso-a-${uid()}`;
+        const sB = `pii-iso-b-${uid()}`;
+        await store.commit<CounterEvents>(
+          sA,
+          [
+            {
+              name: "Incremented",
+              data: { amount: 1 },
+              pii: { email: "alice@example.com" },
+            },
+          ],
+          makeMeta({ stream: sA })
+        );
+        await store.commit<CounterEvents>(
+          sB,
+          [
+            {
+              name: "Incremented",
+              data: { amount: 1 },
+              pii: { email: "bob@example.com" },
+            },
+          ],
+          makeMeta({ stream: sB })
+        );
+        await store.forget_pii!.call(store, sA);
+
+        const a: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            a.push(e);
+          },
+          { stream: sA, stream_exact: true }
+        );
+        expect(a[0].pii == null).toBe(true);
+
+        const b: Committed<CounterEvents, keyof CounterEvents>[] = [];
+        await store.query<CounterEvents>(
+          (e) => {
+            b.push(e);
+          },
+          { stream: sB, stream_exact: true }
+        );
+        expect(b[0].pii).toEqual({ email: "bob@example.com" });
+      });
+
+      it("forget_pii on a stream with no pii events returns 0", async () => {
+        const s = `pii-forget-empty-${uid()}`;
+        await store.commit<CounterEvents>(s, [inc(1)], makeMeta({ stream: s }));
+        const wiped = await store.forget_pii!.call(store, s);
+        expect(wiped).toBe(0);
       });
     });
 

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -203,6 +203,24 @@ export type Message<TEvents extends Schemas, TKey extends keyof TEvents> = {
   readonly name: TKey;
   /** The event or action payload */
   readonly data: Readonly<TEvents[TKey]>;
+  /**
+   * Sensitive-data payload (#566). Carries fields the framework extracted
+   * from `data` at commit-interception time, routed to a separate
+   * `events.pii` column by adapters that declare the `pii_isolation`
+   * capability.
+   *
+   * Populated by the framework's commit interception (foundation #855) —
+   * action handlers do not set this. On commit input it carries the
+   * extracted sensitive fields; on load output it carries the merged
+   * fields read from the adapter's pii column (or `null` after
+   * `Store.forget_pii(stream)`).
+   *
+   * Adapters without `pii_isolation` ignore the field; the framework only
+   * populates it when the adapter declares capability support and the
+   * state declares `.discloses(...)` / has `sensitive(...)`-marked schema
+   * fields.
+   */
+  readonly pii?: Readonly<Record<string, unknown>> | null;
 };
 
 /**

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -217,8 +217,10 @@ export type Message<TEvents extends Schemas, TKey extends keyof TEvents> = {
    *
    * Adapters without `pii_isolation` ignore the field; the framework only
    * populates it when the adapter declares capability support and the
-   * state declares `.discloses(...)` / has `sensitive(...)`-marked schema
-   * fields.
+   * event's schema has `sensitive(...)`-marked fields. (Read-time
+   * visibility gating — who sees plaintext vs `[REDACTED]` — is the
+   * separate concern of `state(...).discloses(predicate)` and lives in
+   * the orchestrator's load path, not on the Store contract.)
    */
   readonly pii?: Readonly<Record<string, unknown>> | null;
 };

--- a/libs/act/src/types/ports.ts
+++ b/libs/act/src/types/ports.ts
@@ -1000,6 +1000,37 @@ export interface Store extends Disposable, EventSource {
   notify?: (
     handler: (notification: StoreNotification) => void
   ) => NotifyDisposer | Promise<NotifyDisposer>;
+
+  /**
+   * Wipe the sensitive-data payload for every event on the stream — the
+   * physical-erasure side of the sensitive-data epic (#566). Sets the
+   * adapter's PII column (or equivalent) to `NULL` for the stream's
+   * events; `events.data` and the rest of the row are never touched.
+   *
+   * Returns the count of rows wiped. Idempotent: a second call on an
+   * already-wiped stream returns `0` without error.
+   *
+   * Capability-gated via `pii_isolation` in `@rotorsoft/act-tck`'s
+   * `StoreCapabilities`. Adapters that can't UPDATE rows (Kafka,
+   * append-only object-storage logs) declare `pii_isolation: false`
+   * and omit this method; `app.forget(stream)` throws on those
+   * adapters at orchestrator level.
+   *
+   * Append-only invariant on `events.data` is preserved — only the
+   * separately-isolated PII column is mutated. Disk reclamation is
+   * adapter-dependent (PG autovacuum reclaims lazily; SQLite needs
+   * `PRAGMA incremental_vacuum` or `VACUUM`). For strict-deletion
+   * jurisdictions the production checklist documents the operator
+   * step.
+   *
+   * Encryption-at-rest is the operator's DB-layer concern (pgcrypto,
+   * RDS TDE, Cloud SQL TDE, SQLite SEE) — not an application-level
+   * port. The framework's job is isolation + erasure.
+   *
+   * @param stream Target stream
+   * @returns Count of events whose PII column was set to NULL
+   */
+  forget_pii?: (stream: string) => Promise<number>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Contract additions for the sensitive-data epic (#566). Three additive changes behind a single capability flag — no runtime behavior changes for existing adapters, the new method and field are both optional and ignored when the capability isn't declared.

- **`Message.pii?: Readonly<Record<string, unknown>> | null`** — carries the framework-extracted sensitive payload at commit time, the merged read-time PII at load. Inherited by `Committed`. Set by the framework's commit interception (foundation #855); action handlers never set it.
- **`Store.forget_pii?(stream): Promise<number>`** — capability-gated. NULLs the adapter's PII column for every event on the stream. Idempotent. Adapters that can't UPDATE (Kafka, append-only object stores) omit it; `app.forget(stream)` throws on those.
- **`StoreCapabilities.pii_isolation?: boolean`** in act-tck — adapters declare `true` once all three pieces (commit-accepts-pii, load-returns-pii, forget_pii) are implemented. The TCK block runs via `describe.skipIf(!caps.pii_isolation)`.

## TCK additions

Six cases in `libs/act-tck/src/store-tck.ts`, all under the new `describe.skipIf(!caps.pii_isolation)("pii_isolation (capability)", ...)` block:

1. Commit-with-pii round-trip via `commit` + `query` — returned events carry the original pii payload.
2. No-pii passthrough — events without pii return `pii == null` on load.
3. `forget_pii` happy path — two-event stream wipes both, returns 2.
4. Idempotency — second `forget_pii` on already-wiped stream returns 0.
5. Stream isolation — `forget_pii` on stream A doesn't touch stream B.
6. `forget_pii` on a no-pii stream returns 0.

All six skip on adapters without the capability declared. Existing in-tree adapters (InMemoryStore, PostgresStore, SqliteStore) still don't declare `pii_isolation` — that lands in #869/#870/#871. So the practical effect of this PR on existing adapters is **zero runtime behavior change** and **zero new test failures**.

## Why this shape (not the closed Encryptor port)

PR #867 (closed) tried an `Encryptor` port + master-key handling + rotation readiness. That was the wrong tool — the framework already mutates events via `Act.close()`/truncate, so the simpler answer is one capability-gated Store method that UPDATEs the dedicated `events.pii` column. Confidentiality at rest is the operator's DB-layer concern (pgcrypto / RDS TDE / Cloud SQL TDE / SQLite SEE), not an application port. See #566 master for the full design journey.

## Test plan

- [x] `pnpm -F @rotorsoft/act build` clean
- [x] `npx tsc --noEmit -p libs/act/tsconfig.json` clean
- [x] `npx tsc --noEmit -p libs/act-tck/tsconfig.json` clean
- [x] All 742 existing act tests + 125 act-sqlite tests pass; 6 new pii_isolation cases skipped (capability not yet declared)
- [ ] (Verifier) Confirm the new `pii` field is invisible to action handlers (they never set it)

Closes #868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)