### PR TITLE
refactor(act-pg): #870 — events.pii column + forget_pii + pii_isolation capability

### DIFF
--- a/libs/act-pg/src/postgres-store.ts
+++ b/libs/act-pg/src/postgres-store.ts
@@ -328,8 +328,15 @@ export class PostgresStore implements Store {
           stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
           version int NOT NULL,
           created timestamptz NOT NULL DEFAULT now(),
-          meta jsonb
+          meta jsonb,
+          pii jsonb
         ) TABLESPACE pg_default;`
+      );
+      // Migration for tables created before pii_isolation (#870).
+      // Variable-length encoding skips NULL columns entirely, so events
+      // without sensitive declarations pay zero extra bytes on disk.
+      await client.query(
+        `ALTER TABLE ${this._fqt} ADD COLUMN IF NOT EXISTS pii jsonb;`
       );
 
       // Indexes on events
@@ -557,12 +564,12 @@ export class PostgresStore implements Store {
         );
 
       const committed: Committed<E, keyof E>[] = [];
-      for (const { name, data } of msgs) {
+      for (const { name, data, pii } of msgs) {
         version++;
         const sql = `
-          INSERT INTO ${this._fqt}(name, data, stream, version, meta)
-          VALUES($1, $2, $3, $4, $5) RETURNING *`;
-        const vals = [name, data, stream, version, meta];
+          INSERT INTO ${this._fqt}(name, data, pii, stream, version, meta)
+          VALUES($1, $2, $3, $4, $5, $6) RETURNING *`;
+        const vals = [name, data, pii ?? null, stream, version, meta];
         try {
           const { rows } = await client.query<Committed<E, keyof E>>(sql, vals);
           committed.push(rows.at(0)!);
@@ -1574,11 +1581,12 @@ export class PostgresStore implements Store {
       await client.query(`TRUNCATE TABLE ${this._fqs}`);
       await driver(async (event) => {
         const { rows } = await client.query<{ id: number }>(
-          `INSERT INTO ${this._fqt}(name, data, stream, version, created, meta)
-           VALUES($1, $2, $3, $4, $5, $6) RETURNING id`,
+          `INSERT INTO ${this._fqt}(name, data, pii, stream, version, created, meta)
+           VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
           [
             event.name,
             event.data,
+            event.pii ?? null,
             event.stream,
             event.version,
             event.created,
@@ -1594,5 +1602,29 @@ export class PostgresStore implements Store {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Wipe the sensitive-data payload for every event on the stream — the
+   * physical-erasure side of the sensitive-data epic (#566). Sets
+   * `events.pii` to `NULL` for the stream's events; `events.data` and
+   * the rest of the row are never touched.
+   *
+   * Row-level locks (no table lock), bounded by events-per-stream.
+   * Idempotent — a second call on an already-wiped stream returns `0`.
+   *
+   * Disk reclamation is autovacuum-driven; for strict-deletion
+   * jurisdictions the production checklist documents `VACUUM FULL` as
+   * the operator step.
+   *
+   * @param stream Target stream
+   * @returns Count of events whose `pii` was set to `NULL`
+   */
+  async forget_pii(stream: string): Promise<number> {
+    const r = await this._pool.query(
+      `UPDATE ${this._fqt} SET pii = NULL WHERE stream = $1 AND pii IS NOT NULL`,
+      [stream]
+    );
+    return r.rowCount ?? 0;
   }
 }

--- a/libs/act-pg/test/store-tck.spec.ts
+++ b/libs/act-pg/test/store-tck.spec.ts
@@ -10,5 +10,5 @@ runStoreTck({
       table: "tck_store",
       notify: true,
     }),
-  capabilities: { notify: true, restore: true },
+  capabilities: { notify: true, restore: true, pii_isolation: true },
 });

--- a/libs/act-pg/test/store.error.spec.ts
+++ b/libs/act-pg/test/store.error.spec.ts
@@ -318,6 +318,17 @@ describe("PostgresStore", () => {
     });
   });
 
+  describe("forget_pii", () => {
+    it("returns 0 when rowCount is undefined (defensive)", async () => {
+      vi.spyOn(pg.Pool.prototype, "query").mockResolvedValue(
+        // @ts-expect-error mock — pg type says rowCount: number | null
+        { rowCount: null }
+      );
+      const result = await store.forget_pii("never-existed");
+      expect(result).toBe(0);
+    });
+  });
+
   describe("restore", () => {
     it("swallows ROLLBACK error after a failed restore", async () => {
       // BEGIN succeeds, first TRUNCATE throws, then ROLLBACK ITSELF

--- a/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
+++ b/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
@@ -32317,8 +32317,15 @@ export class PostgresStore implements Store {
           stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
           version int NOT NULL,
           created timestamptz NOT NULL DEFAULT now(),
-          meta jsonb
+          meta jsonb,
+          pii jsonb
         ) TABLESPACE pg_default;\`
+      );
+      // Migration for tables created before pii_isolation (#870).
+      // Variable-length encoding skips NULL columns entirely, so events
+      // without sensitive declarations pay zero extra bytes on disk.
+      await client.query(
+        \`ALTER TABLE \${this._fqt} ADD COLUMN IF NOT EXISTS pii jsonb;\`
       );
 
       // Indexes on events
@@ -32546,12 +32553,12 @@ export class PostgresStore implements Store {
         );
 
       const committed: Committed<E, keyof E>[] = [];
-      for (const { name, data } of msgs) {
+      for (const { name, data, pii } of msgs) {
         version++;
         const sql = \`
-          INSERT INTO \${this._fqt}(name, data, stream, version, meta)
-          VALUES($1, $2, $3, $4, $5) RETURNING *\`;
-        const vals = [name, data, stream, version, meta];
+          INSERT INTO \${this._fqt}(name, data, pii, stream, version, meta)
+          VALUES($1, $2, $3, $4, $5, $6) RETURNING *\`;
+        const vals = [name, data, pii ?? null, stream, version, meta];
         try {
           const { rows } = await client.query<Committed<E, keyof E>>(sql, vals);
           committed.push(rows.at(0)!);
@@ -33563,11 +33570,12 @@ export class PostgresStore implements Store {
       await client.query(\`TRUNCATE TABLE \${this._fqs}\`);
       await driver(async (event) => {
         const { rows } = await client.query<{ id: number }>(
-          \`INSERT INTO \${this._fqt}(name, data, stream, version, created, meta)
-           VALUES($1, $2, $3, $4, $5, $6) RETURNING id\`,
+          \`INSERT INTO \${this._fqt}(name, data, pii, stream, version, created, meta)
+           VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id\`,
           [
             event.name,
             event.data,
+            event.pii ?? null,
             event.stream,
             event.version,
             event.created,
@@ -33583,6 +33591,30 @@ export class PostgresStore implements Store {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Wipe the sensitive-data payload for every event on the stream — the
+   * physical-erasure side of the sensitive-data epic (#566). Sets
+   * \`events.pii\` to \`NULL\` for the stream's events; \`events.data\` and
+   * the rest of the row are never touched.
+   *
+   * Row-level locks (no table lock), bounded by events-per-stream.
+   * Idempotent — a second call on an already-wiped stream returns \`0\`.
+   *
+   * Disk reclamation is autovacuum-driven; for strict-deletion
+   * jurisdictions the production checklist documents \`VACUUM FULL\` as
+   * the operator step.
+   *
+   * @param stream Target stream
+   * @returns Count of events whose \`pii\` was set to \`NULL\`
+   */
+  async forget_pii(stream: string): Promise<number> {
+    const r = await this._pool.query(
+      \`UPDATE \${this._fqt} SET pii = NULL WHERE stream = $1 AND pii IS NOT NULL\`,
+      [stream]
+    );
+    return r.rowCount ?? 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #870.

Brings the sensitive-data foundation (#855) to production storage. The PostgresStore now carries the `pii` payload alongside `data` in a single commit transaction, persists it in a dedicated nullable `jsonb` column, and implements `forget_pii(stream)` as a bounded `UPDATE`. Same contract as the in-memory adapter; same TCK block runs against it.

Without this, an app that uses `sensitive(...)` schemas works on `InMemoryStore` but the moment it points at PG the commit drops the PII silently. With it, the foundation ships in production.

## Schema

The `events` table gains one column:

```sql
ALTER TABLE {schema}.{table} ADD COLUMN IF NOT EXISTS pii jsonb;
```

Added in `CREATE TABLE IF NOT EXISTS` for fresh installs and via idempotent `ADD COLUMN IF NOT EXISTS` for existing deployments — same in-place evolution pattern as the existing `priority` / `lane` migrations on the `streams` table. No `migrations/00X_*.sql` file: `seed()` is the contract for "the schema is ready."

PG's variable-length tuple encoding skips NULL columns entirely, so events without sensitive declarations pay **zero extra bytes** on disk. Safe on PG 11+ (no table rewrite on `ADD COLUMN ... DEFAULT NULL`).

## Commit path

One extra column in the existing per-event `INSERT ... RETURNING *`:

```sql
INSERT INTO {fqt}(name, data, pii, stream, version, meta)
VALUES($1, $2, $3, $4, $5, $6) RETURNING *
```

Atomic with the rest of the commit transaction — no separate round-trip. Events without `pii` pass `NULL`. `RETURNING *` already round-trips the new column back to the caller.

## Restore path

Mirrors the same column addition so dumps with PII round-trip cleanly through `Store.restore`. Useful for adapter-to-adapter migrations (in-memory → PG) where the source carries PII.

## forget_pii(stream)

```ts
async forget_pii(stream: string): Promise<number> {
  const r = await this._pool.query(
    `UPDATE ${this._fqt} SET pii = NULL WHERE stream = $1 AND pii IS NOT NULL`,
    [stream]
  );
  return r.rowCount ?? 0;
}
```

- Row-level locks, **no table lock**, bounded by events-per-stream.
- Idempotent — second call updates zero rows (the `pii IS NOT NULL` predicate filters out already-wiped rows).
- `events.data` and the rest of the row are never touched — append-only invariant on the domain payload preserved.

## Disk reclamation

Nulling a column doesn't immediately reclaim disk; autovacuum reclaims dead tuples lazily. For strict-deletion jurisdictions, the operator runs `VACUUM FULL events` during a maintenance window. This will be documented in the sensitive-data guide (#863) and production checklist additions, not here.

## Encryption at rest

Out of framework scope. Operators choose the DB-layer mechanism: `pgcrypto`, RDS TDE, Cloud SQL TDE, transparent column-level KMS, etc. The PG adapter just declares the column `jsonb`; confidentiality is the operator's deployment posture.

## Capability + TCK

`store-tck.spec.ts` opts into the shared PII block:

```ts
capabilities: { notify: true, restore: true, pii_isolation: true },
```

The orchestrator's `app.forget(stream)` gates on `typeof store.forget_pii === "function"` rather than the capability flag, so adding the method is sufficient at the runtime contract level. The capability flag drives which TCK tests execute, nothing else.

All four PII contract tests pass:

- commit-with-pii round-trip
- pii-absent passthrough (load returns `null`)
- `forget_pii` happy path + idempotency
- cross-stream isolation (sibling streams' PII untouched)

## Fault injection

`store.error.spec.ts` gains one test mirroring the existing `prioritize` / `reset` / `unblock` defensive patterns — verifies the `rowCount ?? 0` fallback against a mocked PG returning `rowCount: null`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — all 146 test files pass against PG @ port 5431
- [x] PostgresStore TCK suite (87 tests) green including the 4 PII contract tests
- [x] Coverage 100% / 100% / 100% / 100%
- [x] Stability snapshot updated — `PostgresStore` now exposes `forget_pii` as a public method; the snapshot diff captures it explicitly
- [ ] CI green across PG matrix (14 / 15 / 16 / 17)

## Stability charter impact

**Additive on `@rotorsoft/act-pg` public surface:** new `PostgresStore.forget_pii(stream)` method. The base `Store` contract has been carrying this as an optional method since #855; this PR just opts the PG adapter in. No charter-covered file in `@rotorsoft/act` changed.

## Follow-ups (separate tickets)

- **#871** — `@rotorsoft/act-sqlite` PII column impl. Same shape, different SQL.
- **#861** — cache invalidation contract on `app.forget`.
- **#862** — DB-layer encryption-at-rest recipes (pgcrypto / TDE).
- **#863** — `docs/docs/guides/sensitive-data.md` + extension-points update + production checklist additions (`VACUUM FULL`, autovacuum tuning, backup PII exclusion).
- **#864** — book essay on the three rejected designs (inline ciphertext, sibling table, Encryptor port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)