### PR TITLE
chore(act-http): fix dep contract and unblock renovate (#873)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: renovatebot/github-action@v46.0.2
+      - uses: renovatebot/github-action@v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:

--- a/libs/act-http/package.json
+++ b/libs/act-http/package.json
@@ -82,13 +82,29 @@
   "peerDependencies": {
     "@rotorsoft/act": "workspace:^",
     "@rotorsoft/act-ops": "workspace:^",
-    "@trpc/server": ">=11"
+    "@trpc/server": ">=11",
+    "@hono/node-server": "^1",
+    "express": "^5",
+    "fastify": "^5",
+    "hono": "^4"
   },
   "peerDependenciesMeta": {
     "@rotorsoft/act-ops": {
       "optional": true
     },
     "@trpc/server": {
+      "optional": true
+    },
+    "@hono/node-server": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    },
+    "fastify": {
+      "optional": true
+    },
+    "hono": {
       "optional": true
     }
   },
@@ -97,11 +113,12 @@
   },
   "devDependencies": {
     "@rotorsoft/act-ops": "workspace:^",
-    "@hono/node-server": "^1",
+    "@hono/node-server": "^1.19.14",
     "@trpc/server": "^11.17.0",
-    "@types/express": "^5",
-    "fastify": "^5",
-    "hono": "^4",
-    "zod": "^4"
+    "@types/express": "^5.0.6",
+    "express": "^5.2.1",
+    "fastify": "^5.8.5",
+    "hono": "^4.12.23",
+    "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,7 +265,7 @@ importers:
         version: link:../act-patch
     devDependencies:
       '@hono/node-server':
-        specifier: ^1
+        specifier: ^1.19.14
         version: 1.19.14(hono@4.12.23)
       '@rotorsoft/act-ops':
         specifier: workspace:^
@@ -274,16 +274,19 @@ importers:
         specifier: ^11.17.0
         version: 11.17.0(typescript@6.0.3)
       '@types/express':
-        specifier: ^5
+        specifier: ^5.0.6
         version: 5.0.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       fastify:
-        specifier: ^5
+        specifier: ^5.8.5
         version: 5.8.5
       hono:
-        specifier: ^4
+        specifier: ^4.12.23
         version: 4.12.23
       zod:
-        specifier: ^4
+        specifier: ^4.4.3
         version: 4.4.3
 
   libs/act-ops: {}


### PR DESCRIPTION
## Summary

- Reorganize `libs/act-http/package.json`: every framework runtime now declared as an optional `peerDependency` (matching the existing `@trpc/server` pattern), kept in `devDependencies` so the local build/tests still install them. `express` added explicitly (was previously missing — only `@types/express` was declared). `zod` stays a devDep: it's used in JSDoc examples and tests only, consumers get it transitively through `@rotorsoft/act`.
- Pin loose specifiers in `act-http` devDependencies to currently-installed minor versions so Renovate's `rangeStrategy: "bump"` stops thrashing the grouped patch branch (this was the proximate cause of the `repository-changed` aborts on every scheduled Renovate run since ~2026-06-02).
- Bump `renovatebot/github-action` from `v46.0.2` → `v46.1.14` for known collision-handling fixes.

Why both peer and devDep for the same library: peer = install contract for consumers (wide range, signals "bring your own"); devDep = what this repo needs locally to typecheck/build/test (pinned).

Closes #873

## Test plan

- [x] `pnpm install` reproduces with no new peer warnings beyond the pre-existing `esbuild`/`bundle-require` one.
- [x] `pnpm typecheck` clean across the workspace.
- [x] All 1770 non-`act-pg` tests pass; `act-pg` tests untouched (require local Docker postgres).
- [x] `pnpm -F @rotorsoft/act-http build` produces the same dist layout as before.
- [ ] After merge: manually trigger `renovate.yml` once to drain the dashboard backlog cleanly and confirm no `repository-changed` abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)