### PR TITLE
chore(ci): renovate phase-2 — gitAuthor + rebaseWhen + drop checkout (#875)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,7 +16,6 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
       - uses: renovatebot/github-action@v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
     ":maintainLockFilesWeekly",
     ":enableVulnerabilityAlerts"
   ],
+  "gitAuthor": "Rotorsoft Renovate <41707007+Rotorsoft@users.noreply.github.com>",
+  "rebaseWhen": "conflicted",
   "dependencyDashboard": true,
   "enabledManagers": ["npm", "github-actions"],
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## Summary

- `renovate.json`: set `gitAuthor` to the token-owner's noreply identity (commits now verifiable, not shared with Mend's bot); add `rebaseWhen: "conflicted"` to stop the per-run force-push storm on stale branches.
- `.github/workflows/renovate.yml`: drop the redundant `actions/checkout@v6` step — the wrapper runs Renovate in its own Docker container.

Each addresses one hypothesized contributor to the `repository-changed` abort that's still firing after #874. If the pattern persists post-merge, the remaining failure modes live inside the wrapper or Mend's hosted infra — escalate by switching to the hosted Mend Renovate App.

Closes #875

## Test plan

- [ ] After merge, `gh workflow run renovate.yml`.
- [ ] Confirm the run reaches "Repository finished" with `result: done` (not `repository-changed`).
- [ ] Confirm Dependency Dashboard #8 refreshes and rate-limited entries start opening PRs over subsequent runs.
- [ ] If the abort recurs, see Out of scope section in #875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)