### PR TITLE
feat(act): in-memory pii_isolation impl (#869)

### DIFF
--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -296,11 +296,12 @@ export class InMemoryStore implements Store {
   private _maxEventIdByStream: Map<string, number> = new Map();
   // global max non-snapshot event id — fast pre-check for source-less streams in claim()
   private _maxNonSnapEventId = -1;
-  // event_id → cloned sensitive payload. Separate from `_events` so `forget_pii`
-  // can wipe PII without touching the event log — mirrors the `events.pii`
-  // column on durable adapters. Entries exist only for events committed with a
-  // non-null `pii` field; absence means "no PII" (returned as `null` on load).
-  private _pii: Map<number, Record<string, unknown>> = new Map();
+  // stream → (event_id → cloned sensitive payload). Two-level so `forget_pii`
+  // is O(1) — drop the inner Map for the stream and the wipe is done — mirroring
+  // the `DELETE WHERE stream = ?` scope that durable adapters get from their
+  // stream index. Entries exist only for events committed with a non-null
+  // `pii` field; absence means "no PII" (returned as `null` on load).
+  private _pii: Map<string, Map<number, Record<string, unknown>>> = new Map();
 
   private _resetIndexes() {
     this._events.length = 0;
@@ -315,7 +316,7 @@ export class InMemoryStore implements Store {
   private _withPii<E extends Schemas>(
     e: Committed<E, keyof E>
   ): Committed<E, keyof E> {
-    const pii = this._pii.get(e.id);
+    const pii = this._pii.get(e.stream)?.get(e.id);
     return pii ? ({ ...e, pii } as Committed<E, keyof E>) : e;
   }
 
@@ -446,11 +447,16 @@ export class InMemoryStore implements Store {
         meta,
       };
       // The stored event is the pii-less view — `forget_pii` only has to
-      // clear the `_pii` entry, never the event row. Mandatory clone on the
-      // pii payload defends against caller-side mutation.
+      // drop the inner Map for the stream, never the event row. Mandatory
+      // clone on the pii payload defends against caller-side mutation.
       this._events.push(c as Committed<Schemas, keyof Schemas>);
       if (pii != null) {
-        this._pii.set(c.id, structuredClone(pii) as Record<string, unknown>);
+        let perStream = this._pii.get(stream);
+        if (!perStream) {
+          perStream = new Map();
+          this._pii.set(stream, perStream);
+        }
+        perStream.set(c.id, structuredClone(pii) as Record<string, unknown>);
       }
       if (name !== SNAP_EVENT) lastNonSnapId = c.id;
       version++;
@@ -696,21 +702,17 @@ export class InMemoryStore implements Store {
    */
   /**
    * Wipe the sensitive-data payload for every event on the stream — see
-   * {@link Store.forget_pii}. The InMemoryStore implementation walks events
-   * once filtering on `stream`, deletes any matching entry in `_pii`, and
-   * returns the count of entries actually removed. Idempotent: a second call
-   * on an already-wiped stream returns `0`.
+   * {@link Store.forget_pii}. O(1) drop of the stream's inner Map; the size of
+   * that Map is the count of events that had PII. Idempotent: a second call
+   * finds no inner Map and returns `0`.
    *
    * @param stream - Target stream.
    * @returns Count of events whose isolated PII payload was deleted.
    */
   async forget_pii(stream: string): Promise<number> {
     await sleep();
-    let count = 0;
-    for (const e of this._events) {
-      if (e.stream !== stream) continue;
-      if (this._pii.delete(e.id)) count++;
-    }
+    const count = this._pii.get(stream)?.size ?? 0;
+    this._pii.delete(stream);
     return count;
   }
 

--- a/libs/act/src/adapters/in-memory-store.ts
+++ b/libs/act/src/adapters/in-memory-store.ts
@@ -296,12 +296,27 @@ export class InMemoryStore implements Store {
   private _maxEventIdByStream: Map<string, number> = new Map();
   // global max non-snapshot event id — fast pre-check for source-less streams in claim()
   private _maxNonSnapEventId = -1;
+  // event_id → cloned sensitive payload. Separate from `_events` so `forget_pii`
+  // can wipe PII without touching the event log — mirrors the `events.pii`
+  // column on durable adapters. Entries exist only for events committed with a
+  // non-null `pii` field; absence means "no PII" (returned as `null` on load).
+  private _pii: Map<number, Record<string, unknown>> = new Map();
 
   private _resetIndexes() {
     this._events.length = 0;
     this._streamVersions.clear();
     this._maxEventIdByStream.clear();
     this._maxNonSnapEventId = -1;
+    this._pii.clear();
+  }
+
+  // Attach the isolated PII payload (or null) to an event before handing it to
+  // a caller. Allocation-free for events without PII — by far the common case.
+  private _withPii<E extends Schemas>(
+    e: Committed<E, keyof E>
+  ): Committed<E, keyof E> {
+    const pii = this._pii.get(e.id);
+    return pii ? ({ ...e, pii } as Committed<E, keyof E>) : e;
   }
 
   /**
@@ -365,7 +380,9 @@ export class InMemoryStore implements Store {
           continue;
         if (query.after && e.id <= query.after) break;
         if (query.created_after && e.created <= query.created_after) break;
-        await Promise.resolve(callback(e as Committed<E, keyof E>));
+        await Promise.resolve(
+          callback(this._withPii(e as Committed<E, keyof E>))
+        );
         count++;
         if (query?.limit && count >= query.limit) break;
       }
@@ -377,7 +394,9 @@ export class InMemoryStore implements Store {
         if (query?.created_after && e.created <= query.created_after) continue;
         if (query?.before && e.id >= query.before) break;
         if (query?.created_before && e.created >= query.created_before) break;
-        await Promise.resolve(callback(e as Committed<E, keyof E>));
+        await Promise.resolve(
+          callback(this._withPii(e as Committed<E, keyof E>))
+        );
         count++;
         if (query?.limit && count >= query.limit) break;
       }
@@ -416,7 +435,7 @@ export class InMemoryStore implements Store {
 
     let version = currentVersion + 1;
     let lastNonSnapId = -1;
-    const committed = msgs.map(({ name, data }) => {
+    const committed = msgs.map(({ name, data, pii }) => {
       const c: Committed<E, keyof E> = {
         id: this._events.length,
         stream,
@@ -426,10 +445,16 @@ export class InMemoryStore implements Store {
         data,
         meta,
       };
+      // The stored event is the pii-less view — `forget_pii` only has to
+      // clear the `_pii` entry, never the event row. Mandatory clone on the
+      // pii payload defends against caller-side mutation.
       this._events.push(c as Committed<Schemas, keyof Schemas>);
+      if (pii != null) {
+        this._pii.set(c.id, structuredClone(pii) as Record<string, unknown>);
+      }
       if (name !== SNAP_EVENT) lastNonSnapId = c.id;
       version++;
-      return c;
+      return this._withPii(c);
     });
     this._streamVersions.set(stream, version - 1);
     if (lastNonSnapId >= 0) {
@@ -669,6 +694,26 @@ export class InMemoryStore implements Store {
    * @param input - Stream names or a filter selecting the streams to unblock.
    * @returns Count of streams that were actually flipped (were blocked).
    */
+  /**
+   * Wipe the sensitive-data payload for every event on the stream — see
+   * {@link Store.forget_pii}. The InMemoryStore implementation walks events
+   * once filtering on `stream`, deletes any matching entry in `_pii`, and
+   * returns the count of entries actually removed. Idempotent: a second call
+   * on an already-wiped stream returns `0`.
+   *
+   * @param stream - Target stream.
+   * @returns Count of events whose isolated PII payload was deleted.
+   */
+  async forget_pii(stream: string): Promise<number> {
+    await sleep();
+    let count = 0;
+    for (const e of this._events) {
+      if (e.stream !== stream) continue;
+      if (this._pii.delete(e.id)) count++;
+    }
+    return count;
+  }
+
   async unblock(input: string[] | StreamFilter) {
     await sleep();
     let count = 0;

--- a/libs/act/test/store-tck.spec.ts
+++ b/libs/act/test/store-tck.spec.ts
@@ -4,5 +4,5 @@ import { InMemoryStore } from "../src/adapters/in-memory-store.js";
 runStoreTck({
   name: "InMemoryStore",
   factory: () => new InMemoryStore(),
-  capabilities: { restore: true },
+  capabilities: { restore: true, pii_isolation: true },
 });


### PR DESCRIPTION
## Summary

- Implement `Store.forget_pii` + the pii payload round-trip on `InMemoryStore` (`libs/act/src/adapters/in-memory-store.ts`).
- Flip `pii_isolation: true` in `libs/act/test/store-tck.spec.ts` so the TCK block added by #868 actually runs against an adapter.

The contract additions (`Message.pii`, `Committed.pii`, `Store.forget_pii`, `Capabilities.pii_isolation`) all landed in #868; this PR is the first adapter to declare the capability and exercise the TCK block.

## Storage shape

`_pii: Map<stream, Map<event_id, payload>>` — two-level so `forget_pii` drops the inner Map for the stream in one operation. Mirrors how durable adapters scope `DELETE WHERE stream = ?` to a stream-indexed range rather than a table-wide scan.

| Op | Cost | Why |
|---|---|---|
| commit | O(1) + one get-or-init per stream | new inner Map allocated on the stream's first PII-carrying event |
| read (`_withPii`) | O(1) + one extra hash | `_pii.get(stream)?.get(id)` |
| `forget_pii(stream)` | **O(1)** | `_pii.get(stream)?.size; _pii.delete(stream)` — no walk of `_events` |

Mandatory `structuredClone` of the pii payload on commit defends against caller-side mutation. The stored event in `_events` is always the pii-less view; `forget_pii` never touches the event log, only the isolated PII Map.

The branch landed in two commits: first the flat-Map shape, then the stream-keyed refactor. Squash on merge.

Closes #869

## Test plan

- [x] `npx vitest run libs/act/test/store-tck.spec.ts` — 86 cases pass (was 81; +5 from the now-active pii_isolation block).
- [x] `pnpm test` — workspace-wide coverage **100% across all four metrics** (statements / branches / functions / lines), closing the ~5% gap that existed in `store-tck.ts` while the block was skipped against every adapter.
- [x] `pnpm lint` — clean.
- [ ] Post-merge: #870 (act-pg) and #871 (act-sqlite) flip the same flag once their column migrations land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)