### PR TITLE
feat(act-http): #843 — @rotorsoft/act-http/trpc subpath generates a typed tRPC router

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -89,6 +89,11 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "link",
+          label: "@rotorsoft/act-http (trpc)",
+          href: "/docs/api/act-http/src/trpc",
+        },
+        {
+          type: "link",
           label: "@rotorsoft/act-ops/idempotency",
           href: "/docs/api/act-ops/src/idempotency",
         },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -13,6 +13,7 @@
       "@rotorsoft/act-diagram": ["../libs/act-diagram/src/index.ts"],
       "@rotorsoft/act-http/webhook": ["../libs/act-http/src/webhook/index.ts"],
       "@rotorsoft/act-http/sse": ["../libs/act-http/src/sse/index.ts"],
+      "@rotorsoft/act-http/trpc": ["../libs/act-http/src/trpc/index.ts"],
       "@rotorsoft/act-http/receiver/trpc": [
         "../libs/act-http/src/receiver/trpc/index.ts"
       ],

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -7,6 +7,7 @@
     "../libs/act-tck/src/index.ts",
     "../libs/act-http/src/webhook/index.ts",
     "../libs/act-http/src/sse/index.ts",
+    "../libs/act-http/src/trpc/index.ts",
     "../libs/act-http/src/receiver/index.ts",
     "../libs/act-http/src/receiver/trpc/index.ts",
     "../libs/act-http/src/receiver/express/index.ts",

--- a/libs/act-http/README.md
+++ b/libs/act-http/README.md
@@ -147,6 +147,8 @@ const router = trpc(app, {
   actor: (ctx) => ({ id: ctx.user.id, name: ctx.user.name }),
   // Resolve the target stream per call; singleton aggregates return a constant.
   stream: (action, input, ctx) => `tenant-${ctx.tenant}`,
+  // Optional optimistic concurrency — return `undefined` to skip the check.
+  expectedVersion: (action, input, ctx) => readIfMatchHeader(ctx),
 });
 
 createHTTPServer({ router }).listen(4000);
@@ -240,7 +242,7 @@ Auto-generated tRPC router for the act-http-api epic (#835).
 
 - **`trpc(app, options) → Router`** — generator function. Walks `app.registry.actions` once and emits a flat top-level mutation per action. Each procedure runs the internal `authenticated(options.actor)` middleware (so `ctx.actor: Actor` is set on the downstream context), resolves the target stream via `options.stream(action, input, ctx)`, and calls `app.do(action, { stream, actor }, input)`. Known framework errors map through `toApiError` to the conventional tRPC codes; unknown throws surface as `INTERNAL_SERVER_ERROR`.
 - **`authenticated(extractor) → middleware`** — standalone export of the auth middleware the generator uses internally. Hosts composing their own procedure chain (logging + tracing + custom auth flavors) use `t.procedure.use(authenticated(extractor))` to inject `ctx.actor` without going through the generator. The middleware is structurally-typed so any host `t` instance accepts it.
-- **`TrpcOptions<Ctx>`** — `{ actor, stream, idempotency? }`. `actor` is the `ActorExtractor` from `@rotorsoft/act-http/api`. `stream` returns the target stream per call. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom: (ctx) => string | undefined }` — when set, the procedure honors `Idempotency-Key` via `withIdempotency`. Duplicate claims throw `CONFLICT` (the contract intentionally doesn't cache the original handler's result).
+- **`TrpcOptions<Ctx>`** — `{ actor, stream, expectedVersion?, idempotency? }`. `actor` is the `ActorExtractor` from `@rotorsoft/act-http/api`. `stream` returns the target stream per call. `expectedVersion` is optional — `(action, input, ctx) => number | undefined` — when set, the procedure threads the resolved value through `Target.expectedVersion` so `app.do` enforces optimistic concurrency; hosts typically read it from an `If-Match` header or the client's last-known snapshot, and returning `undefined` skips the check for that call. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom: (ctx) => string | undefined }` — when set, the procedure honors `Idempotency-Key` via `withIdempotency`. Duplicate claims throw `CONFLICT` (the contract intentionally doesn't cache the original handler's result).
 
 ### `/sse` subpath
 

--- a/libs/act-http/README.md
+++ b/libs/act-http/README.md
@@ -135,6 +135,40 @@ On failure: the adapter responds with the framework's idiomatic 400 (`missing-ke
 
 The framework-agnostic core (`checkWebhook`) and the underlying primitives (`extractIdempotencyKey`, `verifyWebhook`) are exported from `@rotorsoft/act-http/receiver` for receivers whose framework isn't in the adapter list (Koa, raw Node `http`, gRPC-over-HTTP, …) or for receivers with custom policy (e.g. "missing key falls back to body-derived dedup"). Use the `receiver` builder when you can; fall back to the framework `webhookMiddleware`, then the primitives.
 
+### `trpc` — auto-generated tRPC router
+
+```ts
+import { trpc } from "@rotorsoft/act-http/trpc";
+import { initTRPC } from "@trpc/server";
+import { createHTTPServer } from "@trpc/server/adapters/standalone";
+
+const router = trpc(app, {
+  // ActorExtractor from `@rotorsoft/act-http/api` — host's auth seam.
+  actor: (ctx) => ({ id: ctx.user.id, name: ctx.user.name }),
+  // Resolve the target stream per call; singleton aggregates return a constant.
+  stream: (action, input, ctx) => `tenant-${ctx.tenant}`,
+});
+
+createHTTPServer({ router }).listen(4000);
+
+// Client (same types, no codegen):
+// await client.OpenTicket.mutate({ title: "support" });
+```
+
+The generator walks `app.registry.actions` once and emits a flat top-level mutation per action. The internal `authenticated(extractor)` middleware runs `options.actor` once per call and injects the resolved `Actor` onto `ctx.actor`, so any procedure logic downstream of the chain sees the same actor. `actor` and `stream` are required; `idempotency` is optional — when configured, the mutation reads `Idempotency-Key` via `keyFrom(ctx)` and throws `CONFLICT` on duplicate claims (the contract intentionally doesn't cache original results, matching the receiver-side "ack the duplicate" semantics).
+
+Errors map through the shared `toApiError(...)` table at `@rotorsoft/act-http/api`: `ConcurrencyError` → `CONFLICT`, `InvariantError` → `CONFLICT`, `ValidationError` → `UNPROCESSABLE_CONTENT`, `StreamClosedError` → `PRECONDITION_FAILED`, `NonRetryableError` → `BAD_REQUEST`, anything else → `INTERNAL_SERVER_ERROR`. The same envelope flows from every transport sibling so a client speaking two of them never sees two shapes for the same framework error.
+
+```ts
+// Compose the auth middleware into your own procedure chain instead:
+import { authenticated } from "@rotorsoft/act-http/trpc";
+
+const t = initTRPC.context<MyCtx>().create();
+const authed = t.procedure.use(authenticated(myExtractor));
+// `authed` carries `ctx.actor: Actor` downstream — use it for hand-written
+// procedures alongside the generated ones.
+```
+
 ### `sse` — live state broadcast
 
 ```ts
@@ -199,6 +233,14 @@ Shared utilities consumed by every transport in the auto-generated API umbrella 
 - **`toApiError(err) → { status, body }`** — the single mapping helper every transport calls in its error boundary. Known framework errors map per `ERROR_MAP`; everything else surfaces as 500 / `INTERNAL` (with `detail` only when the throw was an `Error` — thrown strings or objects don't leak payloads).
 - **`withIdempotency(store, key, handler)`** — wraps an action handler in an `Idempotency-Key` claim. Reuses `@rotorsoft/act-ops/idempotency` — same contract `@rotorsoft/act-http/receiver` already speaks, so one `IdempotencyStore` covers both halves of the "Act over the wire" surface. Returns `{ deduped: false, result }` on fresh claim, `{ deduped: true }` on duplicate (handler is not called).
 - **Types**: `IdempotencyResult<T>`, `ErrorMapEntry`.
+
+### `/trpc` subpath
+
+Auto-generated tRPC router for the act-http-api epic (#835).
+
+- **`trpc(app, options) → Router`** — generator function. Walks `app.registry.actions` once and emits a flat top-level mutation per action. Each procedure runs the internal `authenticated(options.actor)` middleware (so `ctx.actor: Actor` is set on the downstream context), resolves the target stream via `options.stream(action, input, ctx)`, and calls `app.do(action, { stream, actor }, input)`. Known framework errors map through `toApiError` to the conventional tRPC codes; unknown throws surface as `INTERNAL_SERVER_ERROR`.
+- **`authenticated(extractor) → middleware`** — standalone export of the auth middleware the generator uses internally. Hosts composing their own procedure chain (logging + tracing + custom auth flavors) use `t.procedure.use(authenticated(extractor))` to inject `ctx.actor` without going through the generator. The middleware is structurally-typed so any host `t` instance accepts it.
+- **`TrpcOptions<Ctx>`** — `{ actor, stream, idempotency? }`. `actor` is the `ActorExtractor` from `@rotorsoft/act-http/api`. `stream` returns the target stream per call. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom: (ctx) => string | undefined }` — when set, the procedure honors `Idempotency-Key` via `withIdempotency`. Duplicate claims throw `CONFLICT` (the contract intentionally doesn't cache the original handler's result).
 
 ### `/sse` subpath
 

--- a/libs/act-http/package.json
+++ b/libs/act-http/package.json
@@ -2,7 +2,7 @@
   "name": "@rotorsoft/act-http",
   "type": "module",
   "version": "1.2.1",
-  "description": "HTTP integrations for act apps — webhooks and SSE",
+  "description": "HTTP integrations for act apps \u2014 webhooks and SSE",
   "keywords": [
     "typescript",
     "http",
@@ -26,25 +26,15 @@
     "dist"
   ],
   "exports": {
-    "./webhook": {
-      "types": "./dist/@types/webhook/index.d.ts",
-      "import": "./dist/webhook/index.js",
-      "require": "./dist/webhook/index.cjs"
-    },
-    "./sse": {
-      "types": "./dist/@types/sse/index.d.ts",
-      "import": "./dist/sse/index.js",
-      "require": "./dist/sse/index.cjs"
+    "./api": {
+      "types": "./dist/@types/api/index.d.ts",
+      "import": "./dist/api/index.js",
+      "require": "./dist/api/index.cjs"
     },
     "./receiver": {
       "types": "./dist/@types/receiver/index.d.ts",
       "import": "./dist/receiver/index.js",
       "require": "./dist/receiver/index.cjs"
-    },
-    "./receiver/trpc": {
-      "types": "./dist/@types/receiver/trpc/index.d.ts",
-      "import": "./dist/receiver/trpc/index.js",
-      "require": "./dist/receiver/trpc/index.cjs"
     },
     "./receiver/express": {
       "types": "./dist/@types/receiver/express/index.d.ts",
@@ -61,10 +51,25 @@
       "import": "./dist/receiver/hono/index.js",
       "require": "./dist/receiver/hono/index.cjs"
     },
-    "./api": {
-      "types": "./dist/@types/api/index.d.ts",
-      "import": "./dist/api/index.js",
-      "require": "./dist/api/index.cjs"
+    "./receiver/trpc": {
+      "types": "./dist/@types/receiver/trpc/index.d.ts",
+      "import": "./dist/receiver/trpc/index.js",
+      "require": "./dist/receiver/trpc/index.cjs"
+    },
+    "./sse": {
+      "types": "./dist/@types/sse/index.d.ts",
+      "import": "./dist/sse/index.js",
+      "require": "./dist/sse/index.cjs"
+    },
+    "./trpc": {
+      "types": "./dist/@types/trpc/index.d.ts",
+      "import": "./dist/trpc/index.js",
+      "require": "./dist/trpc/index.cjs"
+    },
+    "./webhook": {
+      "types": "./dist/@types/webhook/index.d.ts",
+      "import": "./dist/webhook/index.js",
+      "require": "./dist/webhook/index.cjs"
     }
   },
   "sideEffects": false,

--- a/libs/act-http/src/trpc/index.ts
+++ b/libs/act-http/src/trpc/index.ts
@@ -70,6 +70,14 @@ import {
  *   validated action input, and the original tRPC context; returns
  *   the target stream. Singleton aggregates return a constant;
  *   per-tenant aggregates pull from input or context.
+ * - `expectedVersion` (optional) — optimistic-concurrency resolver.
+ *   When set, the procedure threads the resolved value through
+ *   `target.expectedVersion` so `app.do` refuses to commit if the
+ *   stream has moved. Hosts typically read it from an `If-Match`
+ *   header on the underlying HTTP request, or pull it from the
+ *   client's last-known snapshot. Returning `undefined` skips the
+ *   check for that call — handy when only some actions are
+ *   concurrency-sensitive.
  * - `idempotency` (optional) — when set, the procedure honors
  *   `Idempotency-Key` via the shared
  *   {@link withIdempotency} helper. The host supplies the
@@ -91,6 +99,11 @@ export type TrpcOptions<Ctx> = {
     input: unknown,
     ctx: Ctx
   ) => string | Promise<string>;
+  readonly expectedVersion?: (
+    action_name: string,
+    input: unknown,
+    ctx: Ctx
+  ) => number | undefined | Promise<number | undefined>;
   readonly idempotency?: {
     readonly store: IdempotencyStore;
     readonly keyFrom: (ctx: Ctx) => string | undefined;
@@ -244,7 +257,17 @@ export function trpc<Ctx extends object = object>(
         const host_ctx = ctx as unknown as Ctx & { actor: Actor };
         try {
           const stream = await options.stream(action_name, input, host_ctx);
-          const target = { stream, actor: host_ctx.actor };
+          const expected_version = options.expectedVersion
+            ? await options.expectedVersion(action_name, input, host_ctx)
+            : undefined;
+          const target =
+            expected_version === undefined
+              ? { stream, actor: host_ctx.actor }
+              : {
+                  stream,
+                  actor: host_ctx.actor,
+                  expectedVersion: expected_version,
+                };
 
           if (options.idempotency) {
             const key = options.idempotency.keyFrom(host_ctx);

--- a/libs/act-http/src/trpc/index.ts
+++ b/libs/act-http/src/trpc/index.ts
@@ -1,0 +1,286 @@
+/**
+ * @packageDocumentation
+ * @module act-http/trpc
+ *
+ * tRPC subpath for the auto-generated API epic (#835). Walks the
+ * registry of a built `Act` once at function call and emits a typed
+ * router that exposes every registered action as a flat `mutation`,
+ * matching the shape hand-written tRPC routers in the Act ecosystem
+ * already use.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { trpc } from "@rotorsoft/act-http/trpc";
+ *
+ * const router = trpc(app, {
+ *   actor: (ctx) => ({ id: ctx.user.id, name: ctx.user.name }),
+ *   stream: (action, input, ctx) => input.stream ?? ctx.tenant,
+ * });
+ *
+ * // Client sees:
+ * //   appRouter.PressKey.mutate({ key: "5" })
+ * //   appRouter.OpenTicket.mutate({ title: "..." })
+ * ```
+ *
+ * The route shape is flat: one procedure per registered action at
+ * the top level. Action names are the unique identifiers across
+ * the registry (the framework already enforces no duplicates), so
+ * an extra namespace tier would be overhead in the common case.
+ * Pure mutations for this slice; query/projection wiring lives in
+ * a follow-up. See `libs/act-http/README.md` for the full surface
+ * walkthrough.
+ *
+ * **Actor lives on the context.** The generator wires an internal
+ * tRPC middleware that runs the host's
+ * {@link TrpcOptions.actor | actor extractor} once per call and
+ * injects the resolved {@link Actor} onto the downstream context as
+ * `ctx.actor`. Every generated mutation reads from there — auth
+ * resolves at the procedure boundary, not inside each action body,
+ * and any composed middleware (logging, tracing) sees the same
+ * `ctx.actor`. The middleware factory is also exported as
+ * {@link authenticated} for hosts that need to compose it into
+ * their own procedure chain.
+ *
+ * Composes the shared utilities at `@rotorsoft/act-http/api`:
+ * {@link ActorExtractor} for the auth seam, {@link toApiError} for
+ * the uniform error→status/code mapping, {@link withIdempotency}
+ * for `Idempotency-Key` dedup. Three transports (this one, Hono,
+ * OpenAPI) ride the same utilities so a client talking to two
+ * transports never sees two error shapes for the same framework
+ * error.
+ */
+import type { Act, Actor, Schema, Schemas } from "@rotorsoft/act";
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import { initTRPC, TRPCError } from "@trpc/server";
+import {
+  type ActorExtractor,
+  toApiError,
+  withIdempotency,
+} from "../api/index.js";
+
+/**
+ * Per-call options for {@link trpc}. The host supplies the three
+ * seams the package can't make decisions on:
+ *
+ * - `actor` — auth resolver. Receives the tRPC context, returns the
+ *   `Actor` that flows onto `ctx.actor` for every generated
+ *   procedure (via an internal {@link authenticated}).
+ * - `stream` — stream-id resolver. Receives the action name, the
+ *   validated action input, and the original tRPC context; returns
+ *   the target stream. Singleton aggregates return a constant;
+ *   per-tenant aggregates pull from input or context.
+ * - `idempotency` (optional) — when set, the procedure honors
+ *   `Idempotency-Key` via the shared
+ *   {@link withIdempotency} helper. The host supplies the
+ *   `IdempotencyStore` and a `keyFrom` extractor that reads the key
+ *   out of the tRPC context (typically a header). On a duplicate
+ *   claim, the procedure throws a `CONFLICT` `TRPCError` — the
+ *   receiver-side convention of "ack the duplicate" doesn't carry
+ *   over because the contract intentionally does not cache the
+ *   original handler's result.
+ *
+ * @template Ctx The host's tRPC context shape. Flows end-to-end —
+ *   procedures see this exact context type (plus `actor`) at
+ *   runtime.
+ */
+export type TrpcOptions<Ctx> = {
+  readonly actor: ActorExtractor;
+  readonly stream: (
+    action_name: string,
+    input: unknown,
+    ctx: Ctx
+  ) => string | Promise<string>;
+  readonly idempotency?: {
+    readonly store: IdempotencyStore;
+    readonly keyFrom: (ctx: Ctx) => string | undefined;
+  };
+};
+
+/**
+ * Build a tRPC middleware that runs an {@link ActorExtractor} once
+ * per call and forwards the resolved {@link Actor} on the
+ * downstream context as `ctx.actor`. The generator at
+ * {@link trpc} uses this internally; it's also exported so hosts
+ * that want to compose their own procedure chain (logging,
+ * tracing, custom auth flavors) can wire it directly:
+ *
+ * ```ts
+ * import { initTRPC } from "@trpc/server";
+ * import { authenticated } from "@rotorsoft/act-http/trpc";
+ *
+ * type Ctx = { user?: { id: string; name: string } };
+ * const t = initTRPC.context<Ctx>().create();
+ *
+ * const authed = t.procedure.use(
+ *   authenticated((ctx) => {
+ *     if (!ctx.user) throw new Error("not authenticated");
+ *     return { id: ctx.user.id, name: ctx.user.name };
+ *   })
+ * );
+ *
+ * // Inside any procedure built off `authed`, `ctx.actor: Actor`.
+ * ```
+ *
+ * The middleware is unaware of the host's `t` instance — it returns
+ * a structurally-typed function that any tRPC `procedure.use(...)`
+ * accepts. Errors thrown by the extractor surface unchanged
+ * (typically wrap them as `TRPCError({ code: "UNAUTHORIZED" })`
+ * in the extractor body).
+ */
+// biome-ignore lint/suspicious/noExplicitAny: tRPC's internal middleware shape lives behind `unstable-core-do-not-import`; structural typing carries the host's `t` validation.
+export function authenticated(extractor: ActorExtractor): any {
+  return async function actor_middleware({
+    ctx,
+    next,
+  }: {
+    ctx: object;
+    next: (opts: { ctx: object }) => Promise<unknown>;
+  }) {
+    const actor = await extractor(ctx);
+    return next({ ctx: { ...ctx, actor } });
+  };
+}
+
+/**
+ * Map a thrown framework error onto a `TRPCError`. Known errors get
+ * their conventional tRPC code (`ConcurrencyError` → `CONFLICT`,
+ * `ValidationError` → `UNPROCESSABLE_CONTENT`, etc.); unknown throws
+ * surface as `INTERNAL_SERVER_ERROR`. Every transport in the
+ * act-http epic passes through the same {@link toApiError} table,
+ * so a client talking to both this subpath and the REST sibling
+ * sees one envelope per framework error.
+ *
+ * @internal
+ */
+function to_trpc_error(err: unknown): TRPCError {
+  const { status, body } = toApiError(err);
+  const code = status_to_trpc_code(status);
+  return new TRPCError({
+    code,
+    message: body.detail ?? body.error,
+    cause: err instanceof Error ? err : undefined,
+  });
+}
+
+/**
+ * Minimal status → tRPC code map. Only the statuses
+ * {@link ERROR_MAP} produces (plus 500) appear here; anything else
+ * collapses to `INTERNAL_SERVER_ERROR`.
+ *
+ * @internal
+ */
+function status_to_trpc_code(status: number): TRPCError["code"] {
+  switch (status) {
+    case 400:
+      return "BAD_REQUEST";
+    case 409:
+      return "CONFLICT";
+    case 410:
+      return "PRECONDITION_FAILED";
+    case 412:
+      return "CONFLICT";
+    case 422:
+      return "UNPROCESSABLE_CONTENT";
+    default:
+      return "INTERNAL_SERVER_ERROR";
+  }
+}
+
+/**
+ * Build a typed tRPC router from a built `Act` instance.
+ *
+ * Walks `app.registry.actions` once and emits one flat mutation per
+ * action under `router.<actionName>`. The framework already enforces
+ * no duplicate action names across states, so a flat tier reads
+ * cleanly at the client and matches the hand-written router shape
+ * adopters already have. Each mutation:
+ *
+ * 1. Runs the internal {@link authenticated} — `options.actor`
+ *    resolves the {@link Actor} once and injects it onto
+ *    `ctx.actor`.
+ * 2. Resolves the target stream via `options.stream(name, input, ctx)`.
+ * 3. (Optionally) claims the `Idempotency-Key` via
+ *    {@link withIdempotency} — throws `CONFLICT` on duplicate.
+ * 4. Calls `app.do(name, { stream, actor: ctx.actor }, input)`.
+ * 5. Maps any thrown framework error onto a `TRPCError` via
+ *    {@link toApiError}.
+ *
+ * The returned router's procedure inputs come straight from each
+ * action's Zod schema; outputs are the framework's
+ * `Snapshot<TState, TEvents>[]` shape. Strong typing flows
+ * end-to-end via tRPC's normal inference path — the client sees
+ * `appRouter.Calculator.PressKey.mutate({ key: "5" })` as a typed
+ * call without any codegen.
+ *
+ * @template Ctx The tRPC context shape the host's runtime feeds in.
+ *   Flows through `actor`, `stream`, and `idempotency.keyFrom` so
+ *   the operator's existing context types just work. The internal
+ *   middleware augments `Ctx` with `{ actor: Actor }` on the
+ *   downstream procedure context.
+ *
+ * @param app A built `Act` orchestrator.
+ * @param options Auth, stream, and (optional) idempotency seams.
+ * @returns A tRPC router covering every registered action, grouped
+ *   by owning state.
+ */
+export function trpc<Ctx extends object = object>(
+  // biome-ignore lint/suspicious/noExplicitAny: erased — the generator walks the registry at runtime, not the typed surface
+  app: Act<any, Schemas, Schemas, Record<string, Schema>>,
+  options: TrpcOptions<Ctx>
+) {
+  const t = initTRPC.context<Ctx>().create();
+  const authed = t.procedure.use(authenticated(options.actor));
+
+  const handlers: Record<string, ReturnType<typeof authed.mutation>> = {};
+  for (const [action_name, state] of Object.entries(app.registry.actions)) {
+    handlers[action_name] = authed
+      .input(state.actions[action_name] as never)
+      .mutation(async ({ input, ctx }) => {
+        // tRPC's internal `Simplify<Ctx>` transform produces a type
+        // that's structurally identical to `Ctx & { actor }` but not
+        // assignable to the generic parameter. The cast restores the
+        // link; the runtime ctx IS the augmented context.
+        const host_ctx = ctx as unknown as Ctx & { actor: Actor };
+        try {
+          const stream = await options.stream(action_name, input, host_ctx);
+          const target = { stream, actor: host_ctx.actor };
+
+          if (options.idempotency) {
+            const key = options.idempotency.keyFrom(host_ctx);
+            if (!key) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Idempotency-Key required",
+              });
+            }
+            const outcome = await withIdempotency(
+              options.idempotency.store,
+              key,
+              () =>
+                app.do(action_name as never, target as never, input as never)
+            );
+            if (outcome.deduped) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "Idempotency-Key already used; original result not cached",
+              });
+            }
+            return outcome.result;
+          }
+
+          return await app.do(
+            action_name as never,
+            target as never,
+            input as never
+          );
+        } catch (err) {
+          if (err instanceof TRPCError) throw err;
+          throw to_trpc_error(err);
+        }
+      });
+  }
+
+  return t.router(handlers as never);
+}

--- a/libs/act-http/test/trpc/index.spec.ts
+++ b/libs/act-http/test/trpc/index.spec.ts
@@ -1,0 +1,346 @@
+/**
+ * Adapter-generated tRPC router for `@rotorsoft/act-http/trpc` (#843).
+ *
+ * Uses an in-memory `Act` with two states (Calculator + Ticket) so the
+ * cross-state action surface is observable: every action lands as a
+ * top-level mutation, names stay unique across states (the framework
+ * enforces this), and stream/actor resolution flows through the same
+ * seams regardless of owning state.
+ *
+ * Runtime coverage: flat emission across states, the internal actor
+ * middleware, stream extraction, idempotency dedup, error mapping
+ * (validation / concurrency / unknown / non-Error throws). Type-level
+ * coverage via `expectTypeOf` for procedure inputs.
+ */
+import {
+  act,
+  ConcurrencyError,
+  InvariantError,
+  NonRetryableError,
+  StreamClosedError,
+  state,
+  ValidationError,
+  ZodEmpty,
+} from "@rotorsoft/act";
+import { fixture } from "@rotorsoft/act/test";
+import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import { initTRPC, TRPCError } from "@trpc/server";
+import { describe, expect, expectTypeOf, vi } from "vitest";
+import { z } from "zod";
+import { authenticated, type TrpcOptions, trpc } from "../../src/trpc/index.js";
+
+const Calculator = state({
+  Calculator: z.object({ display: z.string() }),
+})
+  .init(() => ({ display: "" }))
+  .emits({
+    KeyPressed: z.object({ key: z.string() }),
+    Cleared: ZodEmpty,
+  })
+  .patch({
+    KeyPressed: ({ data }, s) => ({ display: s.display + data.key }),
+    Cleared: () => ({ display: "" }),
+  })
+  .on({ PressKey: z.object({ key: z.string().min(1) }) })
+  .emit((a) => ["KeyPressed", { key: a.key }])
+  .on({ Clear: ZodEmpty })
+  .emit(() => ["Cleared", {}])
+  .build();
+
+const Ticket = state({
+  Ticket: z.object({ title: z.string(), open: z.boolean() }),
+})
+  .init(() => ({ title: "", open: false }))
+  .emits({ TicketOpened: z.object({ title: z.string() }) })
+  .patch({
+    TicketOpened: ({ data }) => ({ title: data.title, open: true }),
+  })
+  .on({ OpenTicket: z.object({ title: z.string() }) })
+  .emit((a) => ["TicketOpened", { title: a.title }])
+  .build();
+
+const builder = act().withState(Calculator).withState(Ticket);
+
+const test = fixture(builder);
+
+type Ctx = {
+  actorId: string;
+  actorName: string;
+  tenant: string;
+  idempotencyKey?: string;
+};
+
+const default_options = (): TrpcOptions<Ctx> => ({
+  actor: (ctx) => ({
+    id: (ctx as Ctx).actorId,
+    name: (ctx as Ctx).actorName,
+  }),
+  stream: async (_action, _input, ctx) => `tenant-${ctx.tenant}`,
+});
+
+const make_ctx = (overrides: Partial<Ctx> = {}): Ctx => ({
+  actorId: "u-1",
+  actorName: "alice",
+  tenant: "acme",
+  ...overrides,
+});
+
+// biome-ignore lint/suspicious/noExplicitAny: the generator returns a widely-typed router; callers cast at use sites for typed input/output. The type-level test below pins the per-procedure input shape separately.
+type AnyCaller = any;
+
+describe("trpc(app, options) — generated router", () => {
+  test("emits one flat mutation per registered action across all states", ({
+    app,
+  }) => {
+    const router = trpc<Ctx>(app as never, default_options());
+    const def = (router as { _def: { procedures: Record<string, unknown> } })
+      ._def.procedures;
+    expect(Object.keys(def).sort()).toEqual([
+      "Clear",
+      "OpenTicket",
+      "PressKey",
+    ]);
+  });
+
+  test("each emitted procedure is callable as a top-level mutation", ({
+    app,
+  }) => {
+    const router = trpc<Ctx>(app as never, default_options());
+    const t = initTRPC.context<Ctx>().create();
+    const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+    expect(typeof caller.PressKey).toBe("function");
+    expect(typeof caller.Clear).toBe("function");
+    expect(typeof caller.OpenTicket).toBe("function");
+  });
+
+  test("threads actor (via internal middleware) and stream into app.do", async ({
+    app,
+  }) => {
+    const do_spy = vi.spyOn(app, "do");
+    const router = trpc<Ctx>(app as never, default_options());
+    const t = initTRPC.context<Ctx>().create();
+    const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+    const snapshots = await caller.PressKey({ key: "5" });
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].event.name).toBe("KeyPressed");
+    expect(snapshots[0].event.stream).toBe("tenant-acme");
+    expect(do_spy).toHaveBeenCalledWith(
+      "PressKey",
+      {
+        stream: "tenant-acme",
+        actor: { id: "u-1", name: "alice" },
+      },
+      { key: "5" }
+    );
+  });
+
+  test("maps ValidationError to a 4xx code", async ({ app }) => {
+    const router = trpc<Ctx>(app as never, default_options());
+    const t = initTRPC.context<Ctx>().create();
+    const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+    // Empty key violates the action's `.min(1)` Zod constraint. tRPC's
+    // own input parser catches it first as BAD_REQUEST.
+    await expect(caller.PressKey({ key: "" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  describe("framework error mapping (via toApiError)", () => {
+    const cases: ReadonlyArray<{
+      readonly label: string;
+      readonly throws: () => Error;
+      readonly code: string;
+    }> = [
+      {
+        label: "ConcurrencyError → CONFLICT (412)",
+        throws: () => new ConcurrencyError("tenant-acme", 0, [], 1),
+        code: "CONFLICT",
+      },
+      {
+        label: "InvariantError → CONFLICT (409)",
+        throws: () =>
+          new InvariantError(
+            "PressKey",
+            { key: "5" },
+            { stream: "tenant-acme", actor: { id: "u-1", name: "alice" } },
+            {} as never,
+            "calculator must be open"
+          ),
+        code: "CONFLICT",
+      },
+      {
+        label: "StreamClosedError → PRECONDITION_FAILED (410)",
+        throws: () => new StreamClosedError("tenant-acme"),
+        code: "PRECONDITION_FAILED",
+      },
+      {
+        label: "NonRetryableError → BAD_REQUEST (400)",
+        throws: () => new NonRetryableError("permanently busted"),
+        code: "BAD_REQUEST",
+      },
+      {
+        label: "ValidationError → UNPROCESSABLE_CONTENT (422)",
+        throws: () =>
+          new ValidationError("PressKey", { key: "5" }, {
+            issues: [],
+          } as never),
+        code: "UNPROCESSABLE_CONTENT",
+      },
+    ];
+
+    for (const { label, throws, code } of cases) {
+      test(label, async ({ app }) => {
+        const router = trpc<Ctx>(app as never, default_options());
+        const t = initTRPC.context<Ctx>().create();
+        const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+        vi.spyOn(app, "do").mockRejectedValueOnce(throws());
+        await expect(caller.PressKey({ key: "5" })).rejects.toMatchObject({
+          code,
+        });
+      });
+    }
+  });
+
+  test("wraps unknown thrown values as INTERNAL_SERVER_ERROR", async ({
+    app,
+  }) => {
+    const router = trpc<Ctx>(app as never, default_options());
+    const t = initTRPC.context<Ctx>().create();
+    const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+    vi.spyOn(app, "do").mockRejectedValueOnce(new Error("disk on fire"));
+    await expect(caller.PressKey({ key: "5" })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+  });
+
+  test("non-Error throws still surface as TRPCError", async ({ app }) => {
+    const router = trpc<Ctx>(app as never, default_options());
+    const t = initTRPC.context<Ctx>().create();
+    const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+    vi.spyOn(app, "do").mockRejectedValueOnce("not-an-error-instance");
+    await expect(caller.PressKey({ key: "5" })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+  });
+
+  describe("idempotency", () => {
+    test("fresh key dispatches the handler and returns the snapshots", async ({
+      app,
+    }) => {
+      const router = trpc<Ctx>(app as never, {
+        ...default_options(),
+        idempotency: {
+          store: new InMemoryIdempotencyStore(),
+          keyFrom: (ctx) => ctx.idempotencyKey,
+        },
+      });
+      const t = initTRPC.context<Ctx>().create();
+      const caller: AnyCaller = t.createCallerFactory(router)(
+        make_ctx({ idempotencyKey: "fresh-1" })
+      );
+
+      const snapshots = await caller.PressKey({ key: "7" });
+      expect(snapshots[0].event.name).toBe("KeyPressed");
+    });
+
+    test("missing key throws BAD_REQUEST", async ({ app }) => {
+      const router = trpc<Ctx>(app as never, {
+        ...default_options(),
+        idempotency: {
+          store: new InMemoryIdempotencyStore(),
+          keyFrom: () => undefined,
+        },
+      });
+      const t = initTRPC.context<Ctx>().create();
+      const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+      await expect(caller.PressKey({ key: "8" })).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      });
+    });
+
+    test("duplicate claim throws CONFLICT (original result not cached)", async ({
+      app,
+    }) => {
+      const store = new InMemoryIdempotencyStore();
+      const router = trpc<Ctx>(app as never, {
+        ...default_options(),
+        idempotency: {
+          store,
+          keyFrom: (ctx) => ctx.idempotencyKey,
+        },
+      });
+      const t = initTRPC.context<Ctx>().create();
+      const caller: AnyCaller = t.createCallerFactory(router)(
+        make_ctx({ idempotencyKey: "dup-1" })
+      );
+
+      await caller.PressKey({ key: "1" });
+      await expect(caller.PressKey({ key: "1" })).rejects.toMatchObject({
+        code: "CONFLICT",
+      });
+    });
+  });
+
+  describe("authenticated (standalone export)", () => {
+    test("injects the resolved actor onto downstream ctx", async () => {
+      const t = initTRPC.context<{ uid: string }>().create();
+      const authed = t.procedure.use(
+        authenticated((ctx) => ({
+          id: (ctx as { uid: string }).uid,
+          name: `user-${(ctx as { uid: string }).uid}`,
+        }))
+      );
+      // The middleware returns `any` to avoid the
+      // `unstable-core-do-not-import` namespace dance — the per-call
+      // ctx augmentation is real at runtime but invisible to tRPC's
+      // inference, so the test casts to read `ctx.actor`.
+      const router = t.router({
+        whoami: authed.query(
+          ({ ctx }) =>
+            (ctx as unknown as { actor: { id: string; name: string } }).actor
+        ),
+      });
+      const caller = t.createCallerFactory(router)({ uid: "alice" });
+      expect(await caller.whoami()).toEqual({
+        id: "alice",
+        name: "user-alice",
+      });
+    });
+
+    test("propagates errors thrown by the extractor", async () => {
+      const t = initTRPC.context<{ uid?: string }>().create();
+      const authed = t.procedure.use(
+        authenticated((ctx) => {
+          const c = ctx as { uid?: string };
+          if (!c.uid)
+            throw new TRPCError({
+              code: "UNAUTHORIZED",
+              message: "no uid in ctx",
+            });
+          return { id: c.uid, name: c.uid };
+        })
+      );
+      const router = t.router({
+        whoami: authed.query(({ ctx }) => (ctx as { actor?: unknown }).actor),
+      });
+      const caller = t.createCallerFactory(router)({});
+      await expect(caller.whoami()).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+  });
+
+  test("infers procedure input types from the registered Zod schemas", () => {
+    expectTypeOf<z.infer<typeof Calculator.actions.PressKey>>().toEqualTypeOf<{
+      key: string;
+    }>();
+    expectTypeOf<z.infer<typeof Ticket.actions.OpenTicket>>().toEqualTypeOf<{
+      title: string;
+    }>();
+  });
+});

--- a/libs/act-http/test/trpc/index.spec.ts
+++ b/libs/act-http/test/trpc/index.spec.ts
@@ -147,6 +147,51 @@ describe("trpc(app, options) — generated router", () => {
     });
   });
 
+  describe("expectedVersion (optimistic concurrency)", () => {
+    test("threads the resolved value through Target.expectedVersion", async ({
+      app,
+    }) => {
+      const do_spy = vi.spyOn(app, "do").mockResolvedValueOnce([]);
+      const router = trpc<Ctx>(app as never, {
+        ...default_options(),
+        expectedVersion: () => 7,
+      });
+      const t = initTRPC.context<Ctx>().create();
+      const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+      await caller.PressKey({ key: "5" });
+      expect(do_spy).toHaveBeenCalledWith(
+        "PressKey",
+        {
+          stream: "tenant-acme",
+          actor: { id: "u-1", name: "alice" },
+          expectedVersion: 7,
+        },
+        { key: "5" }
+      );
+    });
+
+    test("undefined return value skips the check (no expectedVersion on target)", async ({
+      app,
+    }) => {
+      const do_spy = vi.spyOn(app, "do").mockResolvedValueOnce([]);
+      const router = trpc<Ctx>(app as never, {
+        ...default_options(),
+        expectedVersion: () => undefined,
+      });
+      const t = initTRPC.context<Ctx>().create();
+      const caller: AnyCaller = t.createCallerFactory(router)(make_ctx());
+
+      await caller.PressKey({ key: "5" });
+      expect(do_spy).toHaveBeenCalledWith(
+        "PressKey",
+        // No `expectedVersion` key — the target is the plain shape.
+        { stream: "tenant-acme", actor: { id: "u-1", name: "alice" } },
+        { key: "5" }
+      );
+    });
+  });
+
   describe("framework error mapping (via toApiError)", () => {
     const cases: ReadonlyArray<{
       readonly label: string;

--- a/libs/act-http/tsup.config.ts
+++ b/libs/act-http/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     "src/receiver/fastify/index.ts",
     "src/receiver/hono/index.ts",
     "src/api/index.ts",
+    "src/trpc/index.ts",
   ],
   format: ["esm", "cjs"],
   dts: false,

--- a/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
+++ b/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
@@ -31102,6 +31102,512 @@ export type Subscriber<S extends BroadcastState = BroadcastState> = (
 "
 `;
 
+exports[`@rotorsoft/act-http — public API stability > stable public surface for ./trpc 1`] = `
+"// === actor.ts ===
+import type { Actor } from "@rotorsoft/act";
+
+/**
+ * Extractor function the host supplies to resolve an {@link Actor}
+ * from an incoming request. The framework keeps auth out of the
+ * package — JWT vs session vs API key is the host's call — and asks
+ * for this single closure that every transport (tRPC, Hono, OpenAPI
+ * docs) composes against.
+ *
+ * The \`request\` argument is intentionally generic. Each transport
+ * narrows it at the call site (\`IncomingMessage\` for Hono, the tRPC
+ * context object for tRPC, etc.) — keeping the contract here
+ * transport-agnostic means one extractor implementation plugs into
+ * every adapter unchanged.
+ *
+ * Async is allowed so the extractor can verify a JWT against a
+ * remote JWKS endpoint without forcing every host to synchronously
+ * cache.
+ */
+export type ActorExtractor = (request: unknown) => Actor | Promise<Actor>;
+
+// === errors.ts ===
+import {
+  ConcurrencyError,
+  InvariantError,
+  NonRetryableError,
+  StreamClosedError,
+  ValidationError,
+} from "@rotorsoft/act";
+
+/**
+ * Uniform error envelope shipped over the wire by every act-http
+ * transport. Hosts get the same shape from REST, tRPC, and OpenAPI —
+ * a client that talks to two transports doesn't have to invent two
+ * error parsers.
+ *
+ * - \`error\` — the framework error name (\`"ValidationError"\`,
+ *   \`"InvariantError"\`, …). Stable identifier, safe to switch on.
+ * - \`detail\` — the framework's message text. Human-readable; not
+ *   parsed by clients.
+ * - \`code\` — a machine-readable status code from {@link ERROR_MAP}
+ *   for clients that prefer enum-style branching over name strings.
+ */
+export type ApiError = {
+  error: string;
+  detail?: string;
+  code?: string;
+};
+
+/**
+ * Status + code pair for one known framework error.
+ */
+export type ErrorMapEntry = {
+  status: number;
+  code: string;
+};
+
+/**
+ * The single table that maps framework error types to HTTP status
+ * codes and machine-readable codes. One table, three consumers
+ * (Hono, tRPC, OpenAPI) — cross-transport consistency by
+ * construction.
+ *
+ * Operators wanting different mappings wrap the generated transport
+ * rather than mutating this — the consistency is the load-bearing
+ * property, not the specific status codes.
+ */
+export const ERROR_MAP = {
+  ValidationError: { status: 422, code: "VALIDATION" },
+  InvariantError: { status: 409, code: "INVARIANT" },
+  ConcurrencyError: { status: 412, code: "CONCURRENCY" },
+  StreamClosedError: { status: 410, code: "STREAM_CLOSED" },
+  NonRetryableError: { status: 400, code: "NON_RETRYABLE" },
+} as const satisfies Record<string, ErrorMapEntry>;
+
+const lookup_known = (
+  err: unknown
+): { name: keyof typeof ERROR_MAP } | null => {
+  if (err instanceof ValidationError) return { name: "ValidationError" };
+  if (err instanceof InvariantError) return { name: "InvariantError" };
+  if (err instanceof ConcurrencyError) return { name: "ConcurrencyError" };
+  if (err instanceof StreamClosedError) return { name: "StreamClosedError" };
+  if (err instanceof NonRetryableError) return { name: "NonRetryableError" };
+  return null;
+};
+
+/**
+ * Translate an unknown thrown value into the canonical
+ * {@link ApiError} envelope plus HTTP status. Each transport's error
+ * boundary calls this once and forwards the result to the wire.
+ *
+ * Known framework errors map per {@link ERROR_MAP}. Everything else
+ * surfaces as a 500 with \`code: "INTERNAL"\`; the \`detail\` field is
+ * populated when the throw was an \`Error\` instance, omitted
+ * otherwise (a thrown string or object doesn't get to leak its
+ * payload to the client).
+ */
+export function toApiError(err: unknown): { status: number; body: ApiError } {
+  const known = lookup_known(err);
+  if (known) {
+    const entry = ERROR_MAP[known.name];
+    return {
+      status: entry.status,
+      body: {
+        error: known.name,
+        detail: (err as Error).message,
+        code: entry.code,
+      },
+    };
+  }
+  if (err instanceof Error) {
+    return {
+      status: 500,
+      body: { error: "InternalError", detail: err.message, code: "INTERNAL" },
+    };
+  }
+  return {
+    status: 500,
+    body: { error: "InternalError", code: "INTERNAL" },
+  };
+}
+
+// === idempotency.ts ===
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+
+/**
+ * Result of a {@link withIdempotency} call.
+ *
+ * - \`{ deduped: false, result }\` — the claim was fresh; the handler
+ *   ran and produced \`result\`.
+ * - \`{ deduped: true }\` — the claim was already taken; the handler
+ *   was *not* invoked. The caller decides how to respond (typically
+ *   a 2xx with no body, matching the receiver-side convention).
+ *
+ * Note: the contract does not cache the previous response. A
+ * duplicate call returns the deduped marker only — replaying the
+ * original handler's output would require a response-caching
+ * adapter, which is out of scope here. The receiver-side convention
+ * (and the convention the generated transports follow) is "ack the
+ * duplicate; do nothing else."
+ */
+export type IdempotencyResult<T> =
+  | { deduped: false; result: T }
+  | { deduped: true };
+
+/**
+ * Wrap an action handler so the framework honors \`Idempotency-Key\`
+ * dedup. Acquires the key via {@link IdempotencyStore.claim}, runs
+ * the handler exactly when the claim was fresh, and skips the
+ * handler entirely on a duplicate.
+ *
+ * Reuses the contract \`@rotorsoft/act-ops/idempotency\` already
+ * defines for the receiver-side \`Idempotency-Key\` story. A single
+ * \`IdempotencyStore\` implementation covers both halves of the "Act
+ * over the wire" surface — receiver and generated API.
+ */
+export async function withIdempotency<T>(
+  store: IdempotencyStore,
+  key: string,
+  handler: () => Promise<T>
+): Promise<IdempotencyResult<T>> {
+  const fresh = await store.claim(key);
+  if (!fresh) {
+    return { deduped: true };
+  }
+  return { deduped: false, result: await handler() };
+}
+
+// === index.ts ===
+/**
+ * @packageDocumentation
+ * @module act-http/trpc
+ *
+ * tRPC subpath for the auto-generated API epic (#835). Walks the
+ * registry of a built \`Act\` once at function call and emits a typed
+ * router that exposes every registered action as a flat \`mutation\`,
+ * matching the shape hand-written tRPC routers in the Act ecosystem
+ * already use.
+ *
+ * Usage:
+ *
+ * \`\`\`ts
+ * import { trpc } from "@rotorsoft/act-http/trpc";
+ *
+ * const router = trpc(app, {
+ *   actor: (ctx) => ({ id: ctx.user.id, name: ctx.user.name }),
+ *   stream: (action, input, ctx) => input.stream ?? ctx.tenant,
+ * });
+ *
+ * // Client sees:
+ * //   appRouter.PressKey.mutate({ key: "5" })
+ * //   appRouter.OpenTicket.mutate({ title: "..." })
+ * \`\`\`
+ *
+ * The route shape is flat: one procedure per registered action at
+ * the top level. Action names are the unique identifiers across
+ * the registry (the framework already enforces no duplicates), so
+ * an extra namespace tier would be overhead in the common case.
+ * Pure mutations for this slice; query/projection wiring lives in
+ * a follow-up. See \`libs/act-http/README.md\` for the full surface
+ * walkthrough.
+ *
+ * **Actor lives on the context.** The generator wires an internal
+ * tRPC middleware that runs the host's
+ * {@link TrpcOptions.actor | actor extractor} once per call and
+ * injects the resolved {@link Actor} onto the downstream context as
+ * \`ctx.actor\`. Every generated mutation reads from there — auth
+ * resolves at the procedure boundary, not inside each action body,
+ * and any composed middleware (logging, tracing) sees the same
+ * \`ctx.actor\`. The middleware factory is also exported as
+ * {@link authenticated} for hosts that need to compose it into
+ * their own procedure chain.
+ *
+ * Composes the shared utilities at \`@rotorsoft/act-http/api\`:
+ * {@link ActorExtractor} for the auth seam, {@link toApiError} for
+ * the uniform error→status/code mapping, {@link withIdempotency}
+ * for \`Idempotency-Key\` dedup. Three transports (this one, Hono,
+ * OpenAPI) ride the same utilities so a client talking to two
+ * transports never sees two error shapes for the same framework
+ * error.
+ */
+import type { Act, Actor, Schema, Schemas } from "@rotorsoft/act";
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import { initTRPC, TRPCError } from "@trpc/server";
+import {
+  type ActorExtractor,
+  toApiError,
+  withIdempotency,
+} from "../api/index.js";
+
+/**
+ * Per-call options for {@link trpc}. The host supplies the three
+ * seams the package can't make decisions on:
+ *
+ * - \`actor\` — auth resolver. Receives the tRPC context, returns the
+ *   \`Actor\` that flows onto \`ctx.actor\` for every generated
+ *   procedure (via an internal {@link authenticated}).
+ * - \`stream\` — stream-id resolver. Receives the action name, the
+ *   validated action input, and the original tRPC context; returns
+ *   the target stream. Singleton aggregates return a constant;
+ *   per-tenant aggregates pull from input or context.
+ * - \`idempotency\` (optional) — when set, the procedure honors
+ *   \`Idempotency-Key\` via the shared
+ *   {@link withIdempotency} helper. The host supplies the
+ *   \`IdempotencyStore\` and a \`keyFrom\` extractor that reads the key
+ *   out of the tRPC context (typically a header). On a duplicate
+ *   claim, the procedure throws a \`CONFLICT\` \`TRPCError\` — the
+ *   receiver-side convention of "ack the duplicate" doesn't carry
+ *   over because the contract intentionally does not cache the
+ *   original handler's result.
+ *
+ * @template Ctx The host's tRPC context shape. Flows end-to-end —
+ *   procedures see this exact context type (plus \`actor\`) at
+ *   runtime.
+ */
+export type TrpcOptions<Ctx> = {
+  readonly actor: ActorExtractor;
+  readonly stream: (
+    action_name: string,
+    input: unknown,
+    ctx: Ctx
+  ) => string | Promise<string>;
+  readonly idempotency?: {
+    readonly store: IdempotencyStore;
+    readonly keyFrom: (ctx: Ctx) => string | undefined;
+  };
+};
+
+/**
+ * Build a tRPC middleware that runs an {@link ActorExtractor} once
+ * per call and forwards the resolved {@link Actor} on the
+ * downstream context as \`ctx.actor\`. The generator at
+ * {@link trpc} uses this internally; it's also exported so hosts
+ * that want to compose their own procedure chain (logging,
+ * tracing, custom auth flavors) can wire it directly:
+ *
+ * \`\`\`ts
+ * import { initTRPC } from "@trpc/server";
+ * import { authenticated } from "@rotorsoft/act-http/trpc";
+ *
+ * type Ctx = { user?: { id: string; name: string } };
+ * const t = initTRPC.context<Ctx>().create();
+ *
+ * const authed = t.procedure.use(
+ *   authenticated((ctx) => {
+ *     if (!ctx.user) throw new Error("not authenticated");
+ *     return { id: ctx.user.id, name: ctx.user.name };
+ *   })
+ * );
+ *
+ * // Inside any procedure built off \`authed\`, \`ctx.actor: Actor\`.
+ * \`\`\`
+ *
+ * The middleware is unaware of the host's \`t\` instance — it returns
+ * a structurally-typed function that any tRPC \`procedure.use(...)\`
+ * accepts. Errors thrown by the extractor surface unchanged
+ * (typically wrap them as \`TRPCError({ code: "UNAUTHORIZED" })\`
+ * in the extractor body).
+ */
+// biome-ignore lint/suspicious/noExplicitAny: tRPC's internal middleware shape lives behind \`unstable-core-do-not-import\`; structural typing carries the host's \`t\` validation.
+export function authenticated(extractor: ActorExtractor): any {
+  return async function actor_middleware({
+    ctx,
+    next,
+  }: {
+    ctx: object;
+    next: (opts: { ctx: object }) => Promise<unknown>;
+  }) {
+    const actor = await extractor(ctx);
+    return next({ ctx: { ...ctx, actor } });
+  };
+}
+
+/**
+ * Map a thrown framework error onto a \`TRPCError\`. Known errors get
+ * their conventional tRPC code (\`ConcurrencyError\` → \`CONFLICT\`,
+ * \`ValidationError\` → \`UNPROCESSABLE_CONTENT\`, etc.); unknown throws
+ * surface as \`INTERNAL_SERVER_ERROR\`. Every transport in the
+ * act-http epic passes through the same {@link toApiError} table,
+ * so a client talking to both this subpath and the REST sibling
+ * sees one envelope per framework error.
+ *
+ * @internal
+ */
+function to_trpc_error(err: unknown): TRPCError {
+  const { status, body } = toApiError(err);
+  const code = status_to_trpc_code(status);
+  return new TRPCError({
+    code,
+    message: body.detail ?? body.error,
+    cause: err instanceof Error ? err : undefined,
+  });
+}
+
+/**
+ * Minimal status → tRPC code map. Only the statuses
+ * {@link ERROR_MAP} produces (plus 500) appear here; anything else
+ * collapses to \`INTERNAL_SERVER_ERROR\`.
+ *
+ * @internal
+ */
+function status_to_trpc_code(status: number): TRPCError["code"] {
+  switch (status) {
+    case 400:
+      return "BAD_REQUEST";
+    case 409:
+      return "CONFLICT";
+    case 410:
+      return "PRECONDITION_FAILED";
+    case 412:
+      return "CONFLICT";
+    case 422:
+      return "UNPROCESSABLE_CONTENT";
+    default:
+      return "INTERNAL_SERVER_ERROR";
+  }
+}
+
+/**
+ * Build a typed tRPC router from a built \`Act\` instance.
+ *
+ * Walks \`app.registry.actions\` once and emits one flat mutation per
+ * action under \`router.<actionName>\`. The framework already enforces
+ * no duplicate action names across states, so a flat tier reads
+ * cleanly at the client and matches the hand-written router shape
+ * adopters already have. Each mutation:
+ *
+ * 1. Runs the internal {@link authenticated} — \`options.actor\`
+ *    resolves the {@link Actor} once and injects it onto
+ *    \`ctx.actor\`.
+ * 2. Resolves the target stream via \`options.stream(name, input, ctx)\`.
+ * 3. (Optionally) claims the \`Idempotency-Key\` via
+ *    {@link withIdempotency} — throws \`CONFLICT\` on duplicate.
+ * 4. Calls \`app.do(name, { stream, actor: ctx.actor }, input)\`.
+ * 5. Maps any thrown framework error onto a \`TRPCError\` via
+ *    {@link toApiError}.
+ *
+ * The returned router's procedure inputs come straight from each
+ * action's Zod schema; outputs are the framework's
+ * \`Snapshot<TState, TEvents>[]\` shape. Strong typing flows
+ * end-to-end via tRPC's normal inference path — the client sees
+ * \`appRouter.Calculator.PressKey.mutate({ key: "5" })\` as a typed
+ * call without any codegen.
+ *
+ * @template Ctx The tRPC context shape the host's runtime feeds in.
+ *   Flows through \`actor\`, \`stream\`, and \`idempotency.keyFrom\` so
+ *   the operator's existing context types just work. The internal
+ *   middleware augments \`Ctx\` with \`{ actor: Actor }\` on the
+ *   downstream procedure context.
+ *
+ * @param app A built \`Act\` orchestrator.
+ * @param options Auth, stream, and (optional) idempotency seams.
+ * @returns A tRPC router covering every registered action, grouped
+ *   by owning state.
+ */
+export function trpc<Ctx extends object = object>(
+  // biome-ignore lint/suspicious/noExplicitAny: erased — the generator walks the registry at runtime, not the typed surface
+  app: Act<any, Schemas, Schemas, Record<string, Schema>>,
+  options: TrpcOptions<Ctx>
+) {
+  const t = initTRPC.context<Ctx>().create();
+  const authed = t.procedure.use(authenticated(options.actor));
+
+  const handlers: Record<string, ReturnType<typeof authed.mutation>> = {};
+  for (const [action_name, state] of Object.entries(app.registry.actions)) {
+    handlers[action_name] = authed
+      .input(state.actions[action_name] as never)
+      .mutation(async ({ input, ctx }) => {
+        // tRPC's internal \`Simplify<Ctx>\` transform produces a type
+        // that's structurally identical to \`Ctx & { actor }\` but not
+        // assignable to the generic parameter. The cast restores the
+        // link; the runtime ctx IS the augmented context.
+        const host_ctx = ctx as unknown as Ctx & { actor: Actor };
+        try {
+          const stream = await options.stream(action_name, input, host_ctx);
+          const target = { stream, actor: host_ctx.actor };
+
+          if (options.idempotency) {
+            const key = options.idempotency.keyFrom(host_ctx);
+            if (!key) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Idempotency-Key required",
+              });
+            }
+            const outcome = await withIdempotency(
+              options.idempotency.store,
+              key,
+              () =>
+                app.do(action_name as never, target as never, input as never)
+            );
+            if (outcome.deduped) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "Idempotency-Key already used; original result not cached",
+              });
+            }
+            return outcome.result;
+          }
+
+          return await app.do(
+            action_name as never,
+            target as never,
+            input as never
+          );
+        } catch (err) {
+          if (err instanceof TRPCError) throw err;
+          throw to_trpc_error(err);
+        }
+      });
+  }
+
+  return t.router(handlers as never);
+}
+
+// === index.ts ===
+/**
+ * @packageDocumentation
+ * @module act-http/api
+ *
+ * Shared utilities for the act-http auto-generated API surfaces.
+ * Three concerns that every transport (tRPC, Hono, OpenAPI) has to
+ * address — actor extraction, error envelope mapping,
+ * \`Idempotency-Key\` wiring — defined once here and composed by each
+ * transport sibling subpath.
+ *
+ * - {@link ActorExtractor} — the host-supplied closure that resolves
+ *   an \`Actor\` from an incoming request. Auth (JWT, session, API
+ *   key) stays in the host; the package only asks for this one
+ *   function.
+ * - {@link ApiError}, {@link ERROR_MAP}, {@link toApiError} — the
+ *   uniform error envelope and the status/code mapping every
+ *   transport uses. Cross-transport consistency by construction.
+ * - {@link withIdempotency} — the helper that wraps action handlers
+ *   in an \`Idempotency-Key\` claim. Reuses the
+ *   \`@rotorsoft/act-ops/idempotency\` contract that
+ *   \`@rotorsoft/act-http/receiver\` already speaks, so receivers and
+ *   generated APIs share one \`IdempotencyStore\` implementation.
+ *
+ * Sibling subpaths in the same package consume the utilities here:
+ *
+ * - \`@rotorsoft/act-http/trpc\` — tRPC adapter (#843).
+ * - \`@rotorsoft/act-http/hono\` — Hono adapter (#844).
+ * - \`@rotorsoft/act-http/openapi\` — OpenAPI emitter (#845).
+ *
+ * Existing siblings unrelated to the generated-API work:
+ *
+ * - \`@rotorsoft/act-http/webhook\` — outbound POST delivery.
+ * - \`@rotorsoft/act-http/sse\` — incremental state broadcast.
+ * - \`@rotorsoft/act-http/receiver\` — inbound webhook ingestion.
+ */
+
+export type { ActorExtractor } from "./actor.js";
+export {
+  type ApiError,
+  ERROR_MAP,
+  type ErrorMapEntry,
+  toApiError,
+} from "./errors.js";
+export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
+"
+`;
+
 exports[`@rotorsoft/act-http — public API stability > stable public surface for ./webhook 1`] = `
 "// === classify.ts ===
 import { NonRetryableHttpError, RetryableHttpError } from "./types.js";

--- a/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
+++ b/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
@@ -31345,6 +31345,14 @@ import {
  *   validated action input, and the original tRPC context; returns
  *   the target stream. Singleton aggregates return a constant;
  *   per-tenant aggregates pull from input or context.
+ * - \`expectedVersion\` (optional) — optimistic-concurrency resolver.
+ *   When set, the procedure threads the resolved value through
+ *   \`target.expectedVersion\` so \`app.do\` refuses to commit if the
+ *   stream has moved. Hosts typically read it from an \`If-Match\`
+ *   header on the underlying HTTP request, or pull it from the
+ *   client's last-known snapshot. Returning \`undefined\` skips the
+ *   check for that call — handy when only some actions are
+ *   concurrency-sensitive.
  * - \`idempotency\` (optional) — when set, the procedure honors
  *   \`Idempotency-Key\` via the shared
  *   {@link withIdempotency} helper. The host supplies the
@@ -31366,6 +31374,11 @@ export type TrpcOptions<Ctx> = {
     input: unknown,
     ctx: Ctx
   ) => string | Promise<string>;
+  readonly expectedVersion?: (
+    action_name: string,
+    input: unknown,
+    ctx: Ctx
+  ) => number | undefined | Promise<number | undefined>;
   readonly idempotency?: {
     readonly store: IdempotencyStore;
     readonly keyFrom: (ctx: Ctx) => string | undefined;
@@ -31519,7 +31532,17 @@ export function trpc<Ctx extends object = object>(
         const host_ctx = ctx as unknown as Ctx & { actor: Actor };
         try {
           const stream = await options.stream(action_name, input, host_ctx);
-          const target = { stream, actor: host_ctx.actor };
+          const expected_version = options.expectedVersion
+            ? await options.expectedVersion(action_name, input, host_ctx)
+            : undefined;
+          const target =
+            expected_version === undefined
+              ? { stream, actor: host_ctx.actor }
+              : {
+                  stream,
+                  actor: host_ctx.actor,
+                  expectedVersion: expected_version,
+                };
 
           if (options.idempotency) {
             const key = options.idempotency.keyFrom(host_ctx);

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -28,6 +28,7 @@
         "./libs/act-http/src/receiver/trpc/index.ts"
       ],
       "@rotorsoft/act-http/sse": ["./libs/act-http/src/sse/index.ts"],
+      "@rotorsoft/act-http/trpc": ["./libs/act-http/src/trpc/index.ts"],
       "@rotorsoft/act-http/webhook": ["./libs/act-http/src/webhook/index.ts"],
       "@rotorsoft/act-ops/idempotency": [
         "./libs/act-ops/src/idempotency/index.ts"


### PR DESCRIPTION
## Summary

New `@rotorsoft/act-http/trpc` subpath. The `trpc(app, options)` generator walks `app.registry.actions` once and emits a flat top-level mutation per action, matching the shape hand-written tRPC routers in the Act ecosystem already use. Composes the shared utilities at `@rotorsoft/act-http/api` (`ActorExtractor`, `toApiError`, `withIdempotency`) so every transport in the auto-generated API epic shares one error envelope and one auth seam.

```ts
import { trpc } from "@rotorsoft/act-http/trpc";

const router = trpc(app, {
  actor: (ctx) => ({ id: ctx.user.id, name: ctx.user.name }),
  stream: (action, input, ctx) => `tenant-${ctx.tenant}`,
});
// Client: await client.PressKey.mutate({ key: "5" })
```

## Why a flat router

Two reasons grouping-by-state was dropped:

1. **Action names are already unique across the registry** — the framework's `withState` chain enforces no duplicates, so an extra namespace tier would be overhead in the common case.
2. **#847 server migration becomes a 1:1 replacement.** The existing calculator router in `packages/calculator` is flat; matching its shape means the migration in #847 is `s/t.router({...})/trpc(app, {...})/` with zero client-side changes.

The state-grouping variant is achievable later (would need framework-level changes to preserve state-name literals through the registry) and is left for a follow-up if there's adopter demand.

## Why the auth lives on the context

The generator internally wires `t.procedure.use(authenticated(options.actor))`, so every generated mutation runs the extractor once and the resolved `Actor` is available as `ctx.actor` for any downstream logic (logging, tracing, custom middleware). The `authenticated(extractor)` factory is also exported standalone so hosts composing their own procedure chain can use it without going through the generator:

```ts
import { authenticated } from "@rotorsoft/act-http/trpc";

const t = initTRPC.context<MyCtx>().create();
const authed = t.procedure.use(authenticated(myExtractor));
// ctx.actor: Actor is available downstream of `authed`
```

## Error envelope (cross-transport consistency)

All five known framework errors map through the shared `toApiError(...)`:

| Framework error | tRPC code |
|---|---|
| `ConcurrencyError` | `CONFLICT` |
| `InvariantError` | `CONFLICT` |
| `ValidationError` | `UNPROCESSABLE_CONTENT` |
| `StreamClosedError` | `PRECONDITION_FAILED` |
| `NonRetryableError` | `BAD_REQUEST` |
| anything else | `INTERNAL_SERVER_ERROR` |

`TRPCError` thrown by the auth or idempotency middleware passes through unchanged so the original code/message survives.

## Idempotency

Optional. When configured, the mutation reads `Idempotency-Key` via `keyFrom(ctx)` and throws `CONFLICT` on duplicate claims — the contract intentionally doesn't cache the original handler's result, matching the receiver-side "ack the duplicate" semantics.

## Test plan

- [x] `pnpm test`: 17 new specs covering flat emission, internal + standalone auth middleware, stream extraction, all five framework error mappings, idempotency dedup, and non-Error throws. 2162 total tests pass.
- [x] `pnpm test --coverage`: 100% statements / branches / functions / lines on `libs/act-http/src/trpc/index.ts` and `libs/act-http/src/api/errors.ts`.
- [x] `pnpm typecheck`: clean.
- [x] `pnpm lint`: 0 errors (41 warnings, 3 infos all pre-existing).
- [x] Stability snapshots regenerated for the new subpath (additive only).

## Stability charter impact

**No charter-covered files touched.** `libs/act-http/*` is outside the charter; the act core types this PR consumes (`Act`, `Actor`, `Schema`, `Schemas`) are unchanged.

## Follow-ups

- **#844** — `@rotorsoft/act-http/hono` subpath (mirror this shape on Hono).
- **#845** — `@rotorsoft/act-http/openapi` subpath (OpenAPI 3.1 document emitter).
- **#847** — migrate `packages/server` + `packages/calculator` onto the generator. Was deferred from this PR to keep the scope focused on the generator itself.
- **Typed-grouped routing** (no ticket yet) — preserving state-name literals through the registry would let the grouped shape be type-safe too. Probably a framework-level enhancement; open a ticket if adopter demand emerges.

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)