### PR TITLE
feat(act): sensitive-data foundation — sensitive() + .discloses() + app.forget (#855)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -12,10 +12,11 @@ Breaking changes to anything in this list require a **major** version bump and a
 
 The fluent surfaces exported from `@rotorsoft/act`:
 
-- `state(...)` — including `.init`, `.emits`, `.patch`, `.on` (with optional `ActionOptions` second argument for per-action retry policy), `.given`, `.emit`, `.snap`, `.build`
+- `state(...)` — including `.init`, `.emits`, `.patch`, `.on` (with optional `ActionOptions` second argument for per-action retry policy), `.given`, `.emit`, `.snap`, `.discloses` (sensitive-data epic #566 — disclosure predicate for `sensitive(...)`-marked event fields), `.build`
 - `slice(...)` — including `.actions`, `.given`, `.build`
 - `projection(...)` — including `.from`, `.on`, `.build`
 - `act(...)` — including `.with`, `.build`
+- `sensitive(zodType)` (sensitive-data epic #566 — schema-level marker for PII fields; the orchestrator splits sensitive keys off `data` into `pii` on commit and gates reads by `.discloses`)
 
 Adding new optional builder methods or new optional fields to existing return types is **not** a breaking change. Removing or renaming a method, changing a required parameter, or narrowing an output type **is**.
 
@@ -26,6 +27,7 @@ The runtime surface returned from `act(...).build()`:
 - `do`, `load`, `query`, `query_array`
 - `drain`, `settle`, `correlate`
 - `reset`, `unblock`, `blocked_streams`, `close`
+- `forget` (sensitive-data epic #566 — wipe a stream's PII via `Store.forget_pii`, invalidate the cache, emit the `forgotten` lifecycle event; throws on adapters without `pii_isolation`)
 - `audit`
 
 The signatures, return shapes, and behavioral contracts of these methods are stable. Additive new methods on `IAct` are not breaking. Changing the meaning of an existing call (e.g., what `settle()` guarantees) is.
@@ -54,6 +56,7 @@ The events emitted by the orchestrator on the public event bus (`ActLifecycleEve
 - `settled` — a drain cycle settled (`Drain`)
 - `closed` — a close-the-books cycle completed (`CloseResult`)
 - `notified` — a different process committed to the same backing store (`StoreNotification`); fires only when `Store.notify` is implemented and at least one reaction is registered
+- `forgotten` — a stream's sensitive-data payload was wiped via `app.forget(stream)` (`{stream, at, eventCount}`); fires once per successful call, never on idempotent re-forget
 
 Their names and payload shapes are stable. Adding new optional fields to a payload is not breaking; renaming or removing fields is. Adding new lifecycle event names is not breaking.
 

--- a/biome.json
+++ b/biome.json
@@ -119,9 +119,11 @@
                       "!**/internal/index",
                       "!**/internal/index.js",
                       "!**/internal/lru-map",
-                      "!**/internal/lru-map.js"
+                      "!**/internal/lru-map.js",
+                      "!**/internal/sensitive",
+                      "!**/internal/sensitive.js"
                     ],
-                    "message": "Import via the internal barrel ('./internal/index.js'), not a deep path. Exception: `internal/lru-map.js` is a side-effect-free leaf utility and can be imported directly."
+                    "message": "Import via the internal barrel ('./internal/index.js'), not a deep path. Exception: `internal/lru-map.js` and `internal/sensitive.js` are side-effect-free leaf utilities and can be imported directly. (`sensitive.js` deep-import is load-bearing for `types/schemas.ts` — going through the barrel pulls tracing.ts → config.ts in at type-schema load time and crashes on TDZ.)"
                   }
                 ]
               }

--- a/libs/act/PERFORMANCE.md
+++ b/libs/act/PERFORMANCE.md
@@ -40,6 +40,24 @@ pnpm -F @rotorsoft/act bench:update    # writes perf-baseline.json
 
 ---
 
+## Sensitive-data foundation (#855)
+
+The sensitive-data slices (#855) add machinery to every event that flows through the orchestrator — a `pii_fields(name)` registry lookup, `fields.length === 0` early-exit branches in `merge_for_reducer`/`gate_external`/`strip_for_handler`, and the gating path in `action()`'s post-commit snapshot builder. Events without `sensitive(...)` markers should pay nothing, but "should" needed measurement.
+
+`libs/act/bench/sensitive.micro.bench.ts` exercises the orchestrator's hot paths on a plain non-sensitive Counter — no `sensitive` markers, no `.discloses`, no `actor` arg on load. Ran the same bench on master (pre-#855) and on the merged #855 branch:
+
+| Scenario | Master (before) | #855 (after) | Δ |
+|---|---:|---:|---:|
+| `app.do()` single commit | 419 hz / 2.39 ms | 426 hz / 2.35 ms | +1.6% |
+| `app.load()` over 100 events | 840 hz / 1.19 ms | 856 hz / 1.17 ms | +1.8% |
+| `app.do()` + `app.load()` round-trip | 275 hz / 3.64 ms | 283 hz / 3.53 ms | +3.0% |
+
+`rme` was ±1–2% on every measurement, so the deltas are within run-to-run noise. **The PII machinery imposes no measurable overhead on non-sensitive workloads.** The early-exit short-circuits are doing their job — apps that don't opt into the feature don't pay for it.
+
+Apps that *do* mark sensitive fields pay a per-event cost that's bounded by the number of sensitive keys (1–3 typical): one `Object.keys` pass for the split, one for the gate, one for the strip. None of those routines allocate when there are no sensitive fields on the event.
+
+---
+
 ## Realistic workloads
 
 Run with `pnpm -F @rotorsoft/act bench:realistic`. These exercise the full pipeline real apps pay for: payload validation, invariant checking, multi-step workflows, reaction dispatch through `correlate→drain`, and projection updates. Numbers are not in the CI regression guard — they're for capacity planning.

--- a/libs/act/PERFORMANCE.md
+++ b/libs/act/PERFORMANCE.md
@@ -42,7 +42,7 @@ pnpm -F @rotorsoft/act bench:update    # writes perf-baseline.json
 
 ## Sensitive-data foundation (#855)
 
-The sensitive-data slices (#855) add machinery to every event that flows through the orchestrator — a `pii_fields(name)` registry lookup, `fields.length === 0` early-exit branches in `merge_for_reducer`/`gate_external`/`strip_for_handler`, and the gating path in `action()`'s post-commit snapshot builder. Events without `sensitive(...)` markers should pay nothing, but "should" needed measurement.
+The sensitive-data slices (#855) add machinery to every event that flows through the orchestrator — a `pii_fields(name)` registry lookup, `fields.length === 0` early-exit branches in `pii_merge`/`pii_gate`/`pii_strip`, and the gating path in `action()`'s post-commit snapshot builder. Events without `sensitive(...)` markers should pay nothing, but "should" needed measurement.
 
 `libs/act/bench/sensitive.micro.bench.ts` exercises the orchestrator's hot paths on a plain non-sensitive Counter — no `sensitive` markers, no `.discloses`, no `actor` arg on load. Ran the same bench on master (pre-#855) and on the merged #855 branch:
 

--- a/libs/act/bench/sensitive.micro.bench.ts
+++ b/libs/act/bench/sensitive.micro.bench.ts
@@ -3,7 +3,7 @@
  *
  * The sensitive-data foundation adds work to every event through the
  * orchestrator — `pii_fields(name)` registry lookup, `fields.length === 0`
- * early-exit branches in `merge_for_reducer`/`gate_external`/`strip_for_handler`,
+ * early-exit branches in `pii_merge`/`pii_gate`/`pii_strip`,
  * and the gating path in `action()`'s post-commit snapshot builder.
  *
  * For events with no `sensitive(...)` markers, every one of those checks

--- a/libs/act/bench/sensitive.micro.bench.ts
+++ b/libs/act/bench/sensitive.micro.bench.ts
@@ -1,266 +1,101 @@
 /**
- * #855: runtime cost of the sensitive-data foundation on regular workloads.
+ * #855: orchestrator overhead on non-sensitive workloads.
  *
- * Three axes:
+ * The sensitive-data foundation adds work to every event through the
+ * orchestrator — `pii_fields(name)` registry lookup, `fields.length === 0`
+ * early-exit branches in `merge_for_reducer`/`gate_external`/`strip_for_handler`,
+ * and the gating path in `action()`'s post-commit snapshot builder.
  *
- * 1. **Commit-path overhead** — `action()` splits sensitive fields off `data`
- *    into `pii` before calling `Store.commit`. Non-sensitive events
- *    short-circuit on `sensitive_fields(name).length === 0`. We compare:
- *      - baseline: action() committing a non-sensitive event
- *      - sensitive: action() committing an event with 2 sensitive fields
+ * For events with no `sensitive(...)` markers, every one of those checks
+ * should short-circuit immediately. This bench measures **whether the
+ * regular-event hot path actually pays nothing**. The workload uses a plain
+ * Counter — no sensitive markers anywhere, no `.discloses`, no `actor` arg on
+ * load.
  *
- * 2. **Load-path gate overhead** — `load()` builds the reducer view + the
- *    external view per event. Non-sensitive events short-circuit on the
- *    same field-list check. We compare:
- *      - baseline: load() over a stream of 100 non-sensitive events
- *      - sensitive: load() over a stream of 100 sensitive events with
- *        `.discloses(() => true)` (predicate fires per event)
- *
- * 3. **Handler-strip overhead** — `buildHandle` strips sensitive keys before
- *    invoking the user handler. Non-sensitive events short-circuit. We
- *    compare:
- *      - baseline: handler invocation on a non-sensitive event
- *      - sensitive: handler invocation on a sensitive event with 2 stripped
- *        keys
+ * Run this bench on master to get the **before** numbers, then on this
+ * branch (with the full PII machinery wired in) to get the **after**
+ * numbers. The delta tells you the orchestrator's added cost on real
+ * workloads that don't use the feature.
  *
  * Per CLAUDE.md: InMemory is a baseline reference, never the primary
- * production number. These benches measure orchestrator-level cost only —
- * `act-pg` adapter-level numbers belong in `libs/act-pg/bench/`.
- *
- * Results land in `libs/act/PERFORMANCE.md`.
+ * production number. These benches measure orchestrator-level cost only;
+ * adapter-level numbers belong in `libs/act-pg/bench/`.
  */
 
 /* eslint-disable @typescript-eslint/no-unsafe-argument -- bench helpers use any to avoid State name branding */
 import { afterAll, bench, describe } from "vitest";
 import { z } from "zod";
+import { act } from "../src/builders/act-builder.js";
 import { state } from "../src/builders/state-builder.js";
-import { action, load } from "../src/internal/event-sourcing.js";
-import { pii_fields, strip_for_handler } from "../src/internal/sensitive.js";
-import { dispose, store } from "../src/ports.js";
-import type { Actor, Committed } from "../src/types/index.js";
-import { sensitive } from "../src/types/schemas.js";
+import { dispose } from "../src/ports.js";
+import type { Actor } from "../src/types/index.js";
 
 const actor: Actor = { id: "u-1", name: "Bench" };
 
-// -- 1. Commit-path overhead -------------------------------------------------
-
-const NonPIIEvent = z.object({ by: z.number() });
 const Counter = state({ Counter: z.object({ count: z.number() }) })
   .init(() => ({ count: 0 }))
-  .emits({ Incremented: NonPIIEvent })
+  .emits({ Incremented: z.object({ by: z.number() }) })
   .patch({ Incremented: (event, s) => ({ count: s.count + event.data.by }) })
-  .on({ increment: NonPIIEvent })
-  .emit((a) => ["Incremented", a])
+  .on({ increment: z.object({ by: z.number() }) })
+  .emit((a) => ["Incremented", { by: a.by }])
   .build();
 
-const SensitiveEvent = z.object({
-  email: sensitive(z.string()),
-  name: sensitive(z.string()),
-  plan: z.enum(["free", "pro"]),
-});
-const SensitiveState = state({ Sensitive: z.object({}) })
-  .init(() => ({}))
-  .emits({ Registered: SensitiveEvent })
-  .patch({ Registered: () => ({}) })
-  .on({ register: SensitiveEvent })
-  .emit((p) => ["Registered", p])
-  .discloses(() => true)
-  .build();
-
-// pii_fields lookups: registry-cached versions
-const counter_lookup = (): readonly string[] => [];
-const sensitive_lookup = (name: string): readonly string[] =>
-  name === "Registered" ? ["email", "name"] : [];
-
-describe("commit-path: sensitive split overhead", () => {
-  let counter_stream = 0;
-  let sensitive_stream = 0;
+describe("orchestrator — non-sensitive workload (master vs PR baseline)", () => {
+  let stream_id = 0;
+  // biome-ignore lint/suspicious/noExplicitAny: bench-only, narrow generic preserved at runtime
+  let app: any;
 
   bench(
-    "baseline — non-sensitive event commit",
+    "app.do() — commit one Incremented per call",
     async () => {
-      await action(
-        Counter,
+      await app.do(
         "increment",
-        { stream: `c-${counter_stream++}`, actor },
-        { by: 1 },
-        undefined,
-        true,
-        undefined,
-        counter_lookup
+        { stream: `c-${stream_id++}`, actor },
+        { by: 1 }
       );
     },
     {
       setup: async () => {
         await dispose()();
-        counter_stream = 0;
+        app = act().withState(Counter).build();
+        stream_id = 0;
       },
     }
   );
 
   bench(
-    "sensitive — 2-field split + clean partition",
+    "app.load() — replay a 100-event stream",
     async () => {
-      await action(
-        SensitiveState,
-        "register",
-        { stream: `s-${sensitive_stream++}`, actor },
-        { email: "u@example.com", name: "Ursula", plan: "free" },
-        undefined,
-        true,
-        undefined,
-        sensitive_lookup
-      );
+      await app.load(Counter as any, "load-bench");
     },
     {
       setup: async () => {
         await dispose()();
-        sensitive_stream = 0;
-      },
-    }
-  );
-});
-
-// -- 2. Load-path gate overhead ----------------------------------------------
-
-const EVENTS_PER_STREAM = 100;
-
-describe("load-path: gate overhead over 100-event stream", () => {
-  bench(
-    "baseline — 100 non-sensitive events",
-    async () => {
-      await load(Counter, "load-baseline");
-    },
-    {
-      setup: async () => {
-        await dispose()();
-        for (let i = 0; i < EVENTS_PER_STREAM; i++) {
-          await action(
-            Counter,
-            "increment",
-            { stream: "load-baseline", actor },
-            { by: 1 },
-            undefined,
-            true,
-            undefined,
-            counter_lookup
-          );
+        app = act().withState(Counter).build();
+        for (let i = 0; i < 100; i++) {
+          await app.do("increment", { stream: "load-bench", actor }, { by: 1 });
         }
       },
     }
   );
 
   bench(
-    "sensitive — 100 sensitive events, discloses() => true (per-event predicate + merge)",
+    "app.do() then app.load() — round-trip per call",
     async () => {
-      await load(
-        SensitiveState,
-        "load-sensitive",
-        undefined,
-        undefined,
-        actor,
-        sensitive_lookup
-      );
+      const stream = `rt-${stream_id++}`;
+      await app.do("increment", { stream, actor }, { by: 1 });
+      await app.load(Counter as any, stream);
     },
     {
       setup: async () => {
         await dispose()();
-        for (let i = 0; i < EVENTS_PER_STREAM; i++) {
-          await action(
-            SensitiveState,
-            "register",
-            { stream: "load-sensitive", actor },
-            { email: `u${i}@example.com`, name: `User${i}`, plan: "free" },
-            undefined,
-            true,
-            undefined,
-            sensitive_lookup
-          );
-        }
+        app = act().withState(Counter).build();
+        stream_id = 0;
       },
     }
   );
 });
 
-// -- 3. Handler-strip overhead -----------------------------------------------
-
-describe("handler dispatch: strip overhead", () => {
-  // Build representative events directly so the bench measures only strip cost
-  // (not commit + queue). The Committed shape matches what the drain pipeline
-  // passes to handlers.
-  const counter_event: Committed<
-    { Incremented: { by: number } },
-    "Incremented"
-  > = {
-    id: 0,
-    stream: "c-1",
-    version: 0,
-    created: new Date(),
-    name: "Incremented",
-    data: { by: 1 },
-    meta: { correlation: "x", causation: {} },
-  };
-
-  const sensitive_event: Committed<
-    { Registered: { email: string; name: string; plan: "free" | "pro" } },
-    "Registered"
-  > = {
-    id: 0,
-    stream: "s-1",
-    version: 0,
-    created: new Date(),
-    name: "Registered",
-    data: { email: "u@example.com", name: "Ursula", plan: "free" },
-    pii: { email: "u@example.com", name: "Ursula" },
-    meta: { correlation: "x", causation: {} },
-  };
-
-  bench("baseline — non-sensitive event (short-circuit)", () => {
-    strip_for_handler(counter_event, []);
-  });
-
-  bench("sensitive — strip 2 keys + drop pii field", () => {
-    strip_for_handler(sensitive_event, ["email", "name"]);
-  });
-});
-
-// -- 4. Walker overhead at build time ----------------------------------------
-
-// Pre-build the large schema OUTSIDE the bench loop so we measure walker
-// cost, not Zod object construction.
-const LargeSchema = z.object({
-  a: z.string(),
-  b: z.number(),
-  c: sensitive(z.string()),
-  d: z.boolean(),
-  e: sensitive(z.string()),
-  f: z.string(),
-  g: z.number(),
-  h: sensitive(z.string()),
-  i: z.string(),
-  j: z.number(),
-  k: sensitive(z.string()),
-  l: z.string(),
-});
-
-describe("build time: pii_fields walker per event schema", () => {
-  bench("non-sensitive schema (1 field, none marked)", () => {
-    pii_fields(NonPIIEvent);
-  });
-
-  bench("sensitive schema (3 fields, 2 marked)", () => {
-    pii_fields(SensitiveEvent);
-  });
-
-  bench("large schema (12 fields, 4 marked)", () => {
-    pii_fields(LargeSchema);
-  });
-});
-
-// Cleanup at module teardown — Vitest invokes setup once per iteration
-// group, so a single dispose at the end keeps process state clean for the
-// next bench module.
 afterAll(async () => {
   await dispose()();
-  store();
 });

--- a/libs/act/bench/sensitive.micro.bench.ts
+++ b/libs/act/bench/sensitive.micro.bench.ts
@@ -1,0 +1,266 @@
+/**
+ * #855: runtime cost of the sensitive-data foundation on regular workloads.
+ *
+ * Three axes:
+ *
+ * 1. **Commit-path overhead** — `action()` splits sensitive fields off `data`
+ *    into `pii` before calling `Store.commit`. Non-sensitive events
+ *    short-circuit on `sensitive_fields(name).length === 0`. We compare:
+ *      - baseline: action() committing a non-sensitive event
+ *      - sensitive: action() committing an event with 2 sensitive fields
+ *
+ * 2. **Load-path gate overhead** — `load()` builds the reducer view + the
+ *    external view per event. Non-sensitive events short-circuit on the
+ *    same field-list check. We compare:
+ *      - baseline: load() over a stream of 100 non-sensitive events
+ *      - sensitive: load() over a stream of 100 sensitive events with
+ *        `.discloses(() => true)` (predicate fires per event)
+ *
+ * 3. **Handler-strip overhead** — `buildHandle` strips sensitive keys before
+ *    invoking the user handler. Non-sensitive events short-circuit. We
+ *    compare:
+ *      - baseline: handler invocation on a non-sensitive event
+ *      - sensitive: handler invocation on a sensitive event with 2 stripped
+ *        keys
+ *
+ * Per CLAUDE.md: InMemory is a baseline reference, never the primary
+ * production number. These benches measure orchestrator-level cost only —
+ * `act-pg` adapter-level numbers belong in `libs/act-pg/bench/`.
+ *
+ * Results land in `libs/act/PERFORMANCE.md`.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-argument -- bench helpers use any to avoid State name branding */
+import { afterAll, bench, describe } from "vitest";
+import { z } from "zod";
+import { state } from "../src/builders/state-builder.js";
+import { action, load } from "../src/internal/event-sourcing.js";
+import { pii_fields, strip_for_handler } from "../src/internal/sensitive.js";
+import { dispose, store } from "../src/ports.js";
+import type { Actor, Committed } from "../src/types/index.js";
+import { sensitive } from "../src/types/schemas.js";
+
+const actor: Actor = { id: "u-1", name: "Bench" };
+
+// -- 1. Commit-path overhead -------------------------------------------------
+
+const NonPIIEvent = z.object({ by: z.number() });
+const Counter = state({ Counter: z.object({ count: z.number() }) })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: NonPIIEvent })
+  .patch({ Incremented: (event, s) => ({ count: s.count + event.data.by }) })
+  .on({ increment: NonPIIEvent })
+  .emit((a) => ["Incremented", a])
+  .build();
+
+const SensitiveEvent = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+  plan: z.enum(["free", "pro"]),
+});
+const SensitiveState = state({ Sensitive: z.object({}) })
+  .init(() => ({}))
+  .emits({ Registered: SensitiveEvent })
+  .patch({ Registered: () => ({}) })
+  .on({ register: SensitiveEvent })
+  .emit((p) => ["Registered", p])
+  .discloses(() => true)
+  .build();
+
+// pii_fields lookups: registry-cached versions
+const counter_lookup = (): readonly string[] => [];
+const sensitive_lookup = (name: string): readonly string[] =>
+  name === "Registered" ? ["email", "name"] : [];
+
+describe("commit-path: sensitive split overhead", () => {
+  let counter_stream = 0;
+  let sensitive_stream = 0;
+
+  bench(
+    "baseline — non-sensitive event commit",
+    async () => {
+      await action(
+        Counter,
+        "increment",
+        { stream: `c-${counter_stream++}`, actor },
+        { by: 1 },
+        undefined,
+        true,
+        undefined,
+        counter_lookup
+      );
+    },
+    {
+      setup: async () => {
+        await dispose()();
+        counter_stream = 0;
+      },
+    }
+  );
+
+  bench(
+    "sensitive — 2-field split + clean partition",
+    async () => {
+      await action(
+        SensitiveState,
+        "register",
+        { stream: `s-${sensitive_stream++}`, actor },
+        { email: "u@example.com", name: "Ursula", plan: "free" },
+        undefined,
+        true,
+        undefined,
+        sensitive_lookup
+      );
+    },
+    {
+      setup: async () => {
+        await dispose()();
+        sensitive_stream = 0;
+      },
+    }
+  );
+});
+
+// -- 2. Load-path gate overhead ----------------------------------------------
+
+const EVENTS_PER_STREAM = 100;
+
+describe("load-path: gate overhead over 100-event stream", () => {
+  bench(
+    "baseline — 100 non-sensitive events",
+    async () => {
+      await load(Counter, "load-baseline");
+    },
+    {
+      setup: async () => {
+        await dispose()();
+        for (let i = 0; i < EVENTS_PER_STREAM; i++) {
+          await action(
+            Counter,
+            "increment",
+            { stream: "load-baseline", actor },
+            { by: 1 },
+            undefined,
+            true,
+            undefined,
+            counter_lookup
+          );
+        }
+      },
+    }
+  );
+
+  bench(
+    "sensitive — 100 sensitive events, discloses() => true (per-event predicate + merge)",
+    async () => {
+      await load(
+        SensitiveState,
+        "load-sensitive",
+        undefined,
+        undefined,
+        actor,
+        sensitive_lookup
+      );
+    },
+    {
+      setup: async () => {
+        await dispose()();
+        for (let i = 0; i < EVENTS_PER_STREAM; i++) {
+          await action(
+            SensitiveState,
+            "register",
+            { stream: "load-sensitive", actor },
+            { email: `u${i}@example.com`, name: `User${i}`, plan: "free" },
+            undefined,
+            true,
+            undefined,
+            sensitive_lookup
+          );
+        }
+      },
+    }
+  );
+});
+
+// -- 3. Handler-strip overhead -----------------------------------------------
+
+describe("handler dispatch: strip overhead", () => {
+  // Build representative events directly so the bench measures only strip cost
+  // (not commit + queue). The Committed shape matches what the drain pipeline
+  // passes to handlers.
+  const counter_event: Committed<
+    { Incremented: { by: number } },
+    "Incremented"
+  > = {
+    id: 0,
+    stream: "c-1",
+    version: 0,
+    created: new Date(),
+    name: "Incremented",
+    data: { by: 1 },
+    meta: { correlation: "x", causation: {} },
+  };
+
+  const sensitive_event: Committed<
+    { Registered: { email: string; name: string; plan: "free" | "pro" } },
+    "Registered"
+  > = {
+    id: 0,
+    stream: "s-1",
+    version: 0,
+    created: new Date(),
+    name: "Registered",
+    data: { email: "u@example.com", name: "Ursula", plan: "free" },
+    pii: { email: "u@example.com", name: "Ursula" },
+    meta: { correlation: "x", causation: {} },
+  };
+
+  bench("baseline — non-sensitive event (short-circuit)", () => {
+    strip_for_handler(counter_event, []);
+  });
+
+  bench("sensitive — strip 2 keys + drop pii field", () => {
+    strip_for_handler(sensitive_event, ["email", "name"]);
+  });
+});
+
+// -- 4. Walker overhead at build time ----------------------------------------
+
+// Pre-build the large schema OUTSIDE the bench loop so we measure walker
+// cost, not Zod object construction.
+const LargeSchema = z.object({
+  a: z.string(),
+  b: z.number(),
+  c: sensitive(z.string()),
+  d: z.boolean(),
+  e: sensitive(z.string()),
+  f: z.string(),
+  g: z.number(),
+  h: sensitive(z.string()),
+  i: z.string(),
+  j: z.number(),
+  k: sensitive(z.string()),
+  l: z.string(),
+});
+
+describe("build time: pii_fields walker per event schema", () => {
+  bench("non-sensitive schema (1 field, none marked)", () => {
+    pii_fields(NonPIIEvent);
+  });
+
+  bench("sensitive schema (3 fields, 2 marked)", () => {
+    pii_fields(SensitiveEvent);
+  });
+
+  bench("large schema (12 fields, 4 marked)", () => {
+    pii_fields(LargeSchema);
+  });
+});
+
+// Cleanup at module teardown — Vitest invokes setup once per iteration
+// group, so a single dispose at the end keeps process state clean for the
+// next bench module.
+afterAll(async () => {
+  await dispose()();
+  store();
+});

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -735,19 +735,22 @@ export class Act<
     state: State<TNewState, TNewEvents, TNewActions>,
     stream: string,
     callback?: (snapshot: Snapshot<TNewState, TNewEvents>) => void,
-    asOf?: AsOf
+    asOf?: AsOf,
+    actor?: Actor
   ): Promise<Snapshot<TNewState, TNewEvents>>;
   async load<TKey extends keyof TStateMap & string>(
     name: TKey,
     stream: string,
     callback?: (snapshot: Snapshot<TStateMap[TKey], TEvents>) => void,
-    asOf?: AsOf
+    asOf?: AsOf,
+    actor?: Actor
   ): Promise<Snapshot<TStateMap[TKey], TEvents>>;
   async load<TNewState extends Schema>(
     stateOrName: State<TNewState, any, any> | string,
     stream: string,
     callback?: (snapshot: Snapshot<any, any>) => void,
-    asOf?: AsOf
+    asOf?: AsOf,
+    actor?: Actor
   ): Promise<Snapshot<any, any>> {
     return this._scoped(async () => {
       let merged: State<any, any, any>;
@@ -758,7 +761,9 @@ export class Act<
       } else {
         merged = this._states.get(stateOrName.name) || stateOrName;
       }
-      return await this._es.load(merged, stream, callback, asOf);
+      // When `actor` is omitted the read default-denies — sensitive fields
+      // come back as [REDACTED] regardless of any `.discloses` predicate.
+      return await this._es.load(merged, stream, callback, asOf, actor);
     });
   }
 

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -21,7 +21,7 @@ import {
   SettleLoop,
   scan,
 } from "./internal/index.js";
-import { dispose, log, type Scoped, scoped, store } from "./ports.js";
+import { cache, dispose, log, type Scoped, scoped, store } from "./ports.js";
 import type {
   Actor,
   AsOf,
@@ -129,6 +129,18 @@ export type ActLifecycleEvents<
    * cross-process semantic.
    */
   notified: StoreNotification;
+  /**
+   * A stream's sensitive-data payload was wiped via {@link Act.forget}.
+   * Fires exactly once per successful `forget(stream)` call — idempotent
+   * second calls (no PII left on the stream) return `eventCount: 0` and
+   * do NOT re-emit. Apps that never call `forget()` never see this event.
+   *
+   * Listeners use it for the compliance side of GDPR / CCPA: audit log,
+   * downstream cache busts, projection-side wipes that the framework
+   * doesn't reach (e.g., search indexes, ETL caches). The framework's own
+   * cache is invalidated by `forget()` itself before the event fires.
+   */
+  forgotten: { stream: string; at: Date; eventCount: number };
 };
 
 /**
@@ -319,6 +331,7 @@ export class Act<
   private readonly _bound_load = this.load.bind(this);
   private readonly _bound_query = this.query.bind(this);
   private readonly _bound_query_array = this.query_array.bind(this);
+  private readonly _bound_forget = this.forget.bind(this);
   /** Reaction dispatchers built once and handed to runDrainCycle each cycle. */
   private readonly _handle: Handle<TEvents>;
   private readonly _handle_batch: HandleBatch<TEvents>;
@@ -380,10 +393,11 @@ export class Act<
     this._cd = buildDrain<TEvents>(this._logger);
     this._handle = buildHandle<TEvents, TActions, TActor>({
       logger: this._logger,
-      boundDo: this._bound_do,
-      boundLoad: this._bound_load,
-      boundQuery: this._bound_query,
-      boundQueryArray: this._bound_query_array,
+      bound_do: this._bound_do,
+      bound_load: this._bound_load,
+      bound_query: this._bound_query,
+      bound_query_array: this._bound_query_array,
+      bound_forget: this._bound_forget,
       pii_fields: this.registry.sensitive_fields,
     });
     this._handle_batch = buildHandleBatch<TEvents>(
@@ -870,6 +884,36 @@ export class Act<
       const events: Committed<TEvents, keyof TEvents>[] = [];
       await store().query<TEvents>((e) => events.push(e), query);
       return events;
+    });
+  }
+
+  /**
+   * Wipe the sensitive-data payload for every event on the stream — see
+   * {@link IAct.forget}. Application-level half of #566.
+   *
+   * Throws on adapters without `Store.forget_pii`, invalidates the cache
+   * entry for the stream, emits the `forgotten` lifecycle event with the
+   * row count. Idempotent: a second call returns `{eventCount: 0}` and
+   * does NOT re-emit.
+   *
+   * @param stream - Target stream.
+   * @returns `{eventCount}` — number of events whose PII column was wiped.
+   */
+  async forget(stream: string): Promise<{ eventCount: number }> {
+    return this._scoped(async () => {
+      const s = store();
+      if (!s.forget_pii) {
+        throw new Error(
+          `Store does not implement forget_pii — adapter cannot comply with sensitive-data erasure. ` +
+            `Use an adapter that declares pii_isolation: true (e.g. @rotorsoft/act on the in-memory store).`
+        );
+      }
+      const eventCount = await s.forget_pii(stream);
+      await cache().invalidate(stream);
+      if (eventCount > 0) {
+        this.emit("forgotten", { stream, at: new Date(), eventCount });
+      }
+      return { eventCount };
     });
   }
 

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -385,12 +385,12 @@ export class Act<
       ? (fn) => scoped.run(options.scoped!, fn)
       : (fn) => fn();
     this._correlator = options.correlator ?? defaultCorrelator;
-    this._es = buildEs(
-      this._logger,
-      this._correlator,
-      this.registry.sensitive_fields
-    );
+    this._es = buildEs(this._logger, this._correlator);
     this._cd = buildDrain<TEvents>(this._logger);
+    // Reaction-level PII wrapping happens at build time inside `act-builder`:
+    // reactions registered against an event with `sensitive(...)` fields get
+    // a stripping handler closure; reactions against non-PII events keep
+    // their original handler reference. So the dispatcher is PII-unaware.
     this._handle = buildHandle<TEvents, TActions, TActor>({
       logger: this._logger,
       bound_do: this._bound_do,
@@ -398,12 +398,8 @@ export class Act<
       bound_query: this._bound_query,
       bound_query_array: this._bound_query_array,
       bound_forget: this._bound_forget,
-      pii_fields: this.registry.sensitive_fields,
     });
-    this._handle_batch = buildHandleBatch<TEvents>(
-      this._logger,
-      this.registry.sensitive_fields
-    );
+    this._handle_batch = buildHandleBatch<TEvents>(this._logger);
 
     const {
       staticTargets,

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -372,7 +372,11 @@ export class Act<
       ? (fn) => scoped.run(options.scoped!, fn)
       : (fn) => fn();
     this._correlator = options.correlator ?? defaultCorrelator;
-    this._es = buildEs(this._logger, this._correlator);
+    this._es = buildEs(
+      this._logger,
+      this._correlator,
+      this.registry.sensitive_fields
+    );
     this._cd = buildDrain<TEvents>(this._logger);
     this._handle = buildHandle<TEvents, TActions, TActor>({
       logger: this._logger,

--- a/libs/act/src/act.ts
+++ b/libs/act/src/act.ts
@@ -384,8 +384,12 @@ export class Act<
       boundLoad: this._bound_load,
       boundQuery: this._bound_query,
       boundQueryArray: this._bound_query_array,
+      pii_fields: this.registry.sensitive_fields,
     });
-    this._handle_batch = buildHandleBatch<TEvents>(this._logger);
+    this._handle_batch = buildHandleBatch<TEvents>(
+      this._logger,
+      this.registry.sensitive_fields
+    );
 
     const {
       staticTargets,

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -9,10 +9,14 @@ import {
   _this_,
   currentVersionOf,
   deprecatedEventNames,
+  gate_external,
+  merge_for_reducer,
   mergeEventRegister,
   mergeProjection,
   pii_fields,
   registerState,
+  split_payload,
+  strip_for_handler,
 } from "../internal/index.js";
 import { DEFAULT_LANE, log } from "../ports.js";
 import type {
@@ -565,6 +569,77 @@ export function act<
                   "Remove .snap() or remove sensitive(...) markers."
               );
             }
+          }
+          // Wrap reaction handlers whose triggering event has sensitive
+          // fields (#855). Done once at build time per registered reaction —
+          // `buildHandle` itself stays PII-unaware. Reactions for non-PII
+          // events keep their original handler reference unchanged.
+          for (const [eventName, reg] of Object.entries(
+            registry.events as Record<
+              string,
+              { reactions: Map<string, { handler: any }> }
+            >
+          )) {
+            const fields = _sf.get(eventName);
+            if (!fields) continue;
+            for (const [name, reaction] of reg.reactions) {
+              const inner = reaction.handler;
+              const wrapped = (event: any, stream: string, app: any) =>
+                inner(strip_for_handler(event, fields), stream, app);
+              // Preserve handler.name — buildHandle asserts on named functions.
+              Object.defineProperty(wrapped, "name", { value: inner.name });
+              reaction.handler = wrapped;
+              reg.reactions.set(name, reaction as never);
+            }
+          }
+          // Same idea for batch projections — wrap once at build time so the
+          // batch dispatcher stays PII-unaware. Sensitive events get stripped
+          // per event inside the wrap (the batch may mix sensitive and
+          // non-sensitive event types). When `_sf` is empty the inner Map.get
+          // returns undefined for every event and the wrap is identity — but
+          // we only enter the loop when there are batch handlers, and the
+          // wrap itself is a one-time build cost, so leaving the wrap on
+          // unconditionally avoids a redundant outer guard.
+          for (const [target, original] of batchHandlers) {
+            const wrapped = async (events: any[], stream: string) => {
+              const stripped = events.map((e) => {
+                const f = _sf.get(e.name as string);
+                return f ? strip_for_handler(e, f) : e;
+              });
+              return original(stripped as never, stream);
+            };
+            batchHandlers.set(target, wrapped as never);
+          }
+          // Attach the per-state PII decorators (#855). States with at least
+          // one sensitive event get three closures bound over the per-event
+          // field list + the disclosure predicate; states without sensitive
+          // events get nothing attached so the orchestrator's hot path
+          // short-circuits at `me._x?.(arg) ?? arg` with zero work.
+          for (const state of states.values()) {
+            const fields_by_event = new Map<string, readonly string[]>();
+            for (const eventName of Object.keys(state.events)) {
+              const fields = _sf.get(eventName);
+              if (fields) fields_by_event.set(eventName, fields);
+            }
+            if (fields_by_event.size === 0) continue;
+            const disclose = state.disclose ?? null;
+            state._split_emitted = (e) => {
+              const fields = fields_by_event.get(e.name as string);
+              if (!fields) return e;
+              return split_payload(e, fields) as typeof e & {
+                pii: Record<string, unknown>;
+              };
+            };
+            state._merge_for_reducer = (event) => {
+              const fields = fields_by_event.get(event.name as string);
+              if (!fields) return event;
+              return merge_for_reducer(event, fields);
+            };
+            state._gate_external = (event, actor) => {
+              const fields = fields_by_event.get(event.name as string);
+              if (!fields) return event;
+              return gate_external(event, fields, disclose, actor);
+            };
           }
           _built = true;
         }

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -540,48 +540,46 @@ export function act<
           // Precompute the sensitive-field lookup. Iterates each registered
           // event's Zod schema exactly once at build; later commit/load paths
           // hit the cache in O(1). Events with no sensitive fields don't get
-          // an entry — registry.sensitive_fields returns the empty array.
-          for (const [eventName, reg] of Object.entries(
-            registry.events as Record<string, { schema: import("zod").ZodType }>
-          )) {
-            const fields = pii_fields(reg.schema);
-            if (fields.length > 0) _sf.set(eventName, fields);
-          }
-          // Snapshot the per-state disclosure predicates.
-          for (const state of states.values()) {
-            if (state.disclose) _dp.set(state.name, state.disclose);
-          }
-          // Reject snapshot policies on sensitive-bearing states (#855).
-          // Snapshots write derived state into `__snapshot__.data`, which
-          // `forget_pii` cannot reach. Caught at build so the misconfiguration
-          // surfaces in dev/CI, not as a silent leak past the GDPR boundary
-          // months later.
-          for (const state of states.values()) {
-            if (!state.snap) continue;
-            const offending: string[] = [];
-            for (const eventName of Object.keys(state.events)) {
-              if (_sf.has(eventName)) offending.push(eventName);
-            }
-            if (offending.length > 0) {
-              throw new Error(
-                `State "${state.name}" cannot snapshot — events {${offending.join(", ")}} carry sensitive fields. ` +
-                  "Snapshots write derived state into __snapshot__.data, which forget_pii cannot reach. " +
-                  "Remove .snap() or remove sensitive(...) markers."
-              );
-            }
-          }
-          // Wrap reaction handlers whose triggering event has sensitive
-          // fields (#855). Done once at build time per registered reaction —
-          // `buildHandle` itself stays PII-unaware. Reactions for non-PII
-          // events keep their original handler reference unchanged.
+          // Build the sensitive-data wiring in three passes (#855):
+          //
+          // - events pass: precompute the sensitive-field lookup `_sf` from
+          //   each event's Zod schema; while we're already walking events,
+          //   wrap their registered reaction handlers so `buildHandle`
+          //   stays PII-unaware.
+          // - states pass: snapshot the disclosure predicates into `_dp`,
+          //   reject `.snap()` on sensitive-bearing states, and build the
+          //   per-state step delegates the orchestrator calls (`me.view`,
+          //   `me.message`, wrapped `me.patch[name]`).
+          // - batchHandlers pass: wrap each batch handler so the batch
+          //   dispatcher stays PII-unaware.
+          //
+          // The orchestrator calls three step delegates per event:
+          //   - `me.message(validated)` — produces the commit-bound shape
+          //     (`{name, data, pii?}`) from a validated emit.
+          //   - `me.patch[eventName](event, state)` — the reducer that
+          //     derives the next state from the committed event.
+          //   - `me.view(event, actor)` — produces the caller-visible form
+          //     (snapshot.event).
+          //
+          // For PII-free states (the common case) `view` and `message` are
+          // bound to identity in `state-builder.ts` and `patch` is the
+          // user-declared reducer; the orchestrator's hot path is identical
+          // to the pre-#855 code at runtime. For PII-aware states (≥1
+          // `sensitive(...)` event), each delegate is rebound to fold the
+          // gate / split / merge into the step itself.
           for (const [eventName, reg] of Object.entries(
             registry.events as Record<
               string,
-              { reactions: Map<string, { handler: any }> }
+              {
+                schema: import("zod").ZodType;
+                reactions: Map<string, { handler: any }>;
+              }
             >
           )) {
-            const fields = _sf.get(eventName);
-            if (!fields) continue;
+            const fields = pii_fields(reg.schema);
+            if (fields.length === 0) continue;
+            _sf.set(eventName, fields);
+            // Strip PII from the event payload before reactions see it.
             for (const [name, reaction] of reg.reactions) {
               const inner = reaction.handler;
               const wrapped = (event: any, stream: string, app: any) =>
@@ -592,62 +590,26 @@ export function act<
               reg.reactions.set(name, reaction as never);
             }
           }
-          // Same idea for batch projections — wrap once at build time so the
-          // batch dispatcher stays PII-unaware. Sensitive events get stripped
-          // per event inside the wrap (the batch may mix sensitive and
-          // non-sensitive event types). When `_sf` is empty the inner Map.get
-          // returns undefined for every event and the wrap is identity — but
-          // we only enter the loop when there are batch handlers, and the
-          // wrap itself is a one-time build cost, so leaving the wrap on
-          // unconditionally avoids a redundant outer guard.
-          for (const [target, original] of batchHandlers) {
-            const wrapped = async (events: any[], stream: string) => {
-              const stripped = events.map((e) => {
-                const f = _sf.get(e.name as string);
-                return f ? pii_strip(e, f) : e;
-              });
-              return original(stripped as never, stream);
-            };
-            batchHandlers.set(target, wrapped as never);
-          }
-          // Build the per-state step delegates (#855).
-          //
-          // The orchestrator calls three step delegates per event:
-          //   - `me.message(validated)` — produces the commit-bound
-          //     `{name, data, pii?}` from a validated emit. Called once
-          //     per emitted event in `action()` before `Store.commit`.
-          //   - `me.patch[eventName](event, state)` — the reducer that
-          //     derives the next state from the committed event. Called
-          //     during load() replay and action()'s post-commit fold.
-          //   - `me.view(event, actor)` — produces the caller-visible
-          //     form of a committed event (snapshot.event). Called in
-          //     load() and action()'s snapshot builder.
-          //
-          // For PII-free states (the common case) `view` and `message`
-          // are bound to identity in `state-builder.ts` and `patch` is
-          // the user-declared reducer; the orchestrator's hot path is
-          // identical to the pre-#855 code at runtime.
-          //
-          // For PII-aware states (at least one `sensitive(...)` event)
-          // each delegate is rebound here to bake the PII work into the
-          // step itself: `view` gates per `.discloses`, `message` peels
-          // sensitive fields off `data` into `pii`, and each per-event
-          // `patch[eventName]` for a sensitive event is wrapped to merge
-          // PII back into `data` before the user's reducer sees it.
           for (const state of states.values()) {
+            if (state.disclose) _dp.set(state.name, state.disclose);
             const fields_by_event = new Map<string, readonly string[]>();
             for (const eventName of Object.keys(state.events)) {
               const fields = _sf.get(eventName);
               if (fields) fields_by_event.set(eventName, fields);
             }
-            if (fields_by_event.size === 0) {
-              // Pure state — `view` and `message` are identity, `patch`
-              // is the user's reducer as-declared.
-              state.view = (event) => event;
-              state.message = (validated) => validated;
-              continue;
+            if (fields_by_event.size === 0) continue; // pure — keep state-builder defaults
+            // Snapshots write derived state into `__snapshot__.data`, which
+            // `forget_pii` cannot reach. Reject the combination at build so
+            // the misconfiguration surfaces in dev/CI, not as a silent leak
+            // past the GDPR boundary months later.
+            if (state.snap) {
+              const offending = [...fields_by_event.keys()];
+              throw new Error(
+                `State "${state.name}" cannot snapshot — events {${offending.join(", ")}} carry sensitive fields. ` +
+                  "Snapshots write derived state into __snapshot__.data, which forget_pii cannot reach. " +
+                  "Remove .snap() or remove sensitive(...) markers."
+              );
             }
-            // PII-aware state — bake PII work into each step delegate.
             const disclose = state.disclose ?? null;
             state.view = (event, actor) => {
               const fields = fields_by_event.get(event.name as string);
@@ -657,16 +619,24 @@ export function act<
               const fields = fields_by_event.get(validated.name as string);
               return fields ? pii_split(validated, fields) : validated;
             };
-            // Wrap the per-event reducer to merge PII before the user's
-            // patch sees it. Plain reducers (for non-sensitive events on
-            // this state) stay unwrapped. `state-builder` guarantees a
-            // passthrough reducer for every declared event, so the lookup
-            // is never undefined here.
+            // `state-builder` guarantees a passthrough reducer per declared
+            // event, so the lookup is never undefined here. Plain reducers
+            // (for this state's non-sensitive events) stay unwrapped.
             for (const [eventName, fields] of fields_by_event) {
               const original = state.patch[eventName];
               state.patch[eventName] = (event, s) =>
                 original(pii_merge(event, fields), s);
             }
+          }
+          for (const [target, original] of batchHandlers) {
+            const wrapped = async (events: any[], stream: string) => {
+              const stripped = events.map((e) => {
+                const f = _sf.get(e.name as string);
+                return f ? pii_strip(e, f) : e;
+              });
+              return original(stripped as never, stream);
+            };
+            batchHandlers.set(target, wrapped as never);
           }
           _built = true;
         }

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -547,6 +547,25 @@ export function act<
           for (const state of states.values()) {
             if (state.disclose) _dp.set(state.name, state.disclose);
           }
+          // Reject snapshot policies on sensitive-bearing states (#855).
+          // Snapshots write derived state into `__snapshot__.data`, which
+          // `forget_pii` cannot reach. Caught at build so the misconfiguration
+          // surfaces in dev/CI, not as a silent leak past the GDPR boundary
+          // months later.
+          for (const state of states.values()) {
+            if (!state.snap) continue;
+            const offending: string[] = [];
+            for (const eventName of Object.keys(state.events)) {
+              if (_sf.has(eventName)) offending.push(eventName);
+            }
+            if (offending.length > 0) {
+              throw new Error(
+                `State "${state.name}" cannot snapshot — events {${offending.join(", ")}} carry sensitive fields. ` +
+                  "Snapshots write derived state into __snapshot__.data, which forget_pii cannot reach. " +
+                  "Remove .snap() or remove sensitive(...) markers."
+              );
+            }
+          }
           _built = true;
         }
 

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -14,6 +14,7 @@ import {
   registerState,
 } from "../internal/index.js";
 import { DEFAULT_LANE, log } from "../ports.js";
+import { getSensitiveFields } from "../sensitive.js";
 import type {
   Actor,
   BatchHandler,
@@ -347,9 +348,20 @@ export function act<
   // same builder cast to the widened generic; type fanout is preserved
   // through the public type signatures, runtime allocation is not.
   const states = new Map<string, State<any, any, any>>();
+  // Caches behind registry.sensitive_fields / registry.disclosure_predicate.
+  // Populated by finalize_sensitive_lookups() on the first .build() call.
+  const sensitive_fields_cache = new Map<string, readonly string[]>();
+  const disclosure_predicate_cache = new Map<
+    string,
+    (event: any, actor: Actor) => boolean
+  >();
   const registry: Registry<TSchemaReg, TEvents, TActions> = {
     actions: {} as Registry<TSchemaReg, TEvents, TActions>["actions"],
     events: {} as Registry<TSchemaReg, TEvents, TActions>["events"],
+    sensitive_fields: (eventName) =>
+      sensitive_fields_cache.get(eventName) ?? [],
+    disclosure_predicate: (stateName) =>
+      disclosure_predicate_cache.get(stateName) ?? null,
   };
   const pendingProjections: Projection<any>[] = [];
   const batchHandlers = new Map<string, BatchHandler<any>>();
@@ -526,6 +538,22 @@ export function act<
           }
           finalizeDeprecations();
           validateLaneReferences(registry, lanes);
+          // Precompute the sensitive-field lookup. Iterates each registered
+          // event's Zod schema exactly once at build; later commit/load paths
+          // hit the cache in O(1). Events with no sensitive fields don't get
+          // an entry — registry.sensitive_fields returns the empty array.
+          for (const [eventName, reg] of Object.entries(
+            registry.events as Record<string, { schema: import("zod").ZodType }>
+          )) {
+            const fields = getSensitiveFields(reg.schema);
+            if (fields.length > 0)
+              sensitive_fields_cache.set(eventName, fields);
+          }
+          // Snapshot the per-state disclosure predicates.
+          for (const state of states.values()) {
+            if (state.disclose)
+              disclosure_predicate_cache.set(state.name, state.disclose);
+          }
           _built = true;
         }
 

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -11,10 +11,10 @@ import {
   deprecatedEventNames,
   mergeEventRegister,
   mergeProjection,
+  pii_fields,
   registerState,
 } from "../internal/index.js";
 import { DEFAULT_LANE, log } from "../ports.js";
-import { pii_fields } from "../sensitive.js";
 import type {
   Actor,
   BatchHandler,

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -14,7 +14,7 @@ import {
   registerState,
 } from "../internal/index.js";
 import { DEFAULT_LANE, log } from "../ports.js";
-import { getSensitiveFields } from "../sensitive.js";
+import { pii_fields } from "../sensitive.js";
 import type {
   Actor,
   BatchHandler,
@@ -349,19 +349,14 @@ export function act<
   // through the public type signatures, runtime allocation is not.
   const states = new Map<string, State<any, any, any>>();
   // Caches behind registry.sensitive_fields / registry.disclosure_predicate.
-  // Populated by finalize_sensitive_lookups() on the first .build() call.
-  const sensitive_fields_cache = new Map<string, readonly string[]>();
-  const disclosure_predicate_cache = new Map<
-    string,
-    (event: any, actor: Actor) => boolean
-  >();
+  // Populated on the first .build() call.
+  const _sf = new Map<string, readonly string[]>();
+  const _dp = new Map<string, (event: any, actor: Actor) => boolean>();
   const registry: Registry<TSchemaReg, TEvents, TActions> = {
     actions: {} as Registry<TSchemaReg, TEvents, TActions>["actions"],
     events: {} as Registry<TSchemaReg, TEvents, TActions>["events"],
-    sensitive_fields: (eventName) =>
-      sensitive_fields_cache.get(eventName) ?? [],
-    disclosure_predicate: (stateName) =>
-      disclosure_predicate_cache.get(stateName) ?? null,
+    sensitive_fields: (eventName) => _sf.get(eventName) ?? [],
+    disclosure_predicate: (stateName) => _dp.get(stateName) ?? null,
   };
   const pendingProjections: Projection<any>[] = [];
   const batchHandlers = new Map<string, BatchHandler<any>>();
@@ -545,14 +540,12 @@ export function act<
           for (const [eventName, reg] of Object.entries(
             registry.events as Record<string, { schema: import("zod").ZodType }>
           )) {
-            const fields = getSensitiveFields(reg.schema);
-            if (fields.length > 0)
-              sensitive_fields_cache.set(eventName, fields);
+            const fields = pii_fields(reg.schema);
+            if (fields.length > 0) _sf.set(eventName, fields);
           }
           // Snapshot the per-state disclosure predicates.
           for (const state of states.values()) {
-            if (state.disclose)
-              disclosure_predicate_cache.set(state.name, state.disclose);
+            if (state.disclose) _dp.set(state.name, state.disclose);
           }
           _built = true;
         }

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -9,14 +9,14 @@ import {
   _this_,
   currentVersionOf,
   deprecatedEventNames,
-  gate_external,
-  merge_for_reducer,
   mergeEventRegister,
   mergeProjection,
   pii_fields,
+  pii_gate,
+  pii_merge,
+  pii_split,
+  pii_strip,
   registerState,
-  split_payload,
-  strip_for_handler,
 } from "../internal/index.js";
 import { DEFAULT_LANE, log } from "../ports.js";
 import type {
@@ -585,7 +585,7 @@ export function act<
             for (const [name, reaction] of reg.reactions) {
               const inner = reaction.handler;
               const wrapped = (event: any, stream: string, app: any) =>
-                inner(strip_for_handler(event, fields), stream, app);
+                inner(pii_strip(event, fields), stream, app);
               // Preserve handler.name — buildHandle asserts on named functions.
               Object.defineProperty(wrapped, "name", { value: inner.name });
               reaction.handler = wrapped;
@@ -604,7 +604,7 @@ export function act<
             const wrapped = async (events: any[], stream: string) => {
               const stripped = events.map((e) => {
                 const f = _sf.get(e.name as string);
-                return f ? strip_for_handler(e, f) : e;
+                return f ? pii_strip(e, f) : e;
               });
               return original(stripped as never, stream);
             };
@@ -623,22 +623,22 @@ export function act<
             }
             if (fields_by_event.size === 0) continue;
             const disclose = state.disclose ?? null;
-            state._split_emitted = (e) => {
+            state._pii_split = (e) => {
               const fields = fields_by_event.get(e.name as string);
               if (!fields) return e;
-              return split_payload(e, fields) as typeof e & {
+              return pii_split(e, fields) as typeof e & {
                 pii: Record<string, unknown>;
               };
             };
-            state._merge_for_reducer = (event) => {
+            state._pii_merge = (event) => {
               const fields = fields_by_event.get(event.name as string);
               if (!fields) return event;
-              return merge_for_reducer(event, fields);
+              return pii_merge(event, fields);
             };
-            state._gate_external = (event, actor) => {
+            state._pii_gate = (event, actor) => {
               const fields = fields_by_event.get(event.name as string);
               if (!fields) return event;
-              return gate_external(event, fields, disclose, actor);
+              return pii_gate(event, fields, disclose, actor);
             };
           }
           _built = true;

--- a/libs/act/src/builders/act-builder.ts
+++ b/libs/act/src/builders/act-builder.ts
@@ -610,36 +610,63 @@ export function act<
             };
             batchHandlers.set(target, wrapped as never);
           }
-          // Attach the per-state PII decorators (#855). States with at least
-          // one sensitive event get three closures bound over the per-event
-          // field list + the disclosure predicate; states without sensitive
-          // events get nothing attached so the orchestrator's hot path
-          // short-circuits at `me._x?.(arg) ?? arg` with zero work.
+          // Build the per-state step delegates (#855).
+          //
+          // The orchestrator calls three step delegates per event:
+          //   - `me.message(validated)` — produces the commit-bound
+          //     `{name, data, pii?}` from a validated emit. Called once
+          //     per emitted event in `action()` before `Store.commit`.
+          //   - `me.patch[eventName](event, state)` — the reducer that
+          //     derives the next state from the committed event. Called
+          //     during load() replay and action()'s post-commit fold.
+          //   - `me.view(event, actor)` — produces the caller-visible
+          //     form of a committed event (snapshot.event). Called in
+          //     load() and action()'s snapshot builder.
+          //
+          // For PII-free states (the common case) `view` and `message`
+          // are bound to identity in `state-builder.ts` and `patch` is
+          // the user-declared reducer; the orchestrator's hot path is
+          // identical to the pre-#855 code at runtime.
+          //
+          // For PII-aware states (at least one `sensitive(...)` event)
+          // each delegate is rebound here to bake the PII work into the
+          // step itself: `view` gates per `.discloses`, `message` peels
+          // sensitive fields off `data` into `pii`, and each per-event
+          // `patch[eventName]` for a sensitive event is wrapped to merge
+          // PII back into `data` before the user's reducer sees it.
           for (const state of states.values()) {
             const fields_by_event = new Map<string, readonly string[]>();
             for (const eventName of Object.keys(state.events)) {
               const fields = _sf.get(eventName);
               if (fields) fields_by_event.set(eventName, fields);
             }
-            if (fields_by_event.size === 0) continue;
+            if (fields_by_event.size === 0) {
+              // Pure state — `view` and `message` are identity, `patch`
+              // is the user's reducer as-declared.
+              state.view = (event) => event;
+              state.message = (validated) => validated;
+              continue;
+            }
+            // PII-aware state — bake PII work into each step delegate.
             const disclose = state.disclose ?? null;
-            state._pii_split = (e) => {
-              const fields = fields_by_event.get(e.name as string);
-              if (!fields) return e;
-              return pii_split(e, fields) as typeof e & {
-                pii: Record<string, unknown>;
-              };
-            };
-            state._pii_merge = (event) => {
+            state.view = (event, actor) => {
               const fields = fields_by_event.get(event.name as string);
-              if (!fields) return event;
-              return pii_merge(event, fields);
+              return fields ? pii_gate(event, fields, disclose, actor) : event;
             };
-            state._pii_gate = (event, actor) => {
-              const fields = fields_by_event.get(event.name as string);
-              if (!fields) return event;
-              return pii_gate(event, fields, disclose, actor);
+            state.message = (validated) => {
+              const fields = fields_by_event.get(validated.name as string);
+              return fields ? pii_split(validated, fields) : validated;
             };
+            // Wrap the per-event reducer to merge PII before the user's
+            // patch sees it. Plain reducers (for non-sensitive events on
+            // this state) stay unwrapped. `state-builder` guarantees a
+            // passthrough reducer for every declared event, so the lookup
+            // is never undefined here.
+            for (const [eventName, fields] of fields_by_event) {
+              const original = state.patch[eventName];
+              state.patch[eventName] = (event, s) =>
+                original(pii_merge(event, fields), s);
+            }
           }
           _built = true;
         }

--- a/libs/act/src/builders/state-builder.ts
+++ b/libs/act/src/builders/state-builder.ts
@@ -577,6 +577,11 @@ export function state<TName extends string, TState extends Schema>(
             init,
             patch: defaultPatch,
             on: {},
+            // Step delegates initialized as identity. `act().build()`
+            // overrides on states with `sensitive(...)` events to bake in
+            // the gate / split.
+            view: (event) => event,
+            message: (validated) => validated,
           };
 
           // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- {} avoids string index signature

--- a/libs/act/src/builders/state-builder.ts
+++ b/libs/act/src/builders/state-builder.ts
@@ -8,6 +8,8 @@ import type { ZodType } from "zod";
 import type {
   ActionHandler,
   ActionOptions,
+  Actor,
+  Committed,
   GivenHandlers,
   Invariant,
   PassthroughPatchHandler,
@@ -370,6 +372,41 @@ export type ActionBuilder<
     snap: (snapshot: Snapshot<TState, TEvents>) => boolean
   ) => ActionBuilder<TState, TEvents, TActions, TName>;
   /**
+   * Declares the disclosure predicate for `sensitive(...)`-marked event
+   * fields. Gates external reads: returning `true` allows the actor to see
+   * plaintext on the event; returning `false` substitutes `"[REDACTED]"`.
+   * When absent, the framework default-denies on every external read —
+   * fail-safe.
+   *
+   * One predicate per state. A second `.discloses(...)` call replaces the
+   * first (same shape as snapshots being state-level, not per-event).
+   *
+   * The predicate receives the full event including merged PII so it can
+   * branch on the payload itself (e.g.
+   * `event.data.ownerId === actor.id`). Reducers, projections, and
+   * reactions are unaffected — they follow separate visibility rules
+   * documented in #855.
+   *
+   * @param disclose - Predicate `(event, actor) => boolean`. `true` =
+   *   plaintext, `false` = `"[REDACTED]"` substitution.
+   * @returns The ActionBuilder for chaining.
+   *
+   * @example Owner-or-admin disclosure
+   * ```typescript
+   * state({ User: userSchema })
+   *   .init(() => ({ ... }))
+   *   .emits({ UserRegistered: z.object({ email: sensitive(z.string()) }) })
+   *   .discloses((event, actor) =>
+   *     actor.id === event.stream || actor.roles?.includes("admin"))
+   * ```
+   */
+  discloses: (
+    disclose: (
+      event: Committed<TEvents, keyof TEvents & string>,
+      actor: Actor
+    ) => boolean
+  ) => ActionBuilder<TState, TEvents, TActions, TName>;
+  /**
    * Finalizes and builds the state definition.
    *
    * Call this method after defining all actions, invariants, and patches to create
@@ -636,6 +673,18 @@ function action_builder<
 
     snap(snap: (snapshot: Snapshot<TState, TEvents>) => boolean) {
       internal.snap = snap;
+      return builder;
+    },
+
+    discloses(
+      disclose: (
+        event: Committed<TEvents, keyof TEvents & string>,
+        actor: Actor
+      ) => boolean
+    ) {
+      // Replace on every call — matches snap's state-level semantics. Operators
+      // who need per-event differences branch inside the predicate.
+      internal.disclose = disclose;
       return builder;
     },
 

--- a/libs/act/src/index.ts
+++ b/libs/act/src/index.ts
@@ -11,6 +11,5 @@ export * from "./builders/index.js";
 export * from "./config.js";
 export * from "./csv.js";
 export * from "./ports.js";
-export * from "./sensitive.js";
 export * from "./types/index.js";
 export * from "./utils.js";

--- a/libs/act/src/index.ts
+++ b/libs/act/src/index.ts
@@ -11,5 +11,6 @@ export * from "./builders/index.js";
 export * from "./config.js";
 export * from "./csv.js";
 export * from "./ports.js";
+export * from "./sensitive.js";
 export * from "./types/index.js";
 export * from "./utils.js";

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -497,7 +497,8 @@ export async function action<
   payload: Readonly<TActions[TKey]>,
   reactingTo?: Committed<Schemas, keyof Schemas>,
   skipValidation = false,
-  correlator: Correlator = defaultCorrelator
+  correlator: Correlator = defaultCorrelator,
+  sensitiveFields: (eventName: string) => readonly string[] = () => []
 ): Promise<Snapshot<TState, TEvents>[]> {
   const { stream, expectedVersion, actor } = target;
   if (!stream) throw new Error("Missing target stream");
@@ -565,12 +566,27 @@ export async function action<
         }
       }
 
-      const emitted = tuples.map(([name, data]) => ({
-        name,
-        data: skipValidation
+      const emitted = tuples.map(([name, data]) => {
+        const validated = skipValidation
           ? data
-          : validate(name as string, data, me.events[name]),
-      }));
+          : validate(name as string, data, me.events[name]);
+        // Split sensitive fields off `data` and into `pii` before the event
+        // reaches the Store — the Store's pii_isolation contract is
+        // declarative-only, the orchestrator is responsible for the split.
+        // Zero-cost short-circuit when the event has no sensitive fields,
+        // which is the common case.
+        const fields = sensitiveFields(name as string);
+        if (fields.length === 0) return { name, data: validated };
+        const pii: Record<string, unknown> = {};
+        const cleanData: Record<string, unknown> = { ...(validated as object) };
+        for (const f of fields) {
+          if (f in cleanData) {
+            pii[f] = cleanData[f];
+            delete cleanData[f];
+          }
+        }
+        return { name, data: cleanData as typeof validated, pii };
+      });
 
       const meta: EventMeta = {
         correlation:

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -577,13 +577,18 @@ export async function action<
         // which is the common case.
         const fields = sensitiveFields(name as string);
         if (fields.length === 0) return { name, data: validated };
+        // Single forward pass over the validated keys, building both
+        // partitions in one go. Avoids the spread-and-delete dance — `delete`
+        // would force V8 to transition `cleanData` from hidden-class to
+        // dictionary mode, slowing every downstream read of `event.data`.
+        // For typical sensitive-field counts (1–3 per event) the `includes`
+        // probe is faster than allocating a Set per commit.
+        const validatedRec = validated as Record<string, unknown>;
+        const cleanData: Record<string, unknown> = {};
         const pii: Record<string, unknown> = {};
-        const cleanData: Record<string, unknown> = { ...(validated as object) };
-        for (const f of fields) {
-          if (f in cleanData) {
-            pii[f] = cleanData[f];
-            delete cleanData[f];
-          }
+        for (const k of Object.keys(validatedRec)) {
+          if (fields.includes(k)) pii[k] = validatedRec[k];
+          else cleanData[k] = validatedRec[k];
         }
         return { name, data: cleanData as typeof validated, pii };
       });

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -41,7 +41,6 @@ import type {
 import { sleep, validate } from "../utils.js";
 import { computeBackoffDelay } from "./backoff.js";
 import { defaultCorrelator } from "./correlator.js";
-import { gate_external, merge_for_reducer } from "./sensitive.js";
 
 /**
  * Default per-batch row count for the {@link scan} pagination loop
@@ -381,8 +380,7 @@ export async function load<
   stream: string,
   callback?: (snapshot: Snapshot<TState, TEvents>) => void,
   asOf?: AsOf,
-  actor?: Actor,
-  pii_lookup: (eventName: string) => readonly string[] = () => []
+  actor?: Actor
 ): Promise<Snapshot<TState, TEvents>> {
   const timeTravel = !!asOf && Object.values(asOf).some((v) => v !== undefined);
   const cached = timeTravel ? undefined : await cache().get<TState>(stream);
@@ -402,22 +400,16 @@ export async function load<
   await store().query(
     (e) => {
       version = e.version;
-      // Split per-event handling into two views:
-      //   - reducer view: pii merged into data (or [SHREDDED] post-forget) so
-      //     the reducer always sees plaintext; the source of truth for state.
-      //   - external view: gated by `.discloses` + actor; what we return to
-      //     callers and place in snapshot.event.
-      const fields = pii_lookup(e.name as string);
-      const reducer_view = merge_for_reducer(
-        e as Committed<TEvents, string>,
-        fields
-      );
-      const external_view = gate_external(
-        e as Committed<TEvents, string>,
-        fields,
-        me.disclose ?? null,
-        actor
-      );
+      // Split per-event handling into two views via the State's PII
+      // decorators (attached at build time on states with sensitive events):
+      //   - reducer view: pii merged into data (or [SHREDDED] post-forget)
+      //     so the reducer always sees plaintext.
+      //   - external view: gated by `.discloses` + actor; what callers see.
+      // PII-free states have no decorators attached; the optional-chain
+      // short-circuits to `e` for both, zero PII machinery per event.
+      const typed = e as Committed<TEvents, string>;
+      const reducer_view = me._merge_for_reducer?.(typed) ?? typed;
+      const external_view = me._gate_external?.(typed, actor) ?? typed;
       event = external_view;
       if (e.name === SNAP_EVENT) {
         state = e.data as TState;
@@ -517,8 +509,7 @@ export async function action<
   payload: Readonly<TActions[TKey]>,
   reactingTo?: Committed<Schemas, keyof Schemas>,
   skipValidation = false,
-  correlator: Correlator = defaultCorrelator,
-  pii_fields: (eventName: string) => readonly string[] = () => []
+  correlator: Correlator = defaultCorrelator
 ): Promise<Snapshot<TState, TEvents>[]> {
   const { stream, expectedVersion, actor } = target;
   if (!stream) throw new Error("Missing target stream");
@@ -532,17 +523,17 @@ export async function action<
 
   for (let attempt = 0; ; attempt++) {
     try {
-      // Pass the action target's actor and the same pii_fields lookup down
-      // — action()'s reducer needs plaintext (handled inside load), and the
-      // snapshot.event returned to the caller is gated by `.discloses` with
-      // the action's actor.
+      // Pass the action target's actor down so load() can gate snapshot.event
+      // via the State's `_gate_external` decorator. The reducer's plaintext
+      // view is also handled inside load(), via the same State's
+      // `_merge_for_reducer` decorator. States without sensitive events have
+      // no decorators attached → load() short-circuits at zero cost.
       const snapshot = await load(
         me,
         stream,
         undefined,
         undefined,
-        target.actor,
-        pii_fields
+        target.actor
       );
       if (snapshot.event?.name === TOMBSTONE_EVENT)
         throw new StreamClosedError(stream);
@@ -601,27 +592,14 @@ export async function action<
         const validated = skipValidation
           ? data
           : validate(name as string, data, me.events[name]);
-        // Split sensitive fields off `data` and into `pii` before the event
-        // reaches the Store — the Store's pii_isolation contract is
-        // declarative-only, the orchestrator is responsible for the split.
-        // Zero-cost short-circuit when the event has no sensitive fields,
-        // which is the common case.
-        const fields = pii_fields(name as string);
-        if (fields.length === 0) return { name, data: validated };
-        // Single forward pass over the validated keys, building both
-        // partitions in one go. Avoids the spread-and-delete dance — `delete`
-        // would force V8 to transition `clean` from hidden-class to dictionary
-        // mode, slowing every downstream read of `event.data`. For typical
-        // sensitive-field counts (1–3 per event) the `includes` probe is
-        // faster than allocating a Set per commit.
-        const rec = validated as Record<string, unknown>;
-        const clean: Record<string, unknown> = {};
-        const pii: Record<string, unknown> = {};
-        for (const k of Object.keys(rec)) {
-          if (fields.includes(k)) pii[k] = rec[k];
-          else clean[k] = rec[k];
-        }
-        return { name, data: clean as typeof validated, pii };
+        const base = { name, data: validated };
+        // Delegate the sensitive split to the State's `_split_emitted`
+        // decorator — attached by `act().build()` only on states with at
+        // least one sensitive event. PII-free states have no decorator;
+        // the optional-chain short-circuits and we hand `base` straight
+        // through. The Store's pii_isolation contract sees `pii` already
+        // peeled off `data` when the split fired.
+        return me._split_emitted?.(base) ?? base;
       });
 
       const meta: EventMeta = {
@@ -672,19 +650,13 @@ export async function action<
 
       let { state, patches } = snapshot;
       const snapshots = committed.map((event) => {
-        // Reducers run against the plaintext-merged view (so derived state is
-        // correct even for sensitive events); the snapshot.event returned to
-        // the .do() caller is the gated view (so external visibility tracks
-        // the action target's actor).
-        const fields = pii_fields(event.name as string);
-        const ev = event as Committed<TEvents, keyof TEvents & string>;
-        const reducer_view = merge_for_reducer(ev, fields);
-        const external_view = gate_external(
-          ev,
-          fields,
-          me.disclose ?? null,
-          target.actor
-        );
+        // Reducers run against the plaintext-merged view; the snapshot.event
+        // returned to the .do() caller is the gated view. Both decorators
+        // are attached by `act().build()` only on PII-aware states; PII-free
+        // states short-circuit at the optional-chain and hand the event
+        // straight through.
+        const reducer_view = me._merge_for_reducer?.(event) ?? event;
+        const external_view = me._gate_external?.(event, target.actor) ?? event;
         const p = me.patch[event.name](reducer_view, state);
         state = patch(state, p);
         patches++;

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -518,11 +518,6 @@ export async function action<
 
   for (let attempt = 0; ; attempt++) {
     try {
-      // Pass the action target's actor down so load() can gate snapshot.event
-      // via the State's `_pii_gate` decorator. The reducer's plaintext
-      // view is also handled inside load(), via the same State's
-      // `_pii_merge` decorator. States without sensitive events have
-      // no decorators attached → load() short-circuits at zero cost.
       const snapshot = await load(
         me,
         stream,
@@ -583,9 +578,6 @@ export async function action<
         }
       }
 
-      // Per-event optional-chain split. PII-aware states have `_pii_split`
-      // attached at build time; PII-free states short-circuit at `?.()` and
-      // `?? base` hands the event through.
       const emitted = tuples.map(([name, data]) => {
         const validated = skipValidation
           ? data
@@ -606,8 +598,8 @@ export async function action<
           action: {
             name: action as string,
             ...target,
-            // payload intentionally omitted: it can be large or contain PII,
-            // and callers correlate via the correlation id when they need it.
+            // payload intentionally omitted from causation metadata —
+            // callers correlate via the correlation id when they need it.
           },
           event: reactingTo
             ? {

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -364,7 +364,7 @@ export async function scan(
  * @template TEvents The type of events
  * @template TActions The type of actions
  * @param me The state machine definition. May carry the optional PII
- *   decorators (`_merge_for_reducer`, `_gate_external`) attached at build
+ *   decorators (`_pii_merge`, `_pii_gate`) attached at build
  *   time on states with at least one `sensitive(...)` event; states without
  *   them take the bare replay path with no PII machinery.
  * @param stream The stream (instance) to load
@@ -408,18 +408,17 @@ export async function load<
   let event: Committed<TEvents, string> | undefined;
 
   // Bind the PII transforms once at load entry. The decorator trio
-  // (`_split_emitted` / `_merge_for_reducer` / `_gate_external`) is attached
+  // (`_pii_split` / `_pii_merge` / `_pii_gate`) is attached
   // together at build time on states that declared at least one
-  // `sensitive(...)` event — so a single null-check on any one of them is
-  // the per-state "has PII?" predicate. PII-aware states get real
-  // closures; PII-free states get identity arrows that V8 inlines into the
-  // call site. Either way the per-event body is the same shape — no
-  // per-event optional-chain probe, no duplicated loop body.
+  // `sensitive(...)` event, so the function reference itself IS the
+  // per-state "has PII?" predicate — no separate flag needed. PII-aware
+  // states get real closures; PII-free states get identity arrows that
+  // V8 inlines into the call site. Either way the per-event body is the
+  // same shape — no per-event optional-chain probe, no duplicated loop.
   const identity = <T>(x: T) => x;
-  const pii_aware = me._merge_for_reducer;
-  const reducer_view = pii_aware ?? identity;
-  const external_view = pii_aware
-    ? (e: Committed<TEvents, string>) => me._gate_external!(e, actor)
+  const reducer_view = me._pii_merge ?? identity;
+  const external_view = me._pii_gate
+    ? (e: Committed<TEvents, string>) => me._pii_gate!(e, actor)
     : identity;
 
   await store().query(
@@ -540,9 +539,9 @@ export async function action<
   for (let attempt = 0; ; attempt++) {
     try {
       // Pass the action target's actor down so load() can gate snapshot.event
-      // via the State's `_gate_external` decorator. The reducer's plaintext
+      // via the State's `_pii_gate` decorator. The reducer's plaintext
       // view is also handled inside load(), via the same State's
-      // `_merge_for_reducer` decorator. States without sensitive events have
+      // `_pii_merge` decorator. States without sensitive events have
       // no decorators attached → load() short-circuits at zero cost.
       const snapshot = await load(
         me,
@@ -607,7 +606,7 @@ export async function action<
       // Same bind-once-then-call pattern as load(). For PII-aware states
       // `split` is the per-event splitter that moves sensitive fields into
       // `pii`; for PII-free states it's identity. One loop body either way.
-      const split = me._split_emitted ?? ((e: { name: any; data: any }) => e);
+      const split = me._pii_split ?? ((e: { name: any; data: any }) => e);
       const emitted = tuples.map(([name, data]) => {
         const validated = skipValidation
           ? data
@@ -662,14 +661,12 @@ export async function action<
       }
 
       let { state, patches } = snapshot;
-      // Same bind-once-then-call pattern as load(). Single null-check on
-      // `_merge_for_reducer` is the per-state "has PII?" predicate — the
-      // decorator trio is attached together at build.
+      // Same bind-once-then-call pattern as load() — the function
+      // reference itself is the "has PII?" predicate.
       const post_identity = <T>(x: T) => x;
-      const post_pii_aware = me._merge_for_reducer;
-      const reducer_after = post_pii_aware ?? post_identity;
-      const external_after = post_pii_aware
-        ? (e: (typeof committed)[number]) => me._gate_external!(e, target.actor)
+      const reducer_after = me._pii_merge ?? post_identity;
+      const external_after = me._pii_gate
+        ? (e: (typeof committed)[number]) => me._pii_gate!(e, target.actor)
         : post_identity;
       const snapshots = committed.map((event) => {
         const p = me.patch[event.name](reducer_after(event), state);

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -17,6 +17,8 @@
 
 import { patch } from "@rotorsoft/act-patch";
 import { cache, log, SNAP_EVENT, store, TOMBSTONE_EVENT } from "../ports.js";
+import { gate_external, merge_for_reducer } from "../sensitive.js";
+import type { Actor } from "../types/action.js";
 import {
   ConcurrencyError,
   InvariantError,
@@ -378,7 +380,9 @@ export async function load<
   me: State<TState, TEvents, TActions>,
   stream: string,
   callback?: (snapshot: Snapshot<TState, TEvents>) => void,
-  asOf?: AsOf
+  asOf?: AsOf,
+  actor?: Actor,
+  pii_lookup: (eventName: string) => readonly string[] = () => []
 ): Promise<Snapshot<TState, TEvents>> {
   const timeTravel = !!asOf && Object.values(asOf).some((v) => v !== undefined);
   const cached = timeTravel ? undefined : await cache().get<TState>(stream);
@@ -397,15 +401,31 @@ export async function load<
 
   await store().query(
     (e) => {
-      event = e as Committed<TEvents, string>;
       version = e.version;
+      // Split per-event handling into two views:
+      //   - reducer view: pii merged into data (or [SHREDDED] post-forget) so
+      //     the reducer always sees plaintext; the source of truth for state.
+      //   - external view: gated by `.discloses` + actor; what we return to
+      //     callers and place in snapshot.event.
+      const fields = pii_lookup(e.name as string);
+      const reducer_view = merge_for_reducer(
+        e as Committed<TEvents, string>,
+        fields
+      );
+      const external_view = gate_external(
+        e as Committed<TEvents, string>,
+        fields,
+        me.disclose ?? null,
+        actor
+      );
+      event = external_view;
       if (e.name === SNAP_EVENT) {
         state = e.data as TState;
         snaps++;
         patches = 0;
         replayed++;
       } else if (me.patch[e.name]) {
-        state = patch(state, me.patch[e.name](event, state));
+        state = patch(state, me.patch[e.name](reducer_view, state));
         patches++;
         replayed++;
       } else if (e.name !== TOMBSTONE_EVENT) {
@@ -512,7 +532,18 @@ export async function action<
 
   for (let attempt = 0; ; attempt++) {
     try {
-      const snapshot = await load(me, stream);
+      // Pass the action target's actor and the same pii_fields lookup down
+      // — action()'s reducer needs plaintext (handled inside load), and the
+      // snapshot.event returned to the caller is gated by `.discloses` with
+      // the action's actor.
+      const snapshot = await load(
+        me,
+        stream,
+        undefined,
+        undefined,
+        target.actor,
+        pii_fields
+      );
       if (snapshot.event?.name === TOMBSTONE_EVENT)
         throw new StreamClosedError(stream);
       const expected = expectedVersion ?? snapshot.event?.version;
@@ -641,14 +672,27 @@ export async function action<
 
       let { state, patches } = snapshot;
       const snapshots = committed.map((event) => {
-        const p = me.patch[event.name](event, state);
+        // Reducers run against the plaintext-merged view (so derived state is
+        // correct even for sensitive events); the snapshot.event returned to
+        // the .do() caller is the gated view (so external visibility tracks
+        // the action target's actor).
+        const fields = pii_fields(event.name as string);
+        const ev = event as Committed<TEvents, keyof TEvents & string>;
+        const reducer_view = merge_for_reducer(ev, fields);
+        const external_view = gate_external(
+          ev,
+          fields,
+          me.disclose ?? null,
+          target.actor
+        );
+        const p = me.patch[event.name](reducer_view, state);
         state = patch(state, p);
         patches++;
         // cache_hit / replayed propagate from the initial load — these
         // post-commit snapshots all derive from the same loaded state.
         // version advances per committed event (each is a new stream head).
         return {
-          event,
+          event: external_view,
           state,
           version: event.version,
           patches,

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -407,19 +407,15 @@ export async function load<
   let replayed = 0;
   let event: Committed<TEvents, string> | undefined;
 
-  // Bind the PII transforms once at load entry. The decorator trio
-  // (`_pii_split` / `_pii_merge` / `_pii_gate`) is attached
-  // together at build time on states that declared at least one
-  // `sensitive(...)` event, so the function reference itself IS the
-  // per-state "has PII?" predicate — no separate flag needed. PII-aware
-  // states get real closures; PII-free states get identity arrows that
-  // V8 inlines into the call site. Either way the per-event body is the
-  // same shape — no per-event optional-chain probe, no duplicated loop.
-  const identity = <T>(x: T) => x;
-  const reducer_view = me._pii_merge ?? identity;
-  const external_view = me._pii_gate
-    ? (e: Committed<TEvents, string>) => me._pii_gate!(e, actor)
-    : identity;
+  // Per-event PII views via optional-chain + fallback. The decorator trio
+  // (`_pii_split` / `_pii_merge` / `_pii_gate`) is attached together at
+  // build on states that declared at least one `sensitive(...)` event;
+  // when absent the optional-chain call short-circuits and `?? e` hands
+  // the event straight through. One liner each, same body either way.
+  const reducer_view = (e: Committed<TEvents, string>) =>
+    me._pii_merge?.(e) ?? e;
+  const external_view = (e: Committed<TEvents, string>) =>
+    me._pii_gate?.(e, actor) ?? e;
 
   await store().query(
     (e) => {
@@ -603,15 +599,17 @@ export async function action<
         }
       }
 
-      // Same bind-once-then-call pattern as load(). For PII-aware states
-      // `split` is the per-event splitter that moves sensitive fields into
-      // `pii`; for PII-free states it's identity. One loop body either way.
-      const split = me._pii_split ?? ((e: { name: any; data: any }) => e);
+      // Per-event optional-chain split. PII-aware states have `_pii_split`
+      // attached at build time; PII-free states short-circuit at `?.()` and
+      // `?? base` hands the event through.
       const emitted = tuples.map(([name, data]) => {
-        const validated = skipValidation
-          ? data
-          : validate(name as string, data, me.events[name]);
-        return split({ name, data: validated });
+        const base = {
+          name,
+          data: skipValidation
+            ? data
+            : validate(name as string, data, me.events[name]),
+        };
+        return me._pii_split?.(base) ?? base;
       });
 
       const meta: EventMeta = {
@@ -661,13 +659,13 @@ export async function action<
       }
 
       let { state, patches } = snapshot;
-      // Same bind-once-then-call pattern as load() — the function
-      // reference itself is the "has PII?" predicate.
-      const post_identity = <T>(x: T) => x;
-      const reducer_after = me._pii_merge ?? post_identity;
-      const external_after = me._pii_gate
-        ? (e: (typeof committed)[number]) => me._pii_gate!(e, target.actor)
-        : post_identity;
+      // Same per-event optional-chain pattern as load() — one liner each,
+      // optional-chain short-circuits + `?? e` fallback hand the event
+      // through unchanged on PII-free states.
+      const reducer_after = (e: (typeof committed)[number]) =>
+        me._pii_merge?.(e) ?? e;
+      const external_after = (e: (typeof committed)[number]) =>
+        me._pii_gate?.(e, target.actor) ?? e;
       const snapshots = committed.map((event) => {
         const p = me.patch[event.name](reducer_after(event), state);
         state = patch(state, p);

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -17,7 +17,6 @@
 
 import { patch } from "@rotorsoft/act-patch";
 import { cache, log, SNAP_EVENT, store, TOMBSTONE_EVENT } from "../ports.js";
-import { gate_external, merge_for_reducer } from "../sensitive.js";
 import type { Actor } from "../types/action.js";
 import {
   ConcurrencyError,
@@ -42,6 +41,7 @@ import type {
 import { sleep, validate } from "../utils.js";
 import { computeBackoffDelay } from "./backoff.js";
 import { defaultCorrelator } from "./correlator.js";
+import { gate_external, merge_for_reducer } from "./sensitive.js";
 
 /**
  * Default per-batch row count for the {@link scan} pagination loop

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -363,19 +363,13 @@ export async function scan(
  * @template TState The type of state
  * @template TEvents The type of events
  * @template TActions The type of actions
- * @param me The state machine definition. May carry the optional PII
- *   decorators (`_pii_merge`, `_pii_gate`) attached at build
- *   time on states with at least one `sensitive(...)` event; states without
- *   them take the bare replay path with no PII machinery.
+ * @param me The state machine definition.
  * @param stream The stream (instance) to load
  * @param callback (Optional) Callback to receive the loaded snapshot as it is built
  * @param asOf (Optional) Time-travel cursor; bypasses the cache.
- * @param actor (Optional) When supplied AND the state has sensitive events,
- *   gates the **external** view of each event via `.discloses(predicate)` —
- *   authorized callers see plaintext, unauthorized see `"[REDACTED]"`. The
- *   reducer view is always plaintext-merged regardless of actor so derived
- *   state stays correct. When the state has no sensitive events, the
- *   parameter is ignored.
+ * @param actor (Optional) Passed through to the state's `view` delegate
+ *   when constructing the snapshot.event — semantics are the state's to
+ *   define (see {@link state}).
  * @returns The snapshot of the loaded state
  *
  * @example
@@ -407,28 +401,18 @@ export async function load<
   let replayed = 0;
   let event: Committed<TEvents, string> | undefined;
 
-  // Per-event PII views via optional-chain + fallback. The decorator trio
-  // (`_pii_split` / `_pii_merge` / `_pii_gate`) is attached together at
-  // build on states that declared at least one `sensitive(...)` event;
-  // when absent the optional-chain call short-circuits and `?? e` hands
-  // the event straight through. One liner each, same body either way.
-  const reducer_view = (e: Committed<TEvents, string>) =>
-    me._pii_merge?.(e) ?? e;
-  const external_view = (e: Committed<TEvents, string>) =>
-    me._pii_gate?.(e, actor) ?? e;
-
   await store().query(
     (e) => {
       version = e.version;
       const typed = e as Committed<TEvents, string>;
-      event = external_view(typed);
+      event = me.view(typed, actor);
       if (e.name === SNAP_EVENT) {
         state = e.data as TState;
         snaps++;
         patches = 0;
         replayed++;
       } else if (me.patch[e.name]) {
-        state = patch(state, me.patch[e.name](reducer_view(typed), state));
+        state = patch(state, me.patch[e.name](typed, state));
         patches++;
         replayed++;
       } else if (e.name !== TOMBSTONE_EVENT) {
@@ -603,13 +587,10 @@ export async function action<
       // attached at build time; PII-free states short-circuit at `?.()` and
       // `?? base` hands the event through.
       const emitted = tuples.map(([name, data]) => {
-        const base = {
-          name,
-          data: skipValidation
-            ? data
-            : validate(name as string, data, me.events[name]),
-        };
-        return me._pii_split?.(base) ?? base;
+        const validated = skipValidation
+          ? data
+          : validate(name as string, data, me.events[name]);
+        return me.message({ name, data: validated });
       });
 
       const meta: EventMeta = {
@@ -659,19 +640,12 @@ export async function action<
       }
 
       let { state, patches } = snapshot;
-      // Same per-event optional-chain pattern as load() — one liner each,
-      // optional-chain short-circuits + `?? e` fallback hand the event
-      // through unchanged on PII-free states.
-      const reducer_after = (e: (typeof committed)[number]) =>
-        me._pii_merge?.(e) ?? e;
-      const external_after = (e: (typeof committed)[number]) =>
-        me._pii_gate?.(e, target.actor) ?? e;
       const snapshots = committed.map((event) => {
-        const p = me.patch[event.name](reducer_after(event), state);
+        const p = me.patch[event.name](event, state);
         state = patch(state, p);
         patches++;
         return {
-          event: external_after(event),
+          event: me.view(event, target.actor),
           state,
           version: event.version,
           patches,

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -498,7 +498,7 @@ export async function action<
   reactingTo?: Committed<Schemas, keyof Schemas>,
   skipValidation = false,
   correlator: Correlator = defaultCorrelator,
-  sensitiveFields: (eventName: string) => readonly string[] = () => []
+  pii_fields: (eventName: string) => readonly string[] = () => []
 ): Promise<Snapshot<TState, TEvents>[]> {
   const { stream, expectedVersion, actor } = target;
   if (!stream) throw new Error("Missing target stream");
@@ -575,22 +575,22 @@ export async function action<
         // declarative-only, the orchestrator is responsible for the split.
         // Zero-cost short-circuit when the event has no sensitive fields,
         // which is the common case.
-        const fields = sensitiveFields(name as string);
+        const fields = pii_fields(name as string);
         if (fields.length === 0) return { name, data: validated };
         // Single forward pass over the validated keys, building both
         // partitions in one go. Avoids the spread-and-delete dance — `delete`
-        // would force V8 to transition `cleanData` from hidden-class to
-        // dictionary mode, slowing every downstream read of `event.data`.
-        // For typical sensitive-field counts (1–3 per event) the `includes`
-        // probe is faster than allocating a Set per commit.
-        const validatedRec = validated as Record<string, unknown>;
-        const cleanData: Record<string, unknown> = {};
+        // would force V8 to transition `clean` from hidden-class to dictionary
+        // mode, slowing every downstream read of `event.data`. For typical
+        // sensitive-field counts (1–3 per event) the `includes` probe is
+        // faster than allocating a Set per commit.
+        const rec = validated as Record<string, unknown>;
+        const clean: Record<string, unknown> = {};
         const pii: Record<string, unknown> = {};
-        for (const k of Object.keys(validatedRec)) {
-          if (fields.includes(k)) pii[k] = validatedRec[k];
-          else cleanData[k] = validatedRec[k];
+        for (const k of Object.keys(rec)) {
+          if (fields.includes(k)) pii[k] = rec[k];
+          else clean[k] = rec[k];
         }
-        return { name, data: cleanData as typeof validated, pii };
+        return { name, data: clean as typeof validated, pii };
       });
 
       const meta: EventMeta = {

--- a/libs/act/src/internal/event-sourcing.ts
+++ b/libs/act/src/internal/event-sourcing.ts
@@ -363,9 +363,19 @@ export async function scan(
  * @template TState The type of state
  * @template TEvents The type of events
  * @template TActions The type of actions
- * @param me The state machine definition
+ * @param me The state machine definition. May carry the optional PII
+ *   decorators (`_merge_for_reducer`, `_gate_external`) attached at build
+ *   time on states with at least one `sensitive(...)` event; states without
+ *   them take the bare replay path with no PII machinery.
  * @param stream The stream (instance) to load
  * @param callback (Optional) Callback to receive the loaded snapshot as it is built
+ * @param asOf (Optional) Time-travel cursor; bypasses the cache.
+ * @param actor (Optional) When supplied AND the state has sensitive events,
+ *   gates the **external** view of each event via `.discloses(predicate)` —
+ *   authorized callers see plaintext, unauthorized see `"[REDACTED]"`. The
+ *   reducer view is always plaintext-merged regardless of actor so derived
+ *   state stays correct. When the state has no sensitive events, the
+ *   parameter is ignored.
  * @returns The snapshot of the loaded state
  *
  * @example
@@ -397,27 +407,33 @@ export async function load<
   let replayed = 0;
   let event: Committed<TEvents, string> | undefined;
 
+  // Bind the PII transforms once at load entry. The decorator trio
+  // (`_split_emitted` / `_merge_for_reducer` / `_gate_external`) is attached
+  // together at build time on states that declared at least one
+  // `sensitive(...)` event — so a single null-check on any one of them is
+  // the per-state "has PII?" predicate. PII-aware states get real
+  // closures; PII-free states get identity arrows that V8 inlines into the
+  // call site. Either way the per-event body is the same shape — no
+  // per-event optional-chain probe, no duplicated loop body.
+  const identity = <T>(x: T) => x;
+  const pii_aware = me._merge_for_reducer;
+  const reducer_view = pii_aware ?? identity;
+  const external_view = pii_aware
+    ? (e: Committed<TEvents, string>) => me._gate_external!(e, actor)
+    : identity;
+
   await store().query(
     (e) => {
       version = e.version;
-      // Split per-event handling into two views via the State's PII
-      // decorators (attached at build time on states with sensitive events):
-      //   - reducer view: pii merged into data (or [SHREDDED] post-forget)
-      //     so the reducer always sees plaintext.
-      //   - external view: gated by `.discloses` + actor; what callers see.
-      // PII-free states have no decorators attached; the optional-chain
-      // short-circuits to `e` for both, zero PII machinery per event.
       const typed = e as Committed<TEvents, string>;
-      const reducer_view = me._merge_for_reducer?.(typed) ?? typed;
-      const external_view = me._gate_external?.(typed, actor) ?? typed;
-      event = external_view;
+      event = external_view(typed);
       if (e.name === SNAP_EVENT) {
         state = e.data as TState;
         snaps++;
         patches = 0;
         replayed++;
       } else if (me.patch[e.name]) {
-        state = patch(state, me.patch[e.name](reducer_view, state));
+        state = patch(state, me.patch[e.name](reducer_view(typed), state));
         patches++;
         replayed++;
       } else if (e.name !== TOMBSTONE_EVENT) {
@@ -588,18 +604,15 @@ export async function action<
         }
       }
 
+      // Same bind-once-then-call pattern as load(). For PII-aware states
+      // `split` is the per-event splitter that moves sensitive fields into
+      // `pii`; for PII-free states it's identity. One loop body either way.
+      const split = me._split_emitted ?? ((e: { name: any; data: any }) => e);
       const emitted = tuples.map(([name, data]) => {
         const validated = skipValidation
           ? data
           : validate(name as string, data, me.events[name]);
-        const base = { name, data: validated };
-        // Delegate the sensitive split to the State's `_split_emitted`
-        // decorator — attached by `act().build()` only on states with at
-        // least one sensitive event. PII-free states have no decorator;
-        // the optional-chain short-circuits and we hand `base` straight
-        // through. The Store's pii_isolation contract sees `pii` already
-        // peeled off `data` when the split fired.
-        return me._split_emitted?.(base) ?? base;
+        return split({ name, data: validated });
       });
 
       const meta: EventMeta = {
@@ -649,22 +662,21 @@ export async function action<
       }
 
       let { state, patches } = snapshot;
+      // Same bind-once-then-call pattern as load(). Single null-check on
+      // `_merge_for_reducer` is the per-state "has PII?" predicate — the
+      // decorator trio is attached together at build.
+      const post_identity = <T>(x: T) => x;
+      const post_pii_aware = me._merge_for_reducer;
+      const reducer_after = post_pii_aware ?? post_identity;
+      const external_after = post_pii_aware
+        ? (e: (typeof committed)[number]) => me._gate_external!(e, target.actor)
+        : post_identity;
       const snapshots = committed.map((event) => {
-        // Reducers run against the plaintext-merged view; the snapshot.event
-        // returned to the .do() caller is the gated view. Both decorators
-        // are attached by `act().build()` only on PII-aware states; PII-free
-        // states short-circuit at the optional-chain and hand the event
-        // straight through.
-        const reducer_view = me._merge_for_reducer?.(event) ?? event;
-        const external_view = me._gate_external?.(event, target.actor) ?? event;
-        const p = me.patch[event.name](reducer_view, state);
+        const p = me.patch[event.name](reducer_after(event), state);
         state = patch(state, p);
         patches++;
-        // cache_hit / replayed propagate from the initial load — these
-        // post-commit snapshots all derive from the same loaded state.
-        // version advances per committed event (each is a new stream head).
         return {
-          event: external_view,
+          event: external_after(event),
           state,
           version: event.version,
           patches,

--- a/libs/act/src/internal/index.ts
+++ b/libs/act/src/internal/index.ts
@@ -44,13 +44,13 @@ export {
 export { buildHandle, buildHandleBatch } from "./reactions.js";
 export {
   _registry,
-  gate_external,
-  merge_for_reducer,
   pii_fields,
+  pii_gate,
+  pii_merge,
+  pii_split,
+  pii_strip,
   REDACTED,
   SHREDDED,
-  split_payload,
-  strip_for_handler,
 } from "./sensitive.js";
 export { SettleLoop } from "./settle.js";
 export { buildDrain, buildEs, traceCycle } from "./tracing.js";

--- a/libs/act/src/internal/index.ts
+++ b/libs/act/src/internal/index.ts
@@ -42,5 +42,14 @@ export {
   registerState,
 } from "./merge.js";
 export { buildHandle, buildHandleBatch } from "./reactions.js";
+export {
+  _registry,
+  gate_external,
+  merge_for_reducer,
+  pii_fields,
+  REDACTED,
+  SHREDDED,
+  strip_for_handler,
+} from "./sensitive.js";
 export { SettleLoop } from "./settle.js";
 export { buildDrain, buildEs, traceCycle } from "./tracing.js";

--- a/libs/act/src/internal/index.ts
+++ b/libs/act/src/internal/index.ts
@@ -49,6 +49,7 @@ export {
   pii_fields,
   REDACTED,
   SHREDDED,
+  split_payload,
   strip_for_handler,
 } from "./sensitive.js";
 export { SettleLoop } from "./settle.js";

--- a/libs/act/src/internal/reactions.ts
+++ b/libs/act/src/internal/reactions.ts
@@ -32,7 +32,6 @@ import {
 } from "../types/index.js";
 import { computeBackoffDelay } from "./backoff.js";
 import type { Handle, HandleBatch, HandleResult } from "./drain-cycle.js";
-import { strip_for_handler } from "./sensitive.js";
 
 /**
  * Dependencies a reaction handler needs from the orchestrator: the logger
@@ -52,12 +51,6 @@ export type ReactionDeps<
   readonly bound_query: IAct<TEvents, TActions, TActor>["query"];
   readonly bound_query_array: IAct<TEvents, TActions, TActor>["query_array"];
   readonly bound_forget: IAct<TEvents, TActions, TActor>["forget"];
-  /**
-   * Registry-backed lookup of sensitive field names per event. Reaction and
-   * batch handlers receive the event with these keys stripped from
-   * `data` and the `pii` field dropped (#855 slice 5).
-   */
-  readonly pii_fields: (eventName: string) => readonly string[];
 };
 
 /**
@@ -131,7 +124,6 @@ export function buildHandle<
     bound_query,
     bound_query_array,
     bound_forget,
-    pii_fields,
   } = deps;
   return async (lease, payloads) => {
     if (payloads.length === 0) return { lease, handled: 0, acked_at: lease.at };
@@ -153,14 +145,11 @@ export function buildHandle<
 
     for (const payload of payloads) {
       const { event, handler } = payload;
-      // Strip sensitive fields before the handler ever sees the event —
-      // reactions that genuinely need PII opt back in via `app.load(stream,
-      // { actor: systemActor })` inside the handler, making the
-      // security-relevant path explicit at the call site.
-      const handler_event = strip_for_handler(
-        event as Committed<TEvents, keyof TEvents & string>,
-        pii_fields(event.name as string)
-      );
+      // PII strip is wrapped into the handler itself at build time (#855):
+      // reactions registered against an event with `sensitive(...)` fields
+      // get a stripping handler closure during `act().build()`; reactions
+      // against non-PII events keep their original handler reference.
+      // The dispatcher is PII-unaware — zero per-event branching here.
       scopedApp.do = <TKey extends keyof TActions & string>(
         action: TKey,
         target: Target<TActor>,
@@ -176,7 +165,7 @@ export function buildHandle<
           skipValidation
         );
       try {
-        await handler(handler_event, stream, scopedApp);
+        await handler(event, stream, scopedApp);
         at = event.id;
         handled++;
       } catch (error) {
@@ -203,8 +192,7 @@ export function buildHandle<
  * @internal
  */
 export function buildHandleBatch<TEvents extends Schemas>(
-  logger: Logger,
-  pii_fields: (eventName: string) => readonly string[]
+  logger: Logger
 ): HandleBatch<TEvents> {
   return async (
     lease: Lease,
@@ -212,13 +200,10 @@ export function buildHandleBatch<TEvents extends Schemas>(
     batchHandler: BatchHandler<TEvents>
   ) => {
     const stream = lease.stream;
-    // Same handler-stripping rule applies to batch handlers as to per-event
-    // reactions: projections see events without sensitive keys.
-    const events = payloads.map((p) =>
-      strip_for_handler(
-        p.event as Committed<TEvents, keyof TEvents & string>,
-        pii_fields(p.event.name as string)
-      )
+    // PII strip happens inside `batchHandler` when needed — wrapped at build
+    // time per `act-builder.ts`. The dispatcher hands raw events through.
+    const events = payloads.map(
+      (p) => p.event as Committed<TEvents, keyof TEvents & string>
     );
     const options = payloads[0].options;
 

--- a/libs/act/src/internal/reactions.ts
+++ b/libs/act/src/internal/reactions.ts
@@ -17,6 +17,7 @@
  * @internal
  */
 
+import { strip_for_handler } from "../sensitive.js";
 import {
   type Actor,
   type BatchHandler,
@@ -50,6 +51,12 @@ export type ReactionDeps<
   readonly boundLoad: IAct<TEvents, TActions, TActor>["load"];
   readonly boundQuery: IAct<TEvents, TActions, TActor>["query"];
   readonly boundQueryArray: IAct<TEvents, TActions, TActor>["query_array"];
+  /**
+   * Registry-backed lookup of sensitive field names per event. Reaction and
+   * batch handlers receive the event with these keys stripped from
+   * `data` and the `pii` field dropped (#855 slice 5).
+   */
+  readonly pii_fields: (eventName: string) => readonly string[];
 };
 
 /**
@@ -116,7 +123,14 @@ export function buildHandle<
   TActions extends Schemas,
   TActor extends Actor = Actor,
 >(deps: ReactionDeps<TEvents, TActions, TActor>): Handle<TEvents> {
-  const { logger, boundDo, boundLoad, boundQuery, boundQueryArray } = deps;
+  const {
+    logger,
+    boundDo,
+    boundLoad,
+    boundQuery,
+    boundQueryArray,
+    pii_fields,
+  } = deps;
   return async (lease, payloads) => {
     if (payloads.length === 0) return { lease, handled: 0, acked_at: lease.at };
 
@@ -136,6 +150,14 @@ export function buildHandle<
 
     for (const payload of payloads) {
       const { event, handler } = payload;
+      // Strip sensitive fields before the handler ever sees the event —
+      // reactions that genuinely need PII opt back in via `app.load(stream,
+      // { actor: systemActor })` inside the handler, making the
+      // security-relevant path explicit at the call site.
+      const handler_event = strip_for_handler(
+        event as Committed<TEvents, keyof TEvents & string>,
+        pii_fields(event.name as string)
+      );
       scopedApp.do = <TKey extends keyof TActions & string>(
         action: TKey,
         target: Target<TActor>,
@@ -151,7 +173,7 @@ export function buildHandle<
           skipValidation
         );
       try {
-        await handler(event, stream, scopedApp);
+        await handler(handler_event, stream, scopedApp);
         at = event.id;
         handled++;
       } catch (error) {
@@ -178,7 +200,8 @@ export function buildHandle<
  * @internal
  */
 export function buildHandleBatch<TEvents extends Schemas>(
-  logger: Logger
+  logger: Logger,
+  pii_fields: (eventName: string) => readonly string[]
 ): HandleBatch<TEvents> {
   return async (
     lease: Lease,
@@ -186,7 +209,14 @@ export function buildHandleBatch<TEvents extends Schemas>(
     batchHandler: BatchHandler<TEvents>
   ) => {
     const stream = lease.stream;
-    const events = payloads.map((p) => p.event);
+    // Same handler-stripping rule applies to batch handlers as to per-event
+    // reactions: projections see events without sensitive keys.
+    const events = payloads.map((p) =>
+      strip_for_handler(
+        p.event as Committed<TEvents, keyof TEvents & string>,
+        pii_fields(p.event.name as string)
+      )
+    );
     const options = payloads[0].options;
 
     if (lease.retry > 0)

--- a/libs/act/src/internal/reactions.ts
+++ b/libs/act/src/internal/reactions.ts
@@ -145,11 +145,6 @@ export function buildHandle<
 
     for (const payload of payloads) {
       const { event, handler } = payload;
-      // PII strip is wrapped into the handler itself at build time (#855):
-      // reactions registered against an event with `sensitive(...)` fields
-      // get a stripping handler closure during `act().build()`; reactions
-      // against non-PII events keep their original handler reference.
-      // The dispatcher is PII-unaware — zero per-event branching here.
       scopedApp.do = <TKey extends keyof TActions & string>(
         action: TKey,
         target: Target<TActor>,
@@ -200,8 +195,6 @@ export function buildHandleBatch<TEvents extends Schemas>(
     batchHandler: BatchHandler<TEvents>
   ) => {
     const stream = lease.stream;
-    // PII strip happens inside `batchHandler` when needed — wrapped at build
-    // time per `act-builder.ts`. The dispatcher hands raw events through.
     const events = payloads.map(
       (p) => p.event as Committed<TEvents, keyof TEvents & string>
     );

--- a/libs/act/src/internal/reactions.ts
+++ b/libs/act/src/internal/reactions.ts
@@ -17,7 +17,6 @@
  * @internal
  */
 
-import { strip_for_handler } from "../sensitive.js";
 import {
   type Actor,
   type BatchHandler,
@@ -33,6 +32,7 @@ import {
 } from "../types/index.js";
 import { computeBackoffDelay } from "./backoff.js";
 import type { Handle, HandleBatch, HandleResult } from "./drain-cycle.js";
+import { strip_for_handler } from "./sensitive.js";
 
 /**
  * Dependencies a reaction handler needs from the orchestrator: the logger

--- a/libs/act/src/internal/reactions.ts
+++ b/libs/act/src/internal/reactions.ts
@@ -47,10 +47,11 @@ export type ReactionDeps<
   TActor extends Actor = Actor,
 > = {
   readonly logger: Logger;
-  readonly boundDo: IAct<TEvents, TActions, TActor>["do"];
-  readonly boundLoad: IAct<TEvents, TActions, TActor>["load"];
-  readonly boundQuery: IAct<TEvents, TActions, TActor>["query"];
-  readonly boundQueryArray: IAct<TEvents, TActions, TActor>["query_array"];
+  readonly bound_do: IAct<TEvents, TActions, TActor>["do"];
+  readonly bound_load: IAct<TEvents, TActions, TActor>["load"];
+  readonly bound_query: IAct<TEvents, TActions, TActor>["query"];
+  readonly bound_query_array: IAct<TEvents, TActions, TActor>["query_array"];
+  readonly bound_forget: IAct<TEvents, TActions, TActor>["forget"];
   /**
    * Registry-backed lookup of sensitive field names per event. Reaction and
    * batch handlers receive the event with these keys stripped from
@@ -125,10 +126,11 @@ export function buildHandle<
 >(deps: ReactionDeps<TEvents, TActions, TActor>): Handle<TEvents> {
   const {
     logger,
-    boundDo,
-    boundLoad,
-    boundQuery,
-    boundQueryArray,
+    bound_do,
+    bound_load,
+    bound_query,
+    bound_query_array,
+    bound_forget,
     pii_fields,
   } = deps;
   return async (lease, payloads) => {
@@ -142,10 +144,11 @@ export function buildHandle<
       logger.warn(`Retrying ${stream}@${at} (${lease.retry}).`);
 
     const scopedApp: IAct<TEvents, TActions, TActor> = {
-      do: boundDo,
-      load: boundLoad,
-      query: boundQuery,
-      query_array: boundQueryArray,
+      do: bound_do,
+      load: bound_load,
+      query: bound_query,
+      query_array: bound_query_array,
+      forget: bound_forget,
     };
 
     for (const payload of payloads) {
@@ -165,7 +168,7 @@ export function buildHandle<
         reactingTo?: Committed<Schemas, string>,
         skipValidation?: boolean
       ) =>
-        boundDo(
+        bound_do(
           action,
           target,
           actionPayload,

--- a/libs/act/src/internal/sensitive.ts
+++ b/libs/act/src/internal/sensitive.ts
@@ -104,6 +104,32 @@ export function pii_fields(schema: z.ZodType): readonly string[] {
 }
 
 /**
+ * Split an emitted event's `data` into `data` (non-sensitive) + `pii`
+ * (sensitive) using the field list precomputed at build time. Used by the
+ * State's `_split_emitted` decorator just before `Store.commit`.
+ *
+ * Single forward pass over `Object.keys(validated)` — same shape as the
+ * spread-and-delete-free implementation in slice 3, just hoisted out of the
+ * orchestrator hot path so it's only invoked when the State actually has a
+ * sensitive event.
+ *
+ * @internal
+ */
+export function split_payload(
+  emitted: { name: unknown; data: unknown },
+  fields: readonly string[]
+): { name: unknown; data: unknown; pii: Record<string, unknown> } {
+  const rec = emitted.data as Record<string, unknown>;
+  const clean: Record<string, unknown> = {};
+  const pii: Record<string, unknown> = {};
+  for (const k of Object.keys(rec)) {
+    if (fields.includes(k)) pii[k] = rec[k];
+    else clean[k] = rec[k];
+  }
+  return { name: emitted.name, data: clean, pii };
+}
+
+/**
  * Build the **reducer view** of a committed event — sensitive fields merged
  * back into `data` so per-state reducers always see plaintext.
  *
@@ -126,7 +152,9 @@ export function merge_for_reducer<
   event: Committed<TEvents, TKey>,
   fields: readonly string[]
 ): Committed<TEvents, TKey> {
-  if (fields.length === 0) return event;
+  // Contract: `fields` is non-empty. Callers (the State's `_merge_for_reducer`
+  // decorator) filter on `fields_by_event.get(name)` before invocation, so the
+  // empty-fields short-circuit lives at the caller, not here.
   const data = event.data as Record<string, unknown>;
   const pii = event.pii;
   if (pii != null) {
@@ -170,7 +198,8 @@ export function gate_external<
   predicate: ((event: any, actor: Actor) => boolean) | null,
   actor: Actor | undefined
 ): Committed<TEvents, TKey> {
-  if (fields.length === 0) return event;
+  // Contract: `fields` is non-empty. The State's `_gate_external` decorator
+  // filters on `fields_by_event.get(name)` before invocation.
   const data = event.data as Record<string, unknown>;
   if (event.pii == null) {
     const shredded: Record<string, unknown> = { ...data };
@@ -225,7 +254,8 @@ export function strip_for_handler<
   event: Committed<TEvents, TKey>,
   fields: readonly string[]
 ): Committed<TEvents, TKey> {
-  if (fields.length === 0) return event;
+  // Contract: `fields` is non-empty. `buildHandle` / `buildHandleBatch`
+  // filter on `fields.length > 0` before invocation.
   const data = event.data as Record<string, unknown>;
   const stripped: Record<string, unknown> = {};
   for (const k of Object.keys(data)) {

--- a/libs/act/src/internal/sensitive.ts
+++ b/libs/act/src/internal/sensitive.ts
@@ -12,12 +12,12 @@
  *   `sensitive()` adds to it; the helpers in this module read it.
  * - `pii_fields(schema)` — walk a Zod schema's top-level shape, return the
  *   keys marked via `sensitive(...)`.
- * - `merge_for_reducer(event, fields)` — produce the reducer view (pii merged
+ * - `pii_merge(event, fields)` — produce the reducer view (pii merged
  *   into data; `[SHREDDED]` if pii column is null).
- * - `gate_external(event, fields, predicate, actor)` — produce the external
+ * - `pii_gate(event, fields, predicate, actor)` — produce the external
  *   view: plaintext when authorized, `[REDACTED]` when not, `[SHREDDED]`
  *   when the underlying pii column is null.
- * - `strip_for_handler(event, fields)` — remove sensitive keys entirely
+ * - `pii_strip(event, fields)` — remove sensitive keys entirely
  *   before invoking projection / reaction handlers.
  *
  * @internal
@@ -106,7 +106,7 @@ export function pii_fields(schema: z.ZodType): readonly string[] {
 /**
  * Split an emitted event's `data` into `data` (non-sensitive) + `pii`
  * (sensitive) using the field list precomputed at build time. Used by the
- * State's `_split_emitted` decorator just before `Store.commit`.
+ * State's `_pii_split` decorator just before `Store.commit`.
  *
  * Single forward pass over `Object.keys(validated)` — same shape as the
  * spread-and-delete-free implementation in slice 3, just hoisted out of the
@@ -115,7 +115,7 @@ export function pii_fields(schema: z.ZodType): readonly string[] {
  *
  * @internal
  */
-export function split_payload(
+export function pii_split(
   emitted: { name: unknown; data: unknown },
   fields: readonly string[]
 ): { name: unknown; data: unknown; pii: Record<string, unknown> } {
@@ -141,18 +141,18 @@ export function split_payload(
  *
  * Used inside `load()` before invoking the reducer chain. Reducer-visible PII
  * is by design — the reducer is the source of truth for derived state. The
- * external view returned to callers is separately gated by {@link gate_external}.
+ * external view returned to callers is separately gated by {@link pii_gate}.
  *
  * @internal
  */
-export function merge_for_reducer<
+export function pii_merge<
   TEvents extends Schemas,
   TKey extends keyof TEvents & string,
 >(
   event: Committed<TEvents, TKey>,
   fields: readonly string[]
 ): Committed<TEvents, TKey> {
-  // Contract: `fields` is non-empty. Callers (the State's `_merge_for_reducer`
+  // Contract: `fields` is non-empty. Callers (the State's `_pii_merge`
   // decorator) filter on `fields_by_event.get(name)` before invocation, so the
   // empty-fields short-circuit lives at the caller, not here.
   const data = event.data as Record<string, unknown>;
@@ -189,7 +189,7 @@ export function merge_for_reducer<
  *
  * @internal
  */
-export function gate_external<
+export function pii_gate<
   TEvents extends Schemas,
   TKey extends keyof TEvents & string,
 >(
@@ -198,7 +198,7 @@ export function gate_external<
   predicate: ((event: any, actor: Actor) => boolean) | null,
   actor: Actor | undefined
 ): Committed<TEvents, TKey> {
-  // Contract: `fields` is non-empty. The State's `_gate_external` decorator
+  // Contract: `fields` is non-empty. The State's `_pii_gate` decorator
   // filters on `fields_by_event.get(name)` before invocation.
   const data = event.data as Record<string, unknown>;
   if (event.pii == null) {
@@ -234,7 +234,7 @@ export function gate_external<
  * and the `pii` field dropped from the event. Used before invoking projection
  * handlers and reaction handlers, which never see PII by framework rule.
  *
- * Different from {@link gate_external} (which substitutes {@link REDACTED} or
+ * Different from {@link pii_gate} (which substitutes {@link REDACTED} or
  * {@link SHREDDED}) — projection tables and reaction sinks shouldn't even
  * structurally observe the keys, so a handler that mistakenly writes
  * `event.data.email` into a column would get `undefined`, not a sentinel
@@ -247,7 +247,7 @@ export function gate_external<
  *
  * @internal
  */
-export function strip_for_handler<
+export function pii_strip<
   TEvents extends Schemas,
   TKey extends keyof TEvents & string,
 >(

--- a/libs/act/src/internal/sensitive.ts
+++ b/libs/act/src/internal/sensitive.ts
@@ -1,11 +1,38 @@
+/**
+ * @module sensitive
+ * @category Internal
+ *
+ * Internal mechanics for the sensitive-data foundation (#855 / epic #566).
+ * The public surface (`sensitive(zodType)`) lives at `libs/act/src/sensitive.ts`
+ * and re-exports `REDACTED` / `SHREDDED` from here; this module holds the
+ * registry plus the helpers the orchestrator calls during commit, load, and
+ * handler dispatch.
+ *
+ * - `_registry` — process-global `z.registry<{ sensitive: true }>()`. Public
+ *   `sensitive()` adds to it; the helpers in this module read it.
+ * - `pii_fields(schema)` — walk a Zod schema's top-level shape, return the
+ *   keys marked via `sensitive(...)`.
+ * - `merge_for_reducer(event, fields)` — produce the reducer view (pii merged
+ *   into data; `[SHREDDED]` if pii column is null).
+ * - `gate_external(event, fields, predicate, actor)` — produce the external
+ *   view: plaintext when authorized, `[REDACTED]` when not, `[SHREDDED]`
+ *   when the underlying pii column is null.
+ * - `strip_for_handler(event, fields)` — remove sensitive keys entirely
+ *   before invoking projection / reaction handlers.
+ *
+ * @internal
+ */
+
 import { z } from "zod";
-import type { Actor, Committed, Schemas } from "./types/index.js";
+import type { Actor, Committed, Schemas } from "../types/index.js";
 
 /**
  * Sentinel placed in `event.data[field]` when the caller isn't authorized to
  * see the sensitive field — either `.discloses(predicate)` returned `false`,
  * or no predicate was declared (framework default-deny). Recoverable: a
  * properly-authorized read returns the plaintext.
+ *
+ * Re-exported from `libs/act/src/sensitive.ts` as part of the public surface.
  */
 export const REDACTED = "[REDACTED]" as const;
 
@@ -13,61 +40,26 @@ export const REDACTED = "[REDACTED]" as const;
  * Sentinel placed in `event.data[field]` when the underlying PII payload has
  * been wiped via `Store.forget_pii(stream)` — the row's pii column is `NULL`
  * and the original plaintext is gone forever. Irrecoverable.
+ *
+ * Re-exported from `libs/act/src/sensitive.ts` as part of the public surface.
  */
 export const SHREDDED = "[SHREDDED]" as const;
-
-/**
- * @packageDocumentation
- * @module act
- * @category Sensitive data
- *
- * Schema-level marking for sensitive (PII) event fields. The first piece of
- * the sensitive-data epic (#566) — colocates the security classification with
- * the type definition so there is one source of truth per field.
- *
- * Wrap a Zod field with `sensitive(...)` and the framework registers the
- * underlying schema in a process-global Zod registry. The wrapper is
- * type-transparent: `sensitive(z.string())` is still a `z.ZodString` from
- * TypeScript's perspective, so callers never need to know about the marker.
- *
- * @example
- * ```ts
- * import { state, sensitive } from "@rotorsoft/act";
- *
- * const UserRegistered = z.object({
- *   email: sensitive(z.string().email()),
- *   name: sensitive(z.string()),
- *   plan: z.enum(["free", "pro"]),  // not sensitive — stays in events.data
- * });
- * ```
- */
 
 /**
  * Process-global registry holding every Zod schema marked sensitive. Backed
  * by a `WeakMap`, so wrapper-created instances (`.optional()`, `.nullable()`,
  * `.default()`) that chain off a marked schema produce *new* schema instances
  * the registry doesn't track; the field walker handles those via unwrap.
+ *
+ * Exported so the public `sensitive(zodType)` wrapper can call `_registry.add`.
+ * Underscore prefix marks "framework-private, don't touch from user code."
+ *
+ * @internal
  */
-const _registry = z.registry<{ sensitive: true }>();
+export const _registry = z.registry<{ sensitive: true }>();
 
 /**
- * Mark a Zod schema as sensitive. Returns the same schema instance — the
- * marker is registered out-of-band so the static type is preserved and the
- * call site reads as a pure annotation.
- *
- * Idempotent: re-wrapping an already-sensitive schema is a no-op (the
- * registry entry already exists; `add()` overwrites with the same value).
- *
- * @param schema - The Zod schema to mark sensitive.
- * @returns The same schema instance, unmodified at the type level.
- */
-export function sensitive<T extends z.ZodType>(schema: T): T {
-  _registry.add(schema, { sensitive: true });
-  return schema;
-}
-
-/**
- * Internal — true when the given schema was marked via {@link sensitive}.
+ * True when the given schema was marked via `sensitive(...)`.
  *
  * Walks through Zod wrapper layers (`.optional()`, `.nullable()`,
  * `.default()`, `.readonly()`) by following `_def.innerType` until it reaches
@@ -92,7 +84,7 @@ function is_pii(schema: z.ZodType): boolean {
  *
  * Walks the top-level shape of a `z.object({...})` and returns the keys whose
  * schema (after unwrapping optional/nullable/default wrappers) was marked via
- * {@link sensitive}. Returns an empty array for non-object schemas or events
+ * `sensitive(...)`. Returns an empty array for non-object schemas or events
  * with no sensitive fields — the common-case zero-cost path.
  *
  * Only the top-level shape is walked. Sensitive fields nested inside a

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -172,8 +172,7 @@ export function buildEs(
 ): EsOps {
   // `es.action` takes `correlator` as its last positional arg; bind it once
   // here so the orchestrator's `EsOps.action` keeps the original 6-arg
-  // signature. The PII split (#855) moved off the action signature onto the
-  // State's `_pii_split` decorator — buildEs no longer threads it.
+  // signature.
   const bound_action: EsOps["action"] = (
     me,
     actionName,

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -168,13 +168,12 @@ const traced = <F extends AsyncFn>(
  */
 export function buildEs(
   logger: Logger,
-  correlator: Correlator = defaultCorrelator,
-  pii_fields: (eventName: string) => readonly string[] = () => []
+  correlator: Correlator = defaultCorrelator
 ): EsOps {
-  // `es.action` takes `correlator` and `pii_fields` as its last two positional
-  // args; the orchestrator never wants to plumb them through every call site,
-  // so we bind them once here and present an `EsOps.action` with the original
-  // 6-arg signature.
+  // `es.action` takes `correlator` as its last positional arg; bind it once
+  // here so the orchestrator's `EsOps.action` keeps the original 6-arg
+  // signature. The PII split (#855) moved off the action signature onto the
+  // State's `_split_emitted` decorator — buildEs no longer threads it.
   const bound_action: EsOps["action"] = (
     me,
     actionName,
@@ -190,18 +189,12 @@ export function buildEs(
       payload,
       reactingTo,
       skipValidation,
-      correlator,
-      pii_fields
+      correlator
     );
-  // load takes `pii_lookup` as its last positional arg — same binding pattern
-  // as action's `pii_fields`. EsOps.load presents the original 5-arg signature
-  // (`actor` stays positional so callers can pass it through).
-  const bound_load: EsOps["load"] = (me, stream, cb, asOf, actor) =>
-    es.load(me, stream, cb, asOf, actor, pii_fields);
   if (logger.level !== "trace") {
     return {
       snap: es.snap,
-      load: bound_load,
+      load: es.load,
       action: bound_action,
       tombstone: es.tombstone,
     };
@@ -216,7 +209,7 @@ export function buildEs(
         )
       );
     }),
-    load: traced(bound_load, (result, _me, stream, _cb, asOf) => {
+    load: traced(es.load, (result, _me, stream, _cb, asOf) => {
       const stats = stats_marker(
         result.version,
         result.replayed,

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -169,12 +169,12 @@ const traced = <F extends AsyncFn>(
 export function buildEs(
   logger: Logger,
   correlator: Correlator = defaultCorrelator,
-  sensitiveFields: (eventName: string) => readonly string[] = () => []
+  pii_fields: (eventName: string) => readonly string[] = () => []
 ): EsOps {
-  // `es.action` takes `correlator` and `sensitiveFields` as its last two
-  // positional args; the orchestrator never wants to plumb them through every
-  // call site, so we bind them once here and present an `EsOps.action` with
-  // the original 6-arg signature.
+  // `es.action` takes `correlator` and `pii_fields` as its last two positional
+  // args; the orchestrator never wants to plumb them through every call site,
+  // so we bind them once here and present an `EsOps.action` with the original
+  // 6-arg signature.
   const boundAction: EsOps["action"] = (
     me,
     actionName,
@@ -191,7 +191,7 @@ export function buildEs(
       reactingTo,
       skipValidation,
       correlator,
-      sensitiveFields
+      pii_fields
     );
   if (logger.level !== "trace") {
     return {

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -168,12 +168,13 @@ const traced = <F extends AsyncFn>(
  */
 export function buildEs(
   logger: Logger,
-  correlator: Correlator = defaultCorrelator
+  correlator: Correlator = defaultCorrelator,
+  sensitiveFields: (eventName: string) => readonly string[] = () => []
 ): EsOps {
-  // `es.action` takes `correlator` as its last positional arg; the
-  // orchestrator never wants to plumb it through every call site, so we
-  // bind it once here and present an `EsOps.action` with the original
-  // 6-arg signature.
+  // `es.action` takes `correlator` and `sensitiveFields` as its last two
+  // positional args; the orchestrator never wants to plumb them through every
+  // call site, so we bind them once here and present an `EsOps.action` with
+  // the original 6-arg signature.
   const boundAction: EsOps["action"] = (
     me,
     actionName,
@@ -189,7 +190,8 @@ export function buildEs(
       payload,
       reactingTo,
       skipValidation,
-      correlator
+      correlator,
+      sensitiveFields
     );
   if (logger.level !== "trace") {
     return {

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -173,7 +173,7 @@ export function buildEs(
   // `es.action` takes `correlator` as its last positional arg; bind it once
   // here so the orchestrator's `EsOps.action` keeps the original 6-arg
   // signature. The PII split (#855) moved off the action signature onto the
-  // State's `_split_emitted` decorator — buildEs no longer threads it.
+  // State's `_pii_split` decorator — buildEs no longer threads it.
   const bound_action: EsOps["action"] = (
     me,
     actionName,

--- a/libs/act/src/internal/tracing.ts
+++ b/libs/act/src/internal/tracing.ts
@@ -175,7 +175,7 @@ export function buildEs(
   // args; the orchestrator never wants to plumb them through every call site,
   // so we bind them once here and present an `EsOps.action` with the original
   // 6-arg signature.
-  const boundAction: EsOps["action"] = (
+  const bound_action: EsOps["action"] = (
     me,
     actionName,
     target,
@@ -193,11 +193,16 @@ export function buildEs(
       correlator,
       pii_fields
     );
+  // load takes `pii_lookup` as its last positional arg — same binding pattern
+  // as action's `pii_fields`. EsOps.load presents the original 5-arg signature
+  // (`actor` stays positional so callers can pass it through).
+  const bound_load: EsOps["load"] = (me, stream, cb, asOf, actor) =>
+    es.load(me, stream, cb, asOf, actor, pii_fields);
   if (logger.level !== "trace") {
     return {
       snap: es.snap,
-      load: es.load,
-      action: boundAction,
+      load: bound_load,
+      action: bound_action,
       tombstone: es.tombstone,
     };
   }
@@ -211,7 +216,7 @@ export function buildEs(
         )
       );
     }),
-    load: traced(es.load, (result, _me, stream, _cb, asOf) => {
+    load: traced(bound_load, (result, _me, stream, _cb, asOf) => {
       const stats = stats_marker(
         result.version,
         result.replayed,
@@ -227,7 +232,7 @@ export function buildEs(
       );
     }),
     action: traced(
-      boundAction,
+      bound_action,
       (snapshots, _me, _action, target) => {
         const committed = snapshots.filter((s) => s.event);
         if (committed.length) {

--- a/libs/act/src/sensitive.ts
+++ b/libs/act/src/sensitive.ts
@@ -207,3 +207,43 @@ export function gate_external<
     data: redacted as Committed<TEvents, TKey>["data"],
   };
 }
+
+/**
+ * Build the **handler view** — sensitive keys removed entirely from `data`
+ * and the `pii` field dropped from the event. Used before invoking projection
+ * handlers and reaction handlers, which never see PII by framework rule.
+ *
+ * Different from {@link gate_external} (which substitutes {@link REDACTED} or
+ * {@link SHREDDED}) — projection tables and reaction sinks shouldn't even
+ * structurally observe the keys, so a handler that mistakenly writes
+ * `event.data.email` into a column would get `undefined`, not a sentinel
+ * string that looks like real data. The strictness is deliberate.
+ *
+ * Reactions that genuinely need PII (e.g. a welcome-email reaction reading
+ * `email`) opt back in by explicitly calling `app.load(stream, { actor:
+ * systemActor })` inside the handler — pulling PII through the gate at the
+ * call site makes the security-relevant path visible in code review.
+ *
+ * @internal
+ */
+export function strip_for_handler<
+  TEvents extends Schemas,
+  TKey extends keyof TEvents & string,
+>(
+  event: Committed<TEvents, TKey>,
+  fields: readonly string[]
+): Committed<TEvents, TKey> {
+  if (fields.length === 0) return event;
+  const data = event.data as Record<string, unknown>;
+  const stripped: Record<string, unknown> = {};
+  for (const k of Object.keys(data)) {
+    if (!fields.includes(k)) stripped[k] = data[k];
+  }
+  const { pii: _drop_pii, ...rest } = event as Committed<TEvents, TKey> & {
+    pii?: unknown;
+  };
+  return {
+    ...rest,
+    data: stripped as Committed<TEvents, TKey>["data"],
+  } as Committed<TEvents, TKey>;
+}

--- a/libs/act/src/sensitive.ts
+++ b/libs/act/src/sensitive.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+/**
+ * @packageDocumentation
+ * @module act
+ * @category Sensitive data
+ *
+ * Schema-level marking for sensitive (PII) event fields. The first piece of
+ * the sensitive-data epic (#566) — colocates the security classification with
+ * the type definition so there is one source of truth per field.
+ *
+ * Wrap a Zod field with `sensitive(...)` and the framework registers the
+ * underlying schema in a process-global Zod registry. The wrapper is
+ * type-transparent: `sensitive(z.string())` is still a `z.ZodString` from
+ * TypeScript's perspective, so callers never need to know about the marker.
+ *
+ * @example
+ * ```ts
+ * import { state, sensitive } from "@rotorsoft/act";
+ *
+ * const UserRegistered = z.object({
+ *   email: sensitive(z.string().email()),
+ *   name: sensitive(z.string()),
+ *   plan: z.enum(["free", "pro"]),  // not sensitive — stays in events.data
+ * });
+ * ```
+ */
+
+/**
+ * Process-global registry holding every Zod schema marked sensitive. Backed
+ * by a `WeakMap`, so wrapper-created instances (`.optional()`, `.nullable()`,
+ * `.default()`) that chain off a marked schema produce *new* schema instances
+ * the registry doesn't track; the field walker handles those via unwrap.
+ */
+const sensitiveRegistry = z.registry<{ sensitive: true }>();
+
+/**
+ * Mark a Zod schema as sensitive. Returns the same schema instance — the
+ * marker is registered out-of-band so the static type is preserved and the
+ * call site reads as a pure annotation.
+ *
+ * Idempotent: re-wrapping an already-sensitive schema is a no-op (the
+ * registry entry already exists; `add()` overwrites with the same value).
+ *
+ * @param schema - The Zod schema to mark sensitive.
+ * @returns The same schema instance, unmodified at the type level.
+ */
+export function sensitive<T extends z.ZodType>(schema: T): T {
+  sensitiveRegistry.add(schema, { sensitive: true });
+  return schema;
+}
+
+/**
+ * Internal — true when the given schema was marked via {@link sensitive}.
+ *
+ * Walks through Zod wrapper layers (`.optional()`, `.nullable()`,
+ * `.default()`, `.readonly()`) by following `_def.innerType` until it reaches
+ * a non-wrapper schema, then checks the registry. Wrappers create new schema
+ * instances; the marker lives on the *inner* schema the user wrapped, so we
+ * test that one.
+ *
+ * @internal
+ */
+function isSensitiveSchema(schema: z.ZodType): boolean {
+  let cur: z.ZodType = schema;
+  while (true) {
+    if (sensitiveRegistry.has(cur)) return true;
+    const inner = (cur as { _def?: { innerType?: z.ZodType } })._def?.innerType;
+    if (!inner || inner === cur) return false;
+    cur = inner;
+  }
+}
+
+/**
+ * Derive the list of sensitive field names from an event's Zod schema.
+ *
+ * Walks the top-level shape of a `z.object({...})` and returns the keys whose
+ * schema (after unwrapping optional/nullable/default wrappers) was marked via
+ * {@link sensitive}. Returns an empty array for non-object schemas or events
+ * with no sensitive fields — the common-case zero-cost path.
+ *
+ * Only the top-level shape is walked. Sensitive fields nested inside a
+ * `z.object` declared inside the event payload would require recursive
+ * descent; that's deferred until a real callsite needs it.
+ *
+ * @internal — consumed by the registry's `sensitive_fields(eventName)` lookup.
+ */
+export function getSensitiveFields(schema: z.ZodType): readonly string[] {
+  const shape = (schema as { shape?: Record<string, z.ZodType> }).shape;
+  if (!shape || typeof shape !== "object") return [];
+  const fields: string[] = [];
+  for (const key of Object.keys(shape)) {
+    if (isSensitiveSchema(shape[key])) fields.push(key);
+  }
+  return fields;
+}

--- a/libs/act/src/sensitive.ts
+++ b/libs/act/src/sensitive.ts
@@ -32,7 +32,7 @@ import { z } from "zod";
  * `.default()`) that chain off a marked schema produce *new* schema instances
  * the registry doesn't track; the field walker handles those via unwrap.
  */
-const sensitiveRegistry = z.registry<{ sensitive: true }>();
+const _registry = z.registry<{ sensitive: true }>();
 
 /**
  * Mark a Zod schema as sensitive. Returns the same schema instance — the
@@ -46,7 +46,7 @@ const sensitiveRegistry = z.registry<{ sensitive: true }>();
  * @returns The same schema instance, unmodified at the type level.
  */
 export function sensitive<T extends z.ZodType>(schema: T): T {
-  sensitiveRegistry.add(schema, { sensitive: true });
+  _registry.add(schema, { sensitive: true });
   return schema;
 }
 
@@ -61,10 +61,10 @@ export function sensitive<T extends z.ZodType>(schema: T): T {
  *
  * @internal
  */
-function isSensitiveSchema(schema: z.ZodType): boolean {
+function is_pii(schema: z.ZodType): boolean {
   let cur: z.ZodType = schema;
   while (true) {
-    if (sensitiveRegistry.has(cur)) return true;
+    if (_registry.has(cur)) return true;
     const inner = (cur as { _def?: { innerType?: z.ZodType } })._def?.innerType;
     if (!inner || inner === cur) return false;
     cur = inner;
@@ -85,12 +85,12 @@ function isSensitiveSchema(schema: z.ZodType): boolean {
  *
  * @internal — consumed by the registry's `sensitive_fields(eventName)` lookup.
  */
-export function getSensitiveFields(schema: z.ZodType): readonly string[] {
+export function pii_fields(schema: z.ZodType): readonly string[] {
   const shape = (schema as { shape?: Record<string, z.ZodType> }).shape;
   if (!shape || typeof shape !== "object") return [];
   const fields: string[] = [];
   for (const key of Object.keys(shape)) {
-    if (isSensitiveSchema(shape[key])) fields.push(key);
+    if (is_pii(shape[key])) fields.push(key);
   }
   return fields;
 }

--- a/libs/act/src/sensitive.ts
+++ b/libs/act/src/sensitive.ts
@@ -1,4 +1,20 @@
 import { z } from "zod";
+import type { Actor, Committed, Schemas } from "./types/index.js";
+
+/**
+ * Sentinel placed in `event.data[field]` when the caller isn't authorized to
+ * see the sensitive field — either `.discloses(predicate)` returned `false`,
+ * or no predicate was declared (framework default-deny). Recoverable: a
+ * properly-authorized read returns the plaintext.
+ */
+export const REDACTED = "[REDACTED]" as const;
+
+/**
+ * Sentinel placed in `event.data[field]` when the underlying PII payload has
+ * been wiped via `Store.forget_pii(stream)` — the row's pii column is `NULL`
+ * and the original plaintext is gone forever. Irrecoverable.
+ */
+export const SHREDDED = "[SHREDDED]" as const;
 
 /**
  * @packageDocumentation
@@ -93,4 +109,101 @@ export function pii_fields(schema: z.ZodType): readonly string[] {
     if (is_pii(shape[key])) fields.push(key);
   }
   return fields;
+}
+
+/**
+ * Build the **reducer view** of a committed event — sensitive fields merged
+ * back into `data` so per-state reducers always see plaintext.
+ *
+ * - Event with no `pii` payload AND no schema-declared sensitive fields →
+ *   return the event unchanged (zero-cost path).
+ * - Event with a `pii` payload → merge into `data` (plaintext for the reducer).
+ * - Event whose schema *declares* sensitive fields but `pii` is null/undefined
+ *   (post-`forget_pii`) → substitute {@link SHREDDED} for each declared field.
+ *
+ * Used inside `load()` before invoking the reducer chain. Reducer-visible PII
+ * is by design — the reducer is the source of truth for derived state. The
+ * external view returned to callers is separately gated by {@link gate_external}.
+ *
+ * @internal
+ */
+export function merge_for_reducer<
+  TEvents extends Schemas,
+  TKey extends keyof TEvents & string,
+>(
+  event: Committed<TEvents, TKey>,
+  fields: readonly string[]
+): Committed<TEvents, TKey> {
+  if (fields.length === 0) return event;
+  const data = event.data as Record<string, unknown>;
+  const pii = event.pii;
+  if (pii != null) {
+    return {
+      ...event,
+      data: { ...data, ...pii } as Committed<TEvents, TKey>["data"],
+    };
+  }
+  // Schema declared sensitive fields but the pii payload is gone — shredded.
+  const shredded: Record<string, unknown> = { ...data };
+  for (const f of fields) shredded[f] = SHREDDED;
+  return {
+    ...event,
+    data: shredded as Committed<TEvents, TKey>["data"],
+  };
+}
+
+/**
+ * Build the **external view** of a committed event — the form returned by
+ * `load()`, `query()`, `query_array()`, and the snapshot in `do()`'s reply.
+ *
+ * - Event with no schema-declared sensitive fields → returned unchanged
+ *   (zero-cost path).
+ * - Event whose `pii` payload is null/undefined AND schema declares sensitive
+ *   fields → substitute {@link SHREDDED} for each declared field. Irrecoverable,
+ *   so no predicate check.
+ * - Event with a `pii` payload, predicate returns `true` → merge `pii` into
+ *   `data` (plaintext).
+ * - Event with a `pii` payload, predicate returns `false` OR no predicate
+ *   declared (framework default-deny) → substitute {@link REDACTED} for each
+ *   declared field.
+ *
+ * @internal
+ */
+export function gate_external<
+  TEvents extends Schemas,
+  TKey extends keyof TEvents & string,
+>(
+  event: Committed<TEvents, TKey>,
+  fields: readonly string[],
+  predicate: ((event: any, actor: Actor) => boolean) | null,
+  actor: Actor | undefined
+): Committed<TEvents, TKey> {
+  if (fields.length === 0) return event;
+  const data = event.data as Record<string, unknown>;
+  if (event.pii == null) {
+    const shredded: Record<string, unknown> = { ...data };
+    for (const f of fields) shredded[f] = SHREDDED;
+    return {
+      ...event,
+      data: shredded as Committed<TEvents, TKey>["data"],
+    };
+  }
+  // Plaintext path requires both an actor AND a predicate that allows. Missing
+  // either → default-deny → REDACTED.
+  const allowed = !!actor && !!predicate && predicate(event, actor);
+  if (allowed) {
+    return {
+      ...event,
+      data: {
+        ...data,
+        ...(event.pii as Record<string, unknown>),
+      } as Committed<TEvents, TKey>["data"],
+    };
+  }
+  const redacted: Record<string, unknown> = { ...data };
+  for (const f of fields) redacted[f] = REDACTED;
+  return {
+    ...event,
+    data: redacted as Committed<TEvents, TKey>["data"],
+  };
 }

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -528,6 +528,20 @@ export type State<
    * `ConcurrencyError` surfaces on first conflict.
    */
   options?: { [TKey in keyof TActions]?: ActionOptions };
+  /**
+   * Disclosure predicate set by `.discloses(predicate)`. Gates external
+   * reads of `sensitive(...)`-marked fields — returning `true` allows the
+   * actor to see plaintext, `false` redacts. When absent, the framework
+   * default-denies on every external read (sensitive fields are always
+   * substituted with `"[REDACTED]"`). See #855 / epic #566.
+   */
+  // The stored predicate is erased — `any` for the event makes the field
+  // signature bivariant so a narrow `State<{count: number}, {Counted: ...},
+  // ...>` is assignable to `State<any, any, any>` without TypeScript blocking
+  // on contravariant function params. The public `.discloses()` method on the
+  // builder keeps the narrow signature so users still get type-checked predicates.
+  // biome-ignore lint/suspicious/noExplicitAny: erased for State<any,any,any> compatibility
+  disclose?: (event: any, actor: Actor) => boolean;
 };
 
 /**

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -888,4 +888,23 @@ export interface IAct<
   }>;
 
   query_array(query: Query): Promise<Committed<TEvents, keyof TEvents>[]>;
+
+  /**
+   * Wipe the sensitive-data payload for every event on the stream — the
+   * application-level half of the sensitive-data epic (#566). Delegates to
+   * the Store's `forget_pii(stream)`, invalidates the cache entry for the
+   * stream, then emits the `forgotten` lifecycle event.
+   *
+   * Throws at build time if the configured Store does not implement
+   * `forget_pii` (its adapter declares `pii_isolation: false` or omits the
+   * method) — operators get a clear "your adapter can't comply with GDPR
+   * erasure" signal before the production callsite is exercised.
+   *
+   * Idempotent: a second call on an already-wiped stream returns
+   * `eventCount: 0` and does NOT re-emit `forgotten`.
+   *
+   * @param stream - Target stream to wipe.
+   * @returns Count of events whose PII column was set to NULL.
+   */
+  forget(stream: string): Promise<{ eventCount: number }>;
 }

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -555,15 +555,15 @@ export type State<
    * @internal
    */
   // biome-ignore lint/suspicious/noExplicitAny: internal decorator, event payload varies per state
-  _split_emitted?: (e: { name: any; data: any }) => {
+  _pii_split?: (e: { name: any; data: any }) => {
     name: any;
     data: any;
     pii?: Record<string, unknown>;
   };
   // biome-ignore lint/suspicious/noExplicitAny: same
-  _merge_for_reducer?: (event: any) => any;
+  _pii_merge?: (event: any) => any;
   // biome-ignore lint/suspicious/noExplicitAny: same
-  _gate_external?: (event: any, actor: Actor | undefined) => any;
+  _pii_gate?: (event: any, actor: Actor | undefined) => any;
 };
 
 /**

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -542,6 +542,28 @@ export type State<
   // builder keeps the narrow signature so users still get type-checked predicates.
   // biome-ignore lint/suspicious/noExplicitAny: erased for State<any,any,any> compatibility
   disclose?: (event: any, actor: Actor) => boolean;
+  /**
+   * Build-time decorators for the sensitive-data foundation (#855). Attached
+   * by `act().build()` on states whose events declare `sensitive(...)`
+   * fields; absent on states without PII. The orchestrator's hot paths use
+   * `me._x?.(arg) ?? arg` — for PII-free states the optional-chain
+   * short-circuits and zero PII machinery is touched per event.
+   *
+   * Internal, decided at build time, never set by user code. Underscore
+   * prefix follows the project's private-field convention.
+   *
+   * @internal
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: internal decorator, event payload varies per state
+  _split_emitted?: (e: { name: any; data: any }) => {
+    name: any;
+    data: any;
+    pii?: Record<string, unknown>;
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: same
+  _merge_for_reducer?: (event: any) => any;
+  // biome-ignore lint/suspicious/noExplicitAny: same
+  _gate_external?: (event: any, actor: Actor | undefined) => any;
 };
 
 /**

--- a/libs/act/src/types/action.ts
+++ b/libs/act/src/types/action.ts
@@ -543,27 +543,33 @@ export type State<
   // biome-ignore lint/suspicious/noExplicitAny: erased for State<any,any,any> compatibility
   disclose?: (event: any, actor: Actor) => boolean;
   /**
-   * Build-time decorators for the sensitive-data foundation (#855). Attached
-   * by `act().build()` on states whose events declare `sensitive(...)`
-   * fields; absent on states without PII. The orchestrator's hot paths use
-   * `me._x?.(arg) ?? arg` — for PII-free states the optional-chain
-   * short-circuits and zero PII machinery is touched per event.
+   * Build-time step delegates wired by `act().build()`. The orchestrator
+   * calls these instead of branching on PII per event — for PII-aware
+   * states they bake the merge/gate/split into the step; for PII-free
+   * states they're identity.
    *
-   * Internal, decided at build time, never set by user code. Underscore
-   * prefix follows the project's private-field convention.
+   * - `view(event, actor)` — produces the caller-visible form of a
+   *   committed event (gates `sensitive(...)` fields via `.discloses` on
+   *   PII-aware states; identity otherwise).
+   * - `message(validated)` — produces the `{name, data, pii?}` shape that
+   *   goes to `Store.commit` (peels sensitive fields off `data` into
+   *   `pii` on PII-aware states; identity otherwise).
+   * - `patch[eventName]` — already on State as the per-event reducer.
+   *   Wrapped at build time to merge PII into `data` first when the
+   *   event carries sensitive fields; left bare for plain reducers.
+   *
+   * Internal, always set after build, never assigned by user code.
    *
    * @internal
    */
-  // biome-ignore lint/suspicious/noExplicitAny: internal decorator, event payload varies per state
-  _pii_split?: (e: { name: any; data: any }) => {
+  // biome-ignore lint/suspicious/noExplicitAny: internal step, event payload varies per state
+  view: (event: any, actor: Actor | undefined) => any;
+  // biome-ignore lint/suspicious/noExplicitAny: same
+  message: (validated: { name: any; data: any }) => {
     name: any;
     data: any;
     pii?: Record<string, unknown>;
   };
-  // biome-ignore lint/suspicious/noExplicitAny: same
-  _pii_merge?: (event: any) => any;
-  // biome-ignore lint/suspicious/noExplicitAny: same
-  _pii_gate?: (event: any, actor: Actor | undefined) => any;
 };
 
 /**

--- a/libs/act/src/types/registry.ts
+++ b/libs/act/src/types/registry.ts
@@ -1,5 +1,12 @@
 import type { ZodType, z } from "zod";
-import type { CommittedMeta, Schema, Schemas, State } from "./action.js";
+import type {
+  Actor,
+  Committed,
+  CommittedMeta,
+  Schema,
+  Schemas,
+  State,
+} from "./action.js";
 import type { Reaction } from "./reaction.js";
 
 /**
@@ -52,6 +59,12 @@ export type SchemaRegister<TSchemaReg> = {
  * @template TActions - Action schemas.
  * @property actions - Map of action names to state definitions.
  * @property events - Map of event names to event registration info.
+ * @property sensitive_fields - Lookup of `sensitive(...)`-marked fields per
+ *   event name. Derived once at build time. Returns the empty array for
+ *   unknown events.
+ * @property disclosure_predicate - Lookup of the `.discloses(predicate)`
+ *   declaration per state name. Returns `null` when no predicate was set
+ *   (framework default-deny).
  */
 export type Registry<
   TSchemaReg extends SchemaRegister<TActions>,
@@ -62,6 +75,15 @@ export type Registry<
     [TKey in keyof TActions]: State<TSchemaReg[TKey], TEvents, TActions>;
   };
   readonly events: EventRegister<TEvents>;
+  readonly sensitive_fields: (eventName: string) => readonly string[];
+  readonly disclosure_predicate: (
+    stateName: string
+  ) =>
+    | ((
+        event: Committed<TEvents, keyof TEvents & string>,
+        actor: Actor
+      ) => boolean)
+    | null;
 };
 
 /**

--- a/libs/act/src/types/schemas.ts
+++ b/libs/act/src/types/schemas.ts
@@ -1,4 +1,5 @@
 import { type ZodObject, type ZodRawShape, z } from "zod";
+import { _registry } from "../internal/index.js";
 
 /**
  * @packageDocumentation
@@ -11,6 +12,47 @@ import { type ZodObject, type ZodRawShape, z } from "zod";
  * An empty Zod schema (no properties).
  */
 export const ZodEmpty = z.record(z.string(), z.never());
+
+/**
+ * Sentinel placed in `event.data[field]` when the caller isn't authorized to
+ * see the sensitive field — either `.discloses(predicate)` returned `false`,
+ * or no predicate was declared (framework default-deny). Recoverable: a
+ * properly-authorized read returns the plaintext.
+ *
+ * Part of the sensitive-data foundation (#855 / epic #566).
+ */
+export { REDACTED, SHREDDED } from "../internal/index.js";
+
+/**
+ * Mark a Zod schema as sensitive. Returns the same schema instance — the
+ * marker is registered out-of-band so the static type is preserved and the
+ * call site reads as a pure annotation.
+ *
+ * Idempotent: re-wrapping an already-sensitive schema is a no-op.
+ *
+ * The marker is what the orchestrator inspects to split event payloads into
+ * `data` + `pii` on commit, gate reads via `.discloses`, and strip handler
+ * payloads. Part of the sensitive-data foundation (#855 / epic #566).
+ *
+ * @example
+ * ```ts
+ * import { z } from "zod";
+ * import { state, sensitive } from "@rotorsoft/act";
+ *
+ * const UserRegistered = z.object({
+ *   email: sensitive(z.string()),
+ *   name: sensitive(z.string()),
+ *   plan: z.enum(["free", "pro"]),  // not sensitive — stays in events.data
+ * });
+ * ```
+ *
+ * @param schema - The Zod schema to mark sensitive.
+ * @returns The same schema instance, unmodified at the type level.
+ */
+export function sensitive<T extends z.ZodType>(schema: T): T {
+  _registry.add(schema, { sensitive: true });
+  return schema;
+}
 
 /**
  * Zod schema for an actor (user, system, etc.).

--- a/libs/act/src/types/schemas.ts
+++ b/libs/act/src/types/schemas.ts
@@ -1,5 +1,9 @@
 import { type ZodObject, type ZodRawShape, z } from "zod";
-import { _registry } from "../internal/index.js";
+// Deep-path import (vs `../internal/index.js`) is deliberate — `_registry` is
+// a side-effect-free leaf, and going through the internal barrel would pull
+// tracing.ts → config.ts in at type-schema load time and crash on TDZ when a
+// test imports a public schema before config is initialized.
+import { _registry } from "../internal/sensitive.js";
 
 /**
  * @packageDocumentation
@@ -21,7 +25,7 @@ export const ZodEmpty = z.record(z.string(), z.never());
  *
  * Part of the sensitive-data foundation (#855 / epic #566).
  */
-export { REDACTED, SHREDDED } from "../internal/index.js";
+export { REDACTED, SHREDDED } from "../internal/sensitive.js";
 
 /**
  * Mark a Zod schema as sensitive. Returns the same schema instance — the

--- a/libs/act/test/builder.spec.ts
+++ b/libs/act/test/builder.spec.ts
@@ -74,6 +74,8 @@ describe("Builder", () => {
       events: { e: ZodEmpty },
       patch: { e: () => ({}) },
       on: { a: () => ["e", {}] as [string, object] },
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     const state2 = {
       name: "foo2",
@@ -83,6 +85,8 @@ describe("Builder", () => {
       events: { e: ZodEmpty },
       patch: { e: () => ({}) },
       on: { a: () => ["e", {}] as [string, object] },
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     builder.withState(state1);
     expect(() => builder.withState(state2)).toThrow("Duplicate action");
@@ -208,6 +212,8 @@ describe("Builder", () => {
       events: { nonE1: ZodEmpty },
       patch: { nonE1: () => ({}) },
       on: { nonA: () => ["nonE1", {}] as [string, object] },
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     const s2 = {
       name: "NonObj",
@@ -217,6 +223,8 @@ describe("Builder", () => {
       events: { nonE2: ZodEmpty },
       patch: { nonE2: () => ({}) },
       on: { nonB: () => ["nonE2", {}] as [string, object] },
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     const builder = act();
     builder.withState(s1);

--- a/libs/act/test/commit-pii-split.spec.ts
+++ b/libs/act/test/commit-pii-split.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  type Actor,
+  act,
+  type Committed,
+  dispose,
+  type Schemas,
+  sensitive,
+  state,
+  store,
+} from "../src/index.js";
+
+const userSchema = z.object({
+  email: z.string().optional(),
+  plan: z.enum(["free", "pro"]).optional(),
+});
+
+const userRegisteredSchema = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+  plan: z.enum(["free", "pro"]),
+});
+
+const User = state({ User: userSchema })
+  .init(() => ({}))
+  .emits({ UserRegistered: userRegisteredSchema })
+  .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
+  .on({ register: userRegisteredSchema })
+  .emit((payload) => ["UserRegistered", payload])
+  .build();
+
+const counterSchema = z.object({ count: z.number() });
+const Counter = state({ Counter: counterSchema })
+  .init(() => ({ count: 0 }))
+  .emits({ Incremented: z.object({ by: z.number() }) })
+  .patch({ Incremented: ({ data }, s) => ({ count: s.count + data.by }) })
+  .on({ increment: z.object({ by: z.number() }) })
+  .emit((p) => ["Incremented", p])
+  .build();
+
+const actor: Actor = { id: "u-1", name: "Tester" };
+
+async function collect(): Promise<Committed<Schemas, keyof Schemas>[]> {
+  const out: Committed<Schemas, keyof Schemas>[] = [];
+  await store().query((e) => {
+    out.push(e);
+  });
+  return out;
+}
+
+describe("commit-path PII split (#855 slice 3)", () => {
+  afterEach(async () => {
+    await dispose()();
+  });
+
+  it("splits sensitive fields into events.pii — data carries only non-sensitive keys", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    const events = await collect();
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toEqual({ plan: "free" });
+    expect(events[0].pii).toEqual({ email: "u@example.com", name: "Ursula" });
+  });
+
+  it("zero-cost path — events with no sensitive fields are not split", async () => {
+    const app = act().withState(Counter).build();
+    await app.do("increment", { stream: "c-1", actor }, { by: 5 });
+    const events = await collect();
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toEqual({ by: 5 });
+    // No pii Map entry was set on the store — InMemoryStore returns the event
+    // without a `pii` field, which reads as undefined here.
+    expect(events[0].pii).toBeUndefined();
+  });
+
+  it("the snapshot returned to .do() carries the split data (post-split shape)", async () => {
+    const app = act().withState(User).build();
+    const [snapshot] = await app.do(
+      "register",
+      { stream: "user-2", actor },
+      { email: "u@example.com", name: "Ursula", plan: "pro" }
+    );
+    expect(snapshot.event?.data).toEqual({ plan: "pro" });
+    expect(snapshot.event?.pii).toEqual({
+      email: "u@example.com",
+      name: "Ursula",
+    });
+  });
+
+  it("when only some sensitive fields are present in the payload, only those move to pii", async () => {
+    // Build a state whose schema marks both email and middleName as sensitive,
+    // but middleName is optional — when omitted, it shouldn't appear in pii.
+    const optionalSchema = z.object({
+      email: sensitive(z.string()),
+      middleName: sensitive(z.string()).optional(),
+      plan: z.string(),
+    });
+    const Optional = state({ Optional: z.object({}) })
+      .init(() => ({}))
+      .emits({ OptionalEmitted: optionalSchema })
+      .patch({ OptionalEmitted: () => ({}) })
+      .on({ emit: optionalSchema })
+      .emit((p) => ["OptionalEmitted", p])
+      .build();
+    const app = act().withState(Optional).build();
+    await app.do(
+      "emit",
+      { stream: "o-1", actor },
+      { email: "x@y.com", plan: "free" } // middleName omitted
+    );
+    const events = await collect();
+    expect(events[0].data).toEqual({ plan: "free" });
+    expect(events[0].pii).toEqual({ email: "x@y.com" });
+  });
+});

--- a/libs/act/test/commit-pii-split.spec.ts
+++ b/libs/act/test/commit-pii-split.spec.ts
@@ -22,12 +22,16 @@ const userRegisteredSchema = z.object({
   plan: z.enum(["free", "pro"]),
 });
 
+// `.discloses(() => true)` is the simplest way to confirm the slice 3 split
+// without slice 4's gate intervening — the test wants to verify the
+// underlying split mechanic, not the read-time substitution.
 const User = state({ User: userSchema })
   .init(() => ({}))
   .emits({ UserRegistered: userRegisteredSchema })
   .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
   .on({ register: userRegisteredSchema })
   .emit((payload) => ["UserRegistered", payload])
+  .discloses(() => true)
   .build();
 
 const counterSchema = z.object({ count: z.number() });
@@ -78,14 +82,23 @@ describe("commit-path PII split (#855 slice 3)", () => {
     expect(events[0].pii).toBeUndefined();
   });
 
-  it("the snapshot returned to .do() carries the split data (post-split shape)", async () => {
+  it("the snapshot returned to .do() carries the gated event — split happens underneath", async () => {
+    // User's `.discloses(() => true)` lets the actor see plaintext, so the
+    // gate merges pii back into data on the returned snapshot. The split
+    // is still real — the underlying store has data/pii separated (verified
+    // by the first test) — the gate just reassembles for the authorized
+    // caller's view.
     const app = act().withState(User).build();
     const [snapshot] = await app.do(
       "register",
       { stream: "user-2", actor },
       { email: "u@example.com", name: "Ursula", plan: "pro" }
     );
-    expect(snapshot.event?.data).toEqual({ plan: "pro" });
+    expect(snapshot.event?.data).toEqual({
+      email: "u@example.com",
+      name: "Ursula",
+      plan: "pro",
+    });
     expect(snapshot.event?.pii).toEqual({
       email: "u@example.com",
       name: "Ursula",

--- a/libs/act/test/disclosure.spec.ts
+++ b/libs/act/test/disclosure.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { act, sensitive, state, ZodEmpty } from "../src/index.js";
+
+// Realistic shape for the sensitive-data foundation tests: a state whose
+// emitted event carries two sensitive fields and one non-sensitive field,
+// with a state-level disclosure predicate (owner OR admin).
+
+const userSchema = z.object({
+  email: z.string().optional(),
+  plan: z.enum(["free", "pro"]).optional(),
+});
+
+const userRegisteredSchema = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+  plan: z.enum(["free", "pro"]),
+});
+
+const User = state({ User: userSchema })
+  .init(() => ({}))
+  .emits({ UserRegistered: userRegisteredSchema })
+  .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
+  .on({ register: userRegisteredSchema })
+  .emit((payload) => ["UserRegistered", payload])
+  .discloses(
+    (event, actor) =>
+      actor.id === event.stream ||
+      (Array.isArray(actor.roles) && actor.roles.includes("admin"))
+  )
+  .build();
+
+const Plain = state({ Plain: userSchema })
+  .init(() => ({}))
+  .emits({ Pinged: ZodEmpty })
+  .patch({ Pinged: () => ({}) })
+  .on({ ping: ZodEmpty })
+  .emit(() => ["Pinged", {}])
+  .build();
+
+describe("state(...).discloses()", () => {
+  it("registers the predicate on the built state", () => {
+    expect(User.disclose).toBeTypeOf("function");
+  });
+
+  it("is absent when never called — default-deny on read", () => {
+    expect(Plain.disclose).toBeUndefined();
+  });
+
+  it("overrides on a second call (state-level semantics)", () => {
+    const builder = state({ X: userSchema })
+      .init(() => ({}))
+      .emits({ XHappened: userRegisteredSchema })
+      .patch({ XHappened: () => ({}) })
+      .on({ xdo: userRegisteredSchema })
+      .emit((p) => ["XHappened", p])
+      .discloses(() => true)
+      .discloses(() => false);
+    const built = builder.build();
+    expect(
+      built.disclose?.(
+        {
+          id: 0,
+          stream: "x",
+          version: 0,
+          created: new Date(),
+          name: "XHappened",
+          data: { email: "a", name: "b", plan: "free" },
+          meta: {} as any,
+        },
+        { id: "any", name: "any" }
+      )
+    ).toBe(false);
+  });
+});
+
+describe("registry.sensitive_fields", () => {
+  it("returns the marked keys for an event with sensitive fields", () => {
+    const app = act().withState(User).build();
+    expect([...app.registry.sensitive_fields("UserRegistered")]).toEqual([
+      "email",
+      "name",
+    ]);
+  });
+
+  it("returns an empty array for events with no sensitive fields", () => {
+    const app = act().withState(Plain).build();
+    expect(app.registry.sensitive_fields("Pinged")).toEqual([]);
+  });
+
+  it("returns an empty array for unknown event names — safe lookup", () => {
+    const app = act().withState(Plain).build();
+    expect(app.registry.sensitive_fields("NeverDeclared")).toEqual([]);
+  });
+
+  it("computes once at build, not per call — same array reference returned across calls", () => {
+    const app = act().withState(User).build();
+    const a = app.registry.sensitive_fields("UserRegistered");
+    const b = app.registry.sensitive_fields("UserRegistered");
+    expect(a).toBe(b);
+  });
+});
+
+describe("registry.disclosure_predicate", () => {
+  it("returns the predicate for a state that declared one", () => {
+    const app = act().withState(User).build();
+    const pred = app.registry.disclosure_predicate("User");
+    expect(pred).toBeTypeOf("function");
+    const event = {
+      id: 0,
+      stream: "user-123",
+      version: 0,
+      created: new Date(),
+      name: "UserRegistered" as const,
+      data: { email: "u@example.com", name: "Ursula", plan: "free" as const },
+      meta: {} as any,
+    };
+    expect(pred?.(event, { id: "user-123", name: "Ursula" })).toBe(true);
+    expect(pred?.(event, { id: "other", name: "Other" })).toBe(false);
+    expect(
+      pred?.(event, { id: "other", name: "Admin", roles: ["admin"] } as any)
+    ).toBe(true);
+  });
+
+  it("returns null when the state did not declare a predicate (default-deny)", () => {
+    const app = act().withState(Plain).build();
+    expect(app.registry.disclosure_predicate("Plain")).toBeNull();
+  });
+
+  it("returns null for unknown state names — safe lookup", () => {
+    const app = act().withState(User).build();
+    expect(app.registry.disclosure_predicate("NeverDeclared")).toBeNull();
+  });
+});

--- a/libs/act/test/disclosure.spec.ts
+++ b/libs/act/test/disclosure.spec.ts
@@ -186,7 +186,7 @@ describe("state with mixed sensitive + non-sensitive events", () => {
     );
     expect(click.event?.data).toEqual({ ts: 42 });
     // No pii payload on the non-sensitive event — the State's
-    // `_split_emitted` decorator returned the input unchanged.
+    // `_pii_split` decorator returned the input unchanged.
     expect(click.event?.pii).toBeUndefined();
   });
 });

--- a/libs/act/test/disclosure.spec.ts
+++ b/libs/act/test/disclosure.spec.ts
@@ -132,3 +132,61 @@ describe("registry.disclosure_predicate", () => {
     expect(app.registry.disclosure_predicate("NeverDeclared")).toBeNull();
   });
 });
+
+// State with mixed sensitive + non-sensitive events. Exercises the
+// State decorators' "this event isn't in the per-state PII map" branch —
+// the inner fallback `if (!fields) return event;` that fires per event
+// when a sensitive state emits a non-sensitive event type alongside its
+// sensitive ones.
+describe("state with mixed sensitive + non-sensitive events", () => {
+  const Mixed = state({ Mixed: userSchema })
+    .init(() => ({}))
+    // UserRegistered carries PII; UserClicked carries an analytics number
+    // with no sensitive fields. Both are emitted by the same state.
+    .emits({
+      UserRegistered: userRegisteredSchema,
+      UserClicked: z.object({ ts: z.number() }),
+    })
+    .patch({
+      UserRegistered: ({ data }) => ({ email: data.email }),
+      UserClicked: () => ({}),
+    })
+    .on({ register: userRegisteredSchema })
+    .emit((p) => ["UserRegistered", p])
+    .on({ click: z.object({ ts: z.number() }) })
+    .emit((p) => ["UserClicked", p])
+    .discloses(() => true)
+    .build();
+
+  it("registry.sensitive_fields lists the PII event but not the analytics event", () => {
+    const app = act().withState(Mixed).build();
+    expect([...app.registry.sensitive_fields("UserRegistered")]).toEqual([
+      "email",
+      "name",
+    ]);
+    expect(app.registry.sensitive_fields("UserClicked")).toEqual([]);
+  });
+
+  it("commit splits PII for UserRegistered but passes UserClicked through", async () => {
+    const app = act().withState(Mixed).build();
+    const actor = { id: "x", name: "x" };
+    const [reg] = await app.do(
+      "register",
+      { stream: "mix-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    expect(reg.event?.pii).toEqual({
+      email: "u@example.com",
+      name: "Ursula",
+    });
+    const [click] = await app.do(
+      "click",
+      { stream: "mix-1", actor },
+      { ts: 42 }
+    );
+    expect(click.event?.data).toEqual({ ts: 42 });
+    // No pii payload on the non-sensitive event — the State's
+    // `_split_emitted` decorator returned the input unchanged.
+    expect(click.event?.pii).toBeUndefined();
+  });
+});

--- a/libs/act/test/event-sourcing.spec.ts
+++ b/libs/act/test/event-sourcing.spec.ts
@@ -426,6 +426,8 @@ describe("event-sourcing", () => {
       events: {},
       patch: { Known: vi.fn() },
       on: {},
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     await store().commit(
       "stream-with-unknown",
@@ -458,6 +460,8 @@ describe("event-sourcing", () => {
       events: {},
       patch: { E: vi.fn() },
       on: {},
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     await store().commit("stream", [{ name: "E", data: {} }], {
       correlation: "c",
@@ -476,6 +480,8 @@ describe("event-sourcing", () => {
       events: {},
       patch: {},
       on: { foo: vi.fn() },
+      view: (e: any) => e,
+      message: (v: any) => v,
     };
     await expect(
       action(state, "foo", { stream: "", actor: { id: "a", name: "a" } }, {})

--- a/libs/act/test/forget.spec.ts
+++ b/libs/act/test/forget.spec.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  type Actor,
+  act,
+  cache,
+  dispose,
+  SHREDDED,
+  sensitive,
+  state,
+  store,
+} from "../src/index.js";
+
+const userSchema = z.object({ email: z.string().optional() });
+const userRegisteredSchema = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+  plan: z.enum(["free", "pro"]),
+});
+const User = state({ User: userSchema })
+  .init(() => ({}))
+  .emits({ UserRegistered: userRegisteredSchema })
+  .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
+  .on({ register: userRegisteredSchema })
+  .emit((p) => ["UserRegistered", p])
+  .discloses(() => true)
+  .build();
+
+const actor: Actor = { id: "u-1", name: "Tester" };
+
+describe("app.forget(stream) + forgotten lifecycle (#855 slice 7)", () => {
+  afterEach(async () => {
+    await dispose()();
+  });
+
+  it("happy path — wipes pii, returns the row count, emits forgotten once", async () => {
+    const app = act().withState(User).build();
+    const seen: { stream: string; at: Date; eventCount: number }[] = [];
+    app.on("forgotten", (payload) => {
+      seen.push(payload);
+    });
+    await app.do(
+      "register",
+      { stream: "user-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    const result = await app.forget("user-1");
+    expect(result.eventCount).toBe(1);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].stream).toBe("user-1");
+    expect(seen[0].eventCount).toBe(1);
+    expect(seen[0].at).toBeInstanceOf(Date);
+    // Reading the stream back returns SHREDDED for sensitive fields.
+    const snap = await app.load(User, "user-1", undefined, undefined, actor);
+    expect(snap.event?.data).toEqual({
+      email: SHREDDED,
+      name: SHREDDED,
+      plan: "free",
+    });
+  });
+
+  it("idempotent — second call returns {eventCount: 0} and does NOT re-emit forgotten", async () => {
+    const app = act().withState(User).build();
+    const seen: { stream: string; at: Date; eventCount: number }[] = [];
+    app.on("forgotten", (payload) => {
+      seen.push(payload);
+    });
+    await app.do(
+      "register",
+      { stream: "user-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    await app.forget("user-1");
+    const second = await app.forget("user-1");
+    expect(second.eventCount).toBe(0);
+    expect(seen).toHaveLength(1); // not 2
+  });
+
+  it("invalidates the cache so the next load doesn't return stale PII", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    // Warm the cache with a load.
+    await app.load(User, "user-1", undefined, undefined, actor);
+    // Spy on cache().invalidate to confirm forget triggers it.
+    const spy = vi.spyOn(cache(), "invalidate");
+    await app.forget("user-1");
+    expect(spy).toHaveBeenCalledWith("user-1");
+    spy.mockRestore();
+  });
+
+  it("throws on adapters without forget_pii — operator gets a clear signal", async () => {
+    const app = act().withState(User).build();
+    // Mock-strip the in-memory adapter's forget_pii to mimic an adapter that
+    // doesn't declare pii_isolation. Using the same store() ref so the patch
+    // takes effect for this app.
+    const s = store() as { forget_pii?: unknown };
+    const original = s.forget_pii;
+    s.forget_pii = undefined; // shadow the prototype method
+    try {
+      await expect(app.forget("user-1")).rejects.toThrow(
+        /Store does not implement forget_pii/
+      );
+    } finally {
+      s.forget_pii = original;
+    }
+  });
+
+  it("zero events on a stream that never had any — eventCount 0, no emit", async () => {
+    const app = act().withState(User).build();
+    const seen: unknown[] = [];
+    app.on("forgotten", (p) => {
+      seen.push(p);
+    });
+    const result = await app.forget("never-existed");
+    expect(result.eventCount).toBe(0);
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/libs/act/test/handler-strip.spec.ts
+++ b/libs/act/test/handler-strip.spec.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  type Actor,
+  act,
+  type Committed,
+  dispose,
+  projection,
+  sensitive,
+  state,
+  store,
+} from "../src/index.js";
+
+const userSchema = z.object({
+  email: z.string().optional(),
+  plan: z.enum(["free", "pro"]).optional(),
+});
+
+const UserRegistered = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+  plan: z.enum(["free", "pro"]),
+});
+
+const User = state({ User: userSchema })
+  .init(() => ({}))
+  .emits({ UserRegistered })
+  .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
+  .on({ register: UserRegistered })
+  .emit((p) => ["UserRegistered", p])
+  .discloses(() => true) // allow plaintext through the gate, isolate the handler strip
+  .build();
+
+const actor: Actor = { id: "u-1", name: "Tester" };
+
+describe("handler-side PII strip (#855 slice 5)", () => {
+  afterEach(async () => {
+    await dispose()();
+  });
+
+  it("reaction handler receives the event with sensitive keys removed AND no pii field", async () => {
+    let seen: Committed<any, string> | undefined;
+    async function onRegistered(event: Committed<any, string>) {
+      seen = event;
+    }
+    const app = act()
+      .withState(User)
+      .on("UserRegistered")
+      .do(onRegistered)
+      .to(() => ({ target: "audit" }))
+      .build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    await app.correlate();
+    await app.drain();
+    expect(seen).toBeDefined();
+    // Sensitive keys are GONE — not REDACTED, structurally absent.
+    expect(seen!.data).toEqual({ plan: "free" });
+    expect("email" in (seen!.data as object)).toBe(false);
+    expect("name" in (seen!.data as object)).toBe(false);
+    // The `pii` carrier is also dropped — handlers can't observe it.
+    expect((seen as { pii?: unknown }).pii).toBeUndefined();
+  });
+
+  it("projection batch handler receives stripped events", async () => {
+    const seen: Committed<any, string>[] = [];
+    async function noop() {}
+    async function captureBatch(events: readonly Committed<any, string>[]) {
+      seen.push(...events);
+    }
+    const Roster = projection("user-roster")
+      .on({ UserRegistered })
+      .do(noop)
+      .batch(captureBatch)
+      .build();
+    const app = act().withState(User).withProjection(Roster).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    await app.do(
+      "register",
+      { stream: "user-2", actor },
+      { email: "v@example.com", name: "Vera", plan: "pro" }
+    );
+    await app.correlate();
+    await app.drain();
+    expect(seen).toHaveLength(2);
+    for (const event of seen) {
+      expect(event.data).not.toHaveProperty("email");
+      expect(event.data).not.toHaveProperty("name");
+      expect((event as { pii?: unknown }).pii).toBeUndefined();
+    }
+    expect(seen.map((e) => (e.data as { plan: string }).plan).sort()).toEqual([
+      "free",
+      "pro",
+    ]);
+  });
+
+  it("defensive: sensitive keys still on event.data (e.g. bypassing the commit-split) get stripped", async () => {
+    // Slice 3 normally moves sensitive keys to event.pii before commit, so
+    // the reaction sees event.data already clean. This test bypasses that by
+    // committing directly through `store()` with a sensitive key still on
+    // .data — the strip must remove it regardless.
+    let seen: Committed<any, string> | undefined;
+    async function onRegistered(event: Committed<any, string>) {
+      seen = event;
+    }
+    const app = act()
+      .withState(User)
+      .on("UserRegistered")
+      .do(onRegistered)
+      .to(() => ({ target: "audit-defensive" }))
+      .build();
+    // Bypass the orchestrator's split — commit with the sensitive keys still
+    // present on data. Mirrors what a misuse of the raw Store would produce.
+    await store().commit(
+      "user-9",
+      [
+        {
+          name: "UserRegistered",
+          data: { email: "x@y.com", name: "X", plan: "free" } as any,
+        },
+      ],
+      { correlation: "test-corr", causation: {} }
+    );
+    await app.correlate();
+    await app.drain();
+    expect(seen).toBeDefined();
+    expect(seen!.data).toEqual({ plan: "free" });
+    expect("email" in (seen!.data as object)).toBe(false);
+    expect("name" in (seen!.data as object)).toBe(false);
+  });
+
+  it("non-sensitive events pass through unchanged to reaction handlers (zero-cost path)", async () => {
+    let seen: Committed<any, string> | undefined;
+    const counterSchema = z.object({ count: z.number() });
+    const Incremented = z.object({ by: z.number() });
+    const Counter = state({ Counter: counterSchema })
+      .init(() => ({ count: 0 }))
+      .emits({ Incremented })
+      .patch({ Incremented: ({ data }, s) => ({ count: s.count + data.by }) })
+      .on({ increment: Incremented })
+      .emit((p) => ["Incremented", p])
+      .build();
+    async function onIncremented(event: Committed<any, string>) {
+      seen = event;
+    }
+    const app = act()
+      .withState(Counter)
+      .on("Incremented")
+      .do(onIncremented)
+      .to(() => ({ target: "audit" }))
+      .build();
+    await app.do("increment", { stream: "c-1", actor }, { by: 5 });
+    await app.correlate();
+    await app.drain();
+    expect(seen?.data).toEqual({ by: 5 });
+  });
+});

--- a/libs/act/test/read-gate.spec.ts
+++ b/libs/act/test/read-gate.spec.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  type Actor,
+  act,
+  cache,
+  dispose,
+  REDACTED,
+  SHREDDED,
+  sensitive,
+  state,
+  store,
+} from "../src/index.js";
+
+const userSchema = z.object({
+  email: z.string().optional(),
+  plan: z.enum(["free", "pro"]).optional(),
+});
+
+const userRegisteredSchema = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+  plan: z.enum(["free", "pro"]),
+});
+
+// Owner-or-admin policy — typical real-world shape.
+const User = state({ User: userSchema })
+  .init(() => ({}))
+  .emits({ UserRegistered: userRegisteredSchema })
+  .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
+  .on({ register: userRegisteredSchema })
+  .emit((p) => ["UserRegistered", p])
+  .discloses(
+    (event, actor) =>
+      actor.id === event.stream ||
+      (Array.isArray(actor.roles) && actor.roles.includes("admin"))
+  )
+  .build();
+
+// Same payload, but never declared a `.discloses` — framework default-deny.
+const UserNoPolicy = state({ UserNoPolicy: userSchema })
+  .init(() => ({}))
+  .emits({ NoPolicyRegistered: userRegisteredSchema })
+  .patch({ NoPolicyRegistered: ({ data }) => ({ email: data.email }) })
+  .on({ register: userRegisteredSchema })
+  .emit((p) => ["NoPolicyRegistered", p])
+  .build();
+
+const owner: Actor = { id: "user-1", name: "Ursula" };
+const stranger: Actor = { id: "user-2", name: "Strange" };
+const admin: Actor = {
+  id: "admin-1",
+  name: "Admin",
+  roles: ["admin"],
+} as Actor;
+
+describe("read-path PII gate (#855 slice 4)", () => {
+  afterEach(async () => {
+    await dispose()();
+  });
+
+  // --- do() return is gated by target.actor ---
+
+  it("owner registering themselves sees plaintext in the returned snapshot", async () => {
+    const app = act().withState(User).build();
+    const [snap] = await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    expect(snap.event?.data).toEqual({
+      email: "u@example.com",
+      name: "Ursula",
+      plan: "free",
+    });
+  });
+
+  it("admin registering someone else sees plaintext — predicate matches the roles branch", async () => {
+    const app = act().withState(User).build();
+    const [snap] = await app.do(
+      "register",
+      { stream: "user-1", actor: admin },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    expect(snap.event?.data).toEqual({
+      email: "u@example.com",
+      name: "Ursula",
+      plan: "free",
+    });
+  });
+
+  it("stranger registering user-1 sees REDACTED in the returned snapshot", async () => {
+    const app = act().withState(User).build();
+    const [snap] = await app.do(
+      "register",
+      { stream: "user-1", actor: stranger },
+      { email: "u@example.com", name: "Ursula", plan: "pro" }
+    );
+    expect(snap.event?.data).toEqual({
+      email: REDACTED,
+      name: REDACTED,
+      plan: "pro",
+    });
+  });
+
+  it("state without .discloses default-denies — REDACTED even when the actor 'should' see it", async () => {
+    const app = act().withState(UserNoPolicy).build();
+    const [snap] = await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    expect(snap.event?.data).toEqual({
+      email: REDACTED,
+      name: REDACTED,
+      plan: "free",
+    });
+  });
+
+  // --- load() is gated by actor parameter ---
+
+  it("load with the owner actor sees plaintext (cache invalidated to force a fresh query)", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    await cache().invalidate("user-1");
+    const snap = await app.load(User, "user-1", undefined, undefined, owner);
+    expect(snap.event?.data).toEqual({
+      email: "u@example.com",
+      name: "Ursula",
+      plan: "free",
+    });
+  });
+
+  it("load with a stranger actor sees REDACTED", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "u@example.com", name: "Ursula", plan: "pro" }
+    );
+    await cache().invalidate("user-1");
+    const snap = await app.load(User, "user-1", undefined, undefined, stranger);
+    expect(snap.event?.data).toEqual({
+      email: REDACTED,
+      name: REDACTED,
+      plan: "pro",
+    });
+  });
+
+  it("load with no actor default-denies", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "u@example.com", name: "Ursula", plan: "free" }
+    );
+    await cache().invalidate("user-1");
+    const snap = await app.load(User, "user-1");
+    expect(snap.event?.data).toEqual({
+      email: REDACTED,
+      name: REDACTED,
+      plan: "free",
+    });
+  });
+
+  // --- SHREDDED — irrecoverable post-forget ---
+
+  it("after Store.forget_pii, reads return SHREDDED regardless of authorization", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "u@example.com", name: "Ursula", plan: "pro" }
+    );
+    // Forget at the Store level — the orchestrator's app.forget wrapper lands
+    // in slice 7. Slice 4 only needs to verify the gate substitutes SHREDDED
+    // when the underlying pii column is gone.
+    await store().forget_pii?.("user-1");
+    await cache().invalidate("user-1");
+    const snapOwner = await app.load(
+      User,
+      "user-1",
+      undefined,
+      undefined,
+      owner
+    );
+    expect(snapOwner.event?.data).toEqual({
+      email: SHREDDED,
+      name: SHREDDED,
+      plan: "pro",
+    });
+    await cache().invalidate("user-1");
+    const snapAdmin = await app.load(
+      User,
+      "user-1",
+      undefined,
+      undefined,
+      admin
+    );
+    expect(snapAdmin.event?.data).toEqual({
+      email: SHREDDED,
+      name: SHREDDED,
+      plan: "pro",
+    });
+  });
+
+  // --- Reducer always sees plaintext, even when external gate redacts ---
+
+  it("reducer sees plaintext — derived state stays correct under external redaction", async () => {
+    const app = act().withState(User).build();
+    await app.do(
+      "register",
+      { stream: "user-1", actor: owner },
+      { email: "real@example.com", name: "Ursula", plan: "free" }
+    );
+    await cache().invalidate("user-1");
+    // Load as a stranger. The external view of the event is REDACTED, but the
+    // reducer-derived state (which the reducer copies from event.data.email)
+    // should still hold the plaintext — verifies the reducer saw the merged
+    // view, not the gated one.
+    const snap = await app.load(User, "user-1", undefined, undefined, stranger);
+    expect(snap.state).toEqual({ email: "real@example.com" });
+    expect(snap.event?.data.email).toBe(REDACTED);
+  });
+
+  // --- Non-sensitive events: zero-cost passthrough ---
+
+  it("non-sensitive events pass through unchanged on both do() and load()", async () => {
+    const counterSchema = z.object({ count: z.number() });
+    const Counter = state({ Counter: counterSchema })
+      .init(() => ({ count: 0 }))
+      .emits({ Incremented: z.object({ by: z.number() }) })
+      .patch({
+        Incremented: ({ data }, s) => ({ count: s.count + data.by }),
+      })
+      .on({ increment: z.object({ by: z.number() }) })
+      .emit((p) => ["Incremented", p])
+      .build();
+    const app = act().withState(Counter).build();
+    const [doSnap] = await app.do(
+      "increment",
+      { stream: "c-1", actor: owner },
+      { by: 5 }
+    );
+    expect(doSnap.event?.data).toEqual({ by: 5 });
+    expect(doSnap.state).toEqual({ count: 5 });
+    await cache().invalidate("c-1");
+    const loadSnap = await app.load(Counter, "c-1");
+    expect(loadSnap.event?.data).toEqual({ by: 5 });
+    expect(loadSnap.state).toEqual({ count: 5 });
+  });
+});

--- a/libs/act/test/sensitive.spec.ts
+++ b/libs/act/test/sensitive.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { pii_fields, sensitive } from "../src/sensitive.js";
+import { pii_fields } from "../src/internal/sensitive.js";
+import { sensitive } from "../src/types/schemas.js";
 
 describe("sensitive()", () => {
   it("returns the same schema instance", () => {

--- a/libs/act/test/sensitive.spec.ts
+++ b/libs/act/test/sensitive.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { getSensitiveFields, sensitive } from "../src/sensitive.js";
+import { pii_fields, sensitive } from "../src/sensitive.js";
 
 describe("sensitive()", () => {
   it("returns the same schema instance", () => {
@@ -24,19 +24,19 @@ describe("sensitive()", () => {
     const a = z.string();
     const b = z.string();
     sensitive(a);
-    // b was never marked — getSensitiveFields treats it as non-sensitive
-    expect(getSensitiveFields(z.object({ a, b }))).toEqual(["a"]);
+    // b was never marked — pii_fields treats it as non-sensitive
+    expect(pii_fields(z.object({ a, b }))).toEqual(["a"]);
   });
 });
 
-describe("getSensitiveFields()", () => {
+describe("pii_fields()", () => {
   it("returns the keys whose schema was marked sensitive", () => {
     const schema = z.object({
       email: sensitive(z.string()),
       name: sensitive(z.string()),
       plan: z.enum(["free", "pro"]),
     });
-    expect(getSensitiveFields(schema)).toEqual(["email", "name"]);
+    expect(pii_fields(schema)).toEqual(["email", "name"]);
   });
 
   it("returns an empty array when no field is sensitive", () => {
@@ -44,13 +44,13 @@ describe("getSensitiveFields()", () => {
       plan: z.enum(["free", "pro"]),
       count: z.number(),
     });
-    expect(getSensitiveFields(schema)).toEqual([]);
+    expect(pii_fields(schema)).toEqual([]);
   });
 
   it("returns an empty array for non-object schemas (zero-cost path)", () => {
-    expect(getSensitiveFields(z.string())).toEqual([]);
-    expect(getSensitiveFields(z.number())).toEqual([]);
-    expect(getSensitiveFields(z.array(z.string()))).toEqual([]);
+    expect(pii_fields(z.string())).toEqual([]);
+    expect(pii_fields(z.number())).toEqual([]);
+    expect(pii_fields(z.array(z.string()))).toEqual([]);
   });
 
   it("sees through .optional() — sensitive(x).optional() is still sensitive", () => {
@@ -58,28 +58,28 @@ describe("getSensitiveFields()", () => {
       email: sensitive(z.string()).optional(),
       plan: z.enum(["free", "pro"]),
     });
-    expect(getSensitiveFields(schema)).toEqual(["email"]);
+    expect(pii_fields(schema)).toEqual(["email"]);
   });
 
   it("sees through .nullable() — sensitive(x).nullable() is still sensitive", () => {
     const schema = z.object({
       ssn: sensitive(z.string()).nullable(),
     });
-    expect(getSensitiveFields(schema)).toEqual(["ssn"]);
+    expect(pii_fields(schema)).toEqual(["ssn"]);
   });
 
   it("sees through .default() — sensitive(x).default() is still sensitive", () => {
     const schema = z.object({
       nickname: sensitive(z.string()).default(""),
     });
-    expect(getSensitiveFields(schema)).toEqual(["nickname"]);
+    expect(pii_fields(schema)).toEqual(["nickname"]);
   });
 
   it("sees through chained wrappers — .nullable().optional() composes", () => {
     const schema = z.object({
       middleName: sensitive(z.string()).nullable().optional(),
     });
-    expect(getSensitiveFields(schema)).toEqual(["middleName"]);
+    expect(pii_fields(schema)).toEqual(["middleName"]);
   });
 
   it("does NOT descend into nested object fields — only top-level shape walked", () => {
@@ -91,6 +91,6 @@ describe("getSensitiveFields()", () => {
         email: sensitive(z.string()),
       }),
     });
-    expect(getSensitiveFields(schema)).toEqual([]);
+    expect(pii_fields(schema)).toEqual([]);
   });
 });

--- a/libs/act/test/sensitive.spec.ts
+++ b/libs/act/test/sensitive.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { getSensitiveFields, sensitive } from "../src/sensitive.js";
+
+describe("sensitive()", () => {
+  it("returns the same schema instance", () => {
+    const inner = z.string();
+    expect(sensitive(inner)).toBe(inner);
+  });
+
+  it("preserves the static type at runtime — wrapping doesn't change parse behavior", () => {
+    const schema = sensitive(z.email());
+    expect(schema.parse("a@b.com")).toBe("a@b.com");
+    expect(() => schema.parse("not-an-email")).toThrow();
+  });
+
+  it("is idempotent — re-wrapping is a no-op", () => {
+    const schema = z.string();
+    expect(sensitive(sensitive(schema))).toBe(schema);
+    expect(sensitive(sensitive(sensitive(schema)))).toBe(schema);
+  });
+
+  it("marks each call's schema independently — separate instances aren't conflated", () => {
+    const a = z.string();
+    const b = z.string();
+    sensitive(a);
+    // b was never marked — getSensitiveFields treats it as non-sensitive
+    expect(getSensitiveFields(z.object({ a, b }))).toEqual(["a"]);
+  });
+});
+
+describe("getSensitiveFields()", () => {
+  it("returns the keys whose schema was marked sensitive", () => {
+    const schema = z.object({
+      email: sensitive(z.string()),
+      name: sensitive(z.string()),
+      plan: z.enum(["free", "pro"]),
+    });
+    expect(getSensitiveFields(schema)).toEqual(["email", "name"]);
+  });
+
+  it("returns an empty array when no field is sensitive", () => {
+    const schema = z.object({
+      plan: z.enum(["free", "pro"]),
+      count: z.number(),
+    });
+    expect(getSensitiveFields(schema)).toEqual([]);
+  });
+
+  it("returns an empty array for non-object schemas (zero-cost path)", () => {
+    expect(getSensitiveFields(z.string())).toEqual([]);
+    expect(getSensitiveFields(z.number())).toEqual([]);
+    expect(getSensitiveFields(z.array(z.string()))).toEqual([]);
+  });
+
+  it("sees through .optional() — sensitive(x).optional() is still sensitive", () => {
+    const schema = z.object({
+      email: sensitive(z.string()).optional(),
+      plan: z.enum(["free", "pro"]),
+    });
+    expect(getSensitiveFields(schema)).toEqual(["email"]);
+  });
+
+  it("sees through .nullable() — sensitive(x).nullable() is still sensitive", () => {
+    const schema = z.object({
+      ssn: sensitive(z.string()).nullable(),
+    });
+    expect(getSensitiveFields(schema)).toEqual(["ssn"]);
+  });
+
+  it("sees through .default() — sensitive(x).default() is still sensitive", () => {
+    const schema = z.object({
+      nickname: sensitive(z.string()).default(""),
+    });
+    expect(getSensitiveFields(schema)).toEqual(["nickname"]);
+  });
+
+  it("sees through chained wrappers — .nullable().optional() composes", () => {
+    const schema = z.object({
+      middleName: sensitive(z.string()).nullable().optional(),
+    });
+    expect(getSensitiveFields(schema)).toEqual(["middleName"]);
+  });
+
+  it("does NOT descend into nested object fields — only top-level shape walked", () => {
+    // Nested sensitivity is deferred until a real callsite needs it; this test
+    // pins the current contract so a future change to recursive descent is an
+    // intentional design move, not a silent broadening.
+    const schema = z.object({
+      profile: z.object({
+        email: sensitive(z.string()),
+      }),
+    });
+    expect(getSensitiveFields(schema)).toEqual([]);
+  });
+});

--- a/libs/act/test/snap-validator.spec.ts
+++ b/libs/act/test/snap-validator.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { act, sensitive, state } from "../src/index.js";
+
+const userSchema = z.object({ email: z.string().optional() });
+const counterSchema = z.object({ count: z.number() });
+
+const PIIEvent = z.object({
+  email: sensitive(z.string()),
+  name: sensitive(z.string()),
+});
+
+const NonPIIEvent = z.object({ by: z.number() });
+
+describe("build-time snapshot validator (#855 slice 6)", () => {
+  it("throws when a state declares both sensitive events and .snap()", () => {
+    const Offender = state({ Offender: userSchema })
+      .init(() => ({}))
+      .emits({ PIIEvent })
+      .patch({ PIIEvent: ({ data }) => ({ email: data.email }) })
+      .on({ register: PIIEvent })
+      .emit((p) => ["PIIEvent", p])
+      .snap(() => true)
+      .build();
+    expect(() => act().withState(Offender).build()).toThrow(
+      /State "Offender" cannot snapshot — events \{PIIEvent\} carry sensitive fields/
+    );
+  });
+
+  it("error message lists every offending event name when more than one is sensitive", () => {
+    const ManyEvents = z.object({
+      a: sensitive(z.string()),
+    });
+    const Offender = state({ Offender: userSchema })
+      .init(() => ({}))
+      .emits({ PIIEvent, ManyEvents })
+      .patch({
+        PIIEvent: () => ({}),
+        ManyEvents: () => ({}),
+      })
+      .on({ register: PIIEvent })
+      .emit((p) => ["PIIEvent", p])
+      .snap(() => true)
+      .build();
+    expect(() => act().withState(Offender).build()).toThrow(
+      /events \{PIIEvent, ManyEvents\}/
+    );
+  });
+
+  it("non-sensitive state with .snap() builds cleanly", () => {
+    const Counter = state({ Counter: counterSchema })
+      .init(() => ({ count: 0 }))
+      .emits({ NonPIIEvent })
+      .patch({
+        NonPIIEvent: ({ data }, s) => ({ count: s.count + data.by }),
+      })
+      .on({ increment: NonPIIEvent })
+      .emit((p) => ["NonPIIEvent", p])
+      .snap(() => true)
+      .build();
+    expect(() => act().withState(Counter).build()).not.toThrow();
+  });
+
+  it("sensitive state without .snap() builds cleanly", () => {
+    const User = state({ User: userSchema })
+      .init(() => ({}))
+      .emits({ PIIEvent })
+      .patch({ PIIEvent: ({ data }) => ({ email: data.email }) })
+      .on({ register: PIIEvent })
+      .emit((p) => ["PIIEvent", p])
+      .build();
+    expect(() => act().withState(User).build()).not.toThrow();
+  });
+
+  it("with multiple states, the error names only the offending one", () => {
+    const Counter = state({ Counter: counterSchema })
+      .init(() => ({ count: 0 }))
+      .emits({ NonPIIEvent })
+      .patch({
+        NonPIIEvent: ({ data }, s) => ({ count: s.count + data.by }),
+      })
+      .on({ increment: NonPIIEvent })
+      .emit((p) => ["NonPIIEvent", p])
+      .snap(() => true)
+      .build();
+    const PIIEventForOffender = z.object({
+      email: sensitive(z.string()),
+    });
+    const Offender = state({ Offender: userSchema })
+      .init(() => ({}))
+      .emits({ PIIEventForOffender })
+      .patch({ PIIEventForOffender: () => ({}) })
+      .on({ register: PIIEventForOffender })
+      .emit((p) => ["PIIEventForOffender", p])
+      .snap(() => true)
+      .build();
+    expect(() => act().withState(Counter).withState(Offender).build()).toThrow(
+      /State "Offender" cannot snapshot/
+    );
+  });
+});

--- a/libs/act/test/tracing.spec.ts
+++ b/libs/act/test/tracing.spec.ts
@@ -52,13 +52,14 @@ describe("tracing", () => {
   });
 
   describe("buildEs", () => {
-    it("returns bare ops for non-trace levels (action still wrapped to bind correlator)", () => {
+    it("returns bare ops for non-trace levels (action+load still wrapped to bind correlator/pii_fields)", () => {
       const ops = buildEs(withLevel("info"));
       expect(ops.snap).toBe(es.snap);
-      expect(ops.load).toBe(es.load);
-      // ACT-404: action always carries a bound correlator, so it's a
-      // closure regardless of trace level — the bare-vs-traced split now
-      // only governs snap/load/tombstone.
+      // ACT-404 + #855: action carries a bound correlator AND pii_fields;
+      // load carries a bound pii_fields. Both are closures regardless of
+      // trace level — the bare-vs-traced split now only governs snap +
+      // tombstone.
+      expect(ops.load).not.toBe(es.load);
       expect(ops.action).not.toBe(es.action);
     });
 

--- a/libs/act/test/tracing.spec.ts
+++ b/libs/act/test/tracing.spec.ts
@@ -52,14 +52,15 @@ describe("tracing", () => {
   });
 
   describe("buildEs", () => {
-    it("returns bare ops for non-trace levels (action+load still wrapped to bind correlator/pii_fields)", () => {
+    it("returns bare ops for non-trace levels (action still wrapped to bind correlator)", () => {
       const ops = buildEs(withLevel("info"));
       expect(ops.snap).toBe(es.snap);
-      // ACT-404 + #855: action carries a bound correlator AND pii_fields;
-      // load carries a bound pii_fields. Both are closures regardless of
-      // trace level — the bare-vs-traced split now only governs snap +
-      // tombstone.
-      expect(ops.load).not.toBe(es.load);
+      // ACT-404: action always carries a bound correlator, so it's a
+      // closure regardless of trace level. After the #855 decorator
+      // refactor moved the PII machinery off the action/load signatures
+      // onto per-state closures, load no longer needs a buildEs binding
+      // and is bare at non-trace levels.
+      expect(ops.load).toBe(es.load);
       expect(ops.action).not.toBe(es.action);
     });
 


### PR DESCRIPTION
Closes #855.

The application-level foundation for the actOps sensitive-data epic (#566). Pairs the Store contract that landed in #868 (`events.pii` column, `Store.forget_pii`, `pii_isolation` capability) and the InMemoryStore impl that landed in #882 with the framework half: a schema-level marker, a state-level disclosure predicate, automatic split-on-commit and gate-on-read, projection/reaction stripping, a build-time validator that rejects unsafe configurations, and the operator-facing `app.forget(stream)` / `forgotten` lifecycle pair.

Seven slices on the same branch, each green-test:

```ts
import { z } from "zod";
import { state, sensitive } from "@rotorsoft/act";

const User = state({ User: userSchema })
  .init(() => ({}))
  .emits({
    UserRegistered: z.object({
      email: sensitive(z.string()),
      name: sensitive(z.string()),
      plan: z.enum(["free", "pro"]),
    }),
  })
  .patch({ UserRegistered: ({ data }) => ({ email: data.email }) })
  .on({ register: userRegisteredSchema })
  .emit((p) => ["UserRegistered", p])
  .discloses((event, actor) =>
    actor.id === event.stream ||
    (Array.isArray(actor.roles) && actor.roles.includes("admin"))
  )
  .build();

// Reading as the owner — plaintext.
const [snap] = await app.do("register",
  { stream: "user-123", actor: owner },
  { email: "u@example.com", name: "Ursula", plan: "free" });
snap.event.data; // { email: "u@example.com", name: "Ursula", plan: "free" }

// Reading as a stranger — REDACTED.
const denied = await app.load(User, "user-123", undefined, undefined, stranger);
denied.event.data; // { email: "[REDACTED]", name: "[REDACTED]", plan: "free" }

// GDPR erasure — SHREDDED, irrecoverable.
await app.forget("user-123");
const wiped = await app.load(User, "user-123", undefined, undefined, owner);
wiped.event.data; // { email: "[SHREDDED]", name: "[SHREDDED]", plan: "free" }
```

## `sensitive(zodType)` — schema-level marker (slice 1)

The classification colocates with the type definition: one source of truth per field. `sensitive(z.string())` is still `z.ZodString` from TypeScript's perspective — the marker is registered out-of-band via Zod 4's `z.registry()` (WeakMap-backed, idempotent, survives `.optional()`/`.nullable()`/`.default()` wrapper layers).

Considered three call-site syntaxes before settling: `sensitive(z.string())` (this PR), a custom `z` re-export with `z.sensitive(...)`, and a chain method `z.string().sensitive()`. The chain form is architecturally blocked in Zod 4 — methods are installed by an internal `_installLazyMethods` helper that isn't exported, so there's no patchable `ZodType.prototype`. The wrapper form matches Zod's own non-method extension pattern (`z.preprocess`, `z.lazy`, `z.brand`).

## `.discloses(predicate)` + registry methods (slice 2)

State-level disclosure: `(event, actor) => boolean`. State-level was chosen over per-field — access policy is an aggregate-level concern, and per-field predicates would force operators to repeat the same rule for every sensitive field. Operators who need per-event branches do so inside the predicate.

Default-deny is the failure mode. Omitting `.discloses` means PII is always redacted on external reads. Failure mode of forgetting the policy is loud (UI shows `[REDACTED]`) rather than silent (PII leaks).

Disclosure was chosen as the name — GDPR Article 4 and HIPAA both use it for "share PII with someone other than the data subject." The declaration site doubles as compliance documentation.

The registry gains two new methods, both lazily computed on the first `.build()`:
- `registry.sensitive_fields(eventName)` → `readonly string[]`
- `registry.disclosure_predicate(stateName)` → `((event, actor) => boolean) | null`

## Commit-path split (slice 3, refined)

In `internal/event-sourcing.ts`'s commit path, sensitive fields are moved off `data` and into `pii` before the event reaches the Store. The Store's `pii_isolation` contract from #868 is declarative; the orchestrator is responsible for the split.

The implementation does a single forward pass over the validated keys, routing each to `clean` or `pii` as it goes. Avoids the spread-and-delete dance — `delete` would force V8 to transition `clean` from hidden-class to dictionary mode, slowing every downstream read of `event.data`. For typical sensitive-field counts (1–3 per event), `fields.includes(k)` per key is faster than allocating a Set per commit. Zero-cost short-circuit when an event has no sensitive fields.

## Read-path gate + the two sentinels (slice 4)

Two views per event inside `load()`:
- **reducer view**: pii merged back into `data` (or `[SHREDDED]` if the pii column is null). The reducer always sees plaintext so derived state stays correct.
- **external view**: gated by `.discloses` + actor. What we put in `snapshot.event` and pass to the load callback.

`"[REDACTED]"` vs `"[SHREDDED]"` is a deliberate distinction:
- `[REDACTED]` — recoverable: the data exists, the caller isn't authorized. A properly-authorized read returns plaintext.
- `[SHREDDED]` — irrecoverable: the `events.pii` column is `NULL`, the original plaintext is gone. No predicate check.

Same dual-view in `action()`'s post-commit snapshot builder, so `app.do()`'s returned snapshot.event is gated by `target.actor` — matches the #855 spec table.

`Act.load()` gains an optional 5th positional `actor?: Actor` — additive, charter-clean. When absent, reads default-deny.

## Handler stripping for projections + reactions (slice 5)

Projections and reactions **never** see sensitive fields — framework-enforced via `strip_for_handler(event, fields)` invoked before `buildHandle` / `buildHandleBatch` calls the user handler. The strip is stricter than the read gate: keys are *removed* rather than substituted, so a handler that mistakenly writes `event.data.email` into a projection column gets `undefined` (visibly broken) instead of a sentinel string that looks like real data.

Reactions that genuinely need PII (a welcome-email handler reading `email`) opt back in by explicitly calling `app.load(stream, { actor: systemActor })` inside the handler — pulling PII through the gate at the call site makes the security-relevant path visible at code review.

## Build-time guard against snapshots on sensitive states (slice 6)

`act().build()` walks each registered state. If a state declares `.snap(...)` AND any of its emitted events carries a `sensitive(...)` field, build throws with a message naming the state and the offending events:

```
State "User" cannot snapshot — events {UserRegistered, UserPaymentAdded}
carry sensitive fields. Snapshots write derived state into __snapshot__.data,
which forget_pii cannot reach. Remove .snap() or remove sensitive(...) markers.
```

Snapshots write derived state into `__snapshot__.data`. If a reducer copied PII into state, the snapshot row preserves that PII outside the events.pii column — and `forget_pii(stream)` cannot reach it. Detecting this combination at build catches the misconfiguration in dev/CI rather than as a silent leak past the GDPR boundary months later.

The cost in practice is small. PII typically lives on **user streams**, which carry a handful of events per user — not the thousands-of-events workloads where snapshots earn their cold-load fast-path.

## `app.forget(stream)` + `forgotten` lifecycle event (slice 7)

```ts
const result = await app.forget("user-123");
// → triggers Store.forget_pii (events.pii → NULL for the stream)
// → invalidates cache().get("user-123")
// → emits "forgotten" lifecycle event with { stream, at: Date, eventCount }
// returns { eventCount }
```

Idempotent: a second call returns `{ eventCount: 0 }` and does NOT re-emit `forgotten`. The lifecycle event is for "wipe actually happened," not "wipe attempted."

Throws at runtime when the configured Store has no `forget_pii` — operators get a clear "your adapter cannot comply with sensitive-data erasure" signal at the call site. Adapter capability gating happens at `pii_isolation` in the TCK (per #868).

## Naming-convention sweep

The slices drifted into camelCase on internals once and were corrected mid-PR (`getSensitiveFields` → `pii_fields`, `isSensitiveSchema` → `is_pii`, `sensitiveRegistry` → `_registry`, the `ReactionDeps` `boundDo`/`boundLoad`/... → `bound_do`/`bound_load`/...). Project convention is short snake_case for fields/methods, single-word lowercase for top-level helpers. Public surface (`sensitive`, `discloses`, `forget`, `forgotten`, `Registry.sensitive_fields`, `Registry.disclosure_predicate`) was snake-cased from slice 1.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2101 passing, 12 skipped
- [x] Coverage: 100% statements / 100% branches / 100% functions / 100% lines
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm build` — all packages
- [ ] CI matrix — Postgres 14/15/16/17, libsql pinned + latest

## Stability charter impact — additive

Three charter-covered files modified, every change additive:

- `libs/act/src/act.ts` — new `forget` method on `Act`; new `forgotten` entry in `ActLifecycleEvents`; new optional 5th positional `actor?: Actor` on `Act.load`.
- `libs/act/src/builders/act-builder.ts` — new build-time validator; new precompute pass for `registry.sensitive_fields` / `registry.disclosure_predicate`.
- `libs/act/src/builders/state-builder.ts` — new `.discloses(predicate)` method on the action-builder; new optional `disclose?` field on the runtime `State` type (erased to `(event: any, actor: Actor) => boolean` for State<any,any,any> bivariance).

`STABILITY.md` updated with four new entries in the matching sections.

No removals, no renames at the public surface, no narrowed types.

## Follow-ups (parked under #566 epic)

- **#869** ✅ already shipped — InMemoryStore pii_isolation impl.
- **#870** — act-pg `events.pii` column migration + adapter impl.
- **#871** — act-sqlite pii column migration + adapter impl.
- **#861** — formal cache-invalidation contract on `forget` (this PR calls `cache().invalidate(stream)` directly; #861 will codify the rebuild semantics).
- **#862** — DB-layer encryption-at-rest recipes (pgcrypto / RDS TDE / Cloud SQL TDE / SQLite SEE).
- **#863** — `docs/docs/guides/sensitive-data.md` walkthrough.
- **#864** — book essay covering the three rejected designs (inline ciphertext, sibling table, Encryptor port) and the shipping rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>