### PR TITLE
feat(act-http): #844 — @rotorsoft/act-http/hono subpath generates a typed REST surface

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -94,6 +94,11 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "link",
+          label: "@rotorsoft/act-http (hono)",
+          href: "/docs/api/act-http/src/hono",
+        },
+        {
+          type: "link",
           label: "@rotorsoft/act-ops/idempotency",
           href: "/docs/api/act-ops/src/idempotency",
         },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -14,6 +14,7 @@
       "@rotorsoft/act-http/webhook": ["../libs/act-http/src/webhook/index.ts"],
       "@rotorsoft/act-http/sse": ["../libs/act-http/src/sse/index.ts"],
       "@rotorsoft/act-http/trpc": ["../libs/act-http/src/trpc/index.ts"],
+      "@rotorsoft/act-http/hono": ["../libs/act-http/src/hono/index.ts"],
       "@rotorsoft/act-http/receiver/trpc": [
         "../libs/act-http/src/receiver/trpc/index.ts"
       ],

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -8,6 +8,7 @@
     "../libs/act-http/src/webhook/index.ts",
     "../libs/act-http/src/sse/index.ts",
     "../libs/act-http/src/trpc/index.ts",
+    "../libs/act-http/src/hono/index.ts",
     "../libs/act-http/src/receiver/index.ts",
     "../libs/act-http/src/receiver/trpc/index.ts",
     "../libs/act-http/src/receiver/express/index.ts",

--- a/libs/act-http/README.md
+++ b/libs/act-http/README.md
@@ -171,6 +171,45 @@ const authed = t.procedure.use(authenticated(myExtractor));
 // procedures alongside the generated ones.
 ```
 
+### `hono` — auto-generated REST surface
+
+```ts
+import { hono } from "@rotorsoft/act-http/hono";
+import { serve } from "@hono/node-server";
+
+const api = hono(app, {
+  // ActorExtractor from `@rotorsoft/act-http/api` — host's auth seam.
+  actor: (c) => resolveActorFromJwt(c),
+  // Resolve the target stream per call; singleton aggregates return a constant.
+  stream: (action, input, c) => `tenant-${c.req.header("x-tenant")}`,
+  // Optional optimistic concurrency — return `undefined` to skip the check.
+  expectedVersion: (action, input, c) => {
+    const v = c.req.header("if-match");
+    return v ? Number.parseInt(v, 10) : undefined;
+  },
+});
+
+serve({ fetch: api.fetch, port: 4000 });
+// POST /api/actions/OpenTicket  body: { title }
+// → 200 [Snapshot] | 4xx ApiError envelope
+```
+
+The generator walks `app.registry.actions` once and registers one `POST /actions/<actionName>` per action under the configured `basePath` (default `/api`). Bodies are validated with `@hono/zod-validator` against the action's registered Zod schema; failures short-circuit with `400`. The internal `authenticated(extractor)` middleware runs `options.actor` once per request and stashes the resolved `Actor` under `c.get("actor")`, available to any downstream middleware (logging, tracing, hand-written routes mounted on the same Hono instance). `Idempotency-Key` is read from the request header by default; `keyFrom` overrides for hosts that prefer a custom convention.
+
+Errors map through the shared `toApiError(...)` table at `@rotorsoft/act-http/api`: `ConcurrencyError → 412 / CONCURRENCY`, `InvariantError → 409 / INVARIANT`, `ValidationError → 422 / VALIDATION`, `StreamClosedError → 410 / STREAM_CLOSED`, `NonRetryableError → 400 / NON_RETRYABLE`. The envelope (`{ error, detail?, code? }`) is the same shape every other act-http transport ships so a client speaking REST plus tRPC never sees two formats for the same framework error.
+
+Edge-runtime ready — Hono runs unchanged on Node, Bun, Cloudflare Workers, Vercel Edge, and AWS Lambda. Operators wiring `idempotency` on edge runtimes should verify the `IdempotencyStore` is edge-compatible (in-memory works per worker; cross-worker requires a distributed store).
+
+```ts
+// Compose the auth middleware into your own Hono chain instead:
+import { Hono } from "hono";
+import { authenticated, type ActMiddlewareVariables } from "@rotorsoft/act-http/hono";
+
+const api = new Hono<{ Variables: ActMiddlewareVariables }>();
+api.use("*", authenticated((c) => resolveActorFromJwt(c)));
+// Hand-written routes alongside the generated ones now see c.get("actor") typed.
+```
+
 ### `sse` — live state broadcast
 
 ```ts
@@ -243,6 +282,15 @@ Auto-generated tRPC router for the act-http-api epic (#835).
 - **`trpc(app, options) → Router`** — generator function. Walks `app.registry.actions` once and emits a flat top-level mutation per action. Each procedure runs the internal `authenticated(options.actor)` middleware (so `ctx.actor: Actor` is set on the downstream context), resolves the target stream via `options.stream(action, input, ctx)`, and calls `app.do(action, { stream, actor }, input)`. Known framework errors map through `toApiError` to the conventional tRPC codes; unknown throws surface as `INTERNAL_SERVER_ERROR`.
 - **`authenticated(extractor) → middleware`** — standalone export of the auth middleware the generator uses internally. Hosts composing their own procedure chain (logging + tracing + custom auth flavors) use `t.procedure.use(authenticated(extractor))` to inject `ctx.actor` without going through the generator. The middleware is structurally-typed so any host `t` instance accepts it.
 - **`TrpcOptions<Ctx>`** — `{ actor, stream, expectedVersion?, idempotency? }`. `actor` is the `ActorExtractor` from `@rotorsoft/act-http/api`. `stream` returns the target stream per call. `expectedVersion` is optional — `(action, input, ctx) => number | undefined` — when set, the procedure threads the resolved value through `Target.expectedVersion` so `app.do` enforces optimistic concurrency; hosts typically read it from an `If-Match` header or the client's last-known snapshot, and returning `undefined` skips the check for that call. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom: (ctx) => string | undefined }` — when set, the procedure honors `Idempotency-Key` via `withIdempotency`. Duplicate claims throw `CONFLICT` (the contract intentionally doesn't cache the original handler's result).
+
+### `/hono` subpath
+
+Auto-generated REST surface for the act-http-api epic (#835).
+
+- **`hono(app, options) → Hono`** — generator function. Walks `app.registry.actions` once and registers a `POST /actions/<actionName>` per action under `basePath` (default `/api`). Body is validated with `@hono/zod-validator` against the action's Zod schema; failures short-circuit with `400`. The internal `authenticated(options.actor)` middleware stashes the resolved `Actor` under `c.get("actor")`. Routes return `200 Snapshot[]` on success, `4xx ApiError` envelope (with the conventional HTTP status) on framework errors, `500 / INTERNAL` on unknown throws.
+- **`authenticated(extractor) → MiddlewareHandler`** — standalone export of the auth middleware the generator uses internally. Hosts composing their own Hono chain wire `api.use("*", authenticated(extractor))` and downstream routes read `c.get("actor"): Actor`. Errors thrown by the extractor surface as `401 / UNAUTHORIZED`.
+- **`HonoOptions`** — `{ actor, stream, expectedVersion?, idempotency?, basePath? }`. `actor` is the `ActorExtractor`. `stream` returns the target stream per call. `expectedVersion` threads `Target.expectedVersion` for optimistic concurrency — returning `undefined` skips the check. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom?: (c) => string | undefined }` — when set, the route honors `Idempotency-Key` via `withIdempotency`; default `keyFrom` reads the `Idempotency-Key` header. Duplicate claims return `409 / CONFLICT`. `basePath` defaults to `/api`.
+- **`ActMiddlewareVariables`** — `{ actor: Actor }`. Use as the `Variables` generic on a host Hono instance to get `c.get("actor")` typed downstream of `authenticated`.
 
 ### `/sse` subpath
 

--- a/libs/act-http/package.json
+++ b/libs/act-http/package.json
@@ -2,7 +2,7 @@
   "name": "@rotorsoft/act-http",
   "type": "module",
   "version": "1.3.0",
-  "description": "HTTP integrations for act apps — webhooks and SSE",
+  "description": "HTTP integrations for act apps \u2014 webhooks and SSE",
   "keywords": [
     "typescript",
     "http",
@@ -30,6 +30,11 @@
       "types": "./dist/@types/api/index.d.ts",
       "import": "./dist/api/index.js",
       "require": "./dist/api/index.cjs"
+    },
+    "./hono": {
+      "types": "./dist/@types/hono/index.d.ts",
+      "import": "./dist/hono/index.js",
+      "require": "./dist/hono/index.cjs"
     },
     "./receiver": {
       "types": "./dist/@types/receiver/index.d.ts",
@@ -85,10 +90,10 @@
     "build": "pnpm clean && tsup && pnpm types"
   },
   "peerDependencies": {
+    "@hono/node-server": "^2.0.4",
     "@rotorsoft/act": "workspace:^",
     "@rotorsoft/act-ops": "workspace:^",
     "@trpc/server": ">=11.17.0",
-    "@hono/node-server": "^2.0.4",
     "express": "^5.2.1",
     "fastify": "^5.8.5",
     "hono": "^4.12.24"
@@ -117,8 +122,9 @@
     "@rotorsoft/act-patch": "workspace:^"
   },
   "devDependencies": {
-    "@rotorsoft/act-ops": "workspace:^",
     "@hono/node-server": "^2.0.4",
+    "@hono/zod-validator": "^0.8.0",
+    "@rotorsoft/act-ops": "workspace:^",
     "@trpc/server": "^11.17.0",
     "@types/express": "^5.0.6",
     "express": "^5.2.1",

--- a/libs/act-http/src/hono/index.ts
+++ b/libs/act-http/src/hono/index.ts
@@ -1,0 +1,265 @@
+/**
+ * @packageDocumentation
+ * @module act-http/hono
+ *
+ * Hono subpath for the auto-generated API epic (#835). Walks the
+ * registry of a built `Act` once at function call and emits a Hono
+ * app with one `POST /actions/<name>` route per registered action,
+ * Zod-validated bodies, and the shared error envelope.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { hono } from "@rotorsoft/act-http/hono";
+ *
+ * const api = hono(app, {
+ *   actor: (c) => ({ id: c.req.header("x-user-id")!, name: "..." }),
+ *   stream: (action, input, c) => `tenant-${c.req.header("x-tenant")}`,
+ * });
+ *
+ * // Mounts at /api by default — pass `basePath` to override.
+ * // POST /api/actions/OpenTicket  body: { title }  → 200 Snapshot[] | 4xx ApiError
+ * ```
+ *
+ * The route shape matches the flat tRPC sibling at
+ * `@rotorsoft/act-http/trpc`: one endpoint per action, no
+ * state-name tier. Action names are unique across the registry —
+ * the framework enforces no duplicates — so an extra namespace
+ * level would be overhead. Queries live in a follow-up; this
+ * slice is mutations only.
+ *
+ * **Actor lives on the context.** The generator wires an internal
+ * middleware that runs the host's
+ * {@link HonoOptions.actor | actor extractor} once per call and
+ * stashes the resolved {@link Actor} under `c.get("actor")`. Every
+ * generated route reads from there — auth resolves at one seam,
+ * downstream middleware (logging, tracing) sees the same actor.
+ * The middleware factory is also exported as {@link authenticated}
+ * for hosts that want to compose it into their own Hono chain
+ * alongside hand-written routes.
+ *
+ * Composes the shared utilities at `@rotorsoft/act-http/api`:
+ * {@link ActorExtractor} for the auth seam, {@link toApiError} for
+ * the uniform error → status / code mapping, {@link withIdempotency}
+ * for `Idempotency-Key` dedup. Three transports (tRPC, this one,
+ * OpenAPI) ride the same utilities so a client speaking two of
+ * them never sees two shapes for the same framework error.
+ */
+import { zValidator } from "@hono/zod-validator";
+import type { Act, Actor, Schema, Schemas } from "@rotorsoft/act";
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import type { Context, MiddlewareHandler } from "hono";
+import { Hono } from "hono";
+import {
+  type ActorExtractor,
+  type ApiError,
+  toApiError,
+  withIdempotency,
+} from "../api/index.js";
+
+/**
+ * Hono context variables this subpath contributes. The generic on
+ * the returned middleware threads it through so routes downstream
+ * of {@link authenticated} see `c.get("actor")` typed without a
+ * manual cast.
+ */
+export type ActMiddlewareVariables = {
+  actor: Actor;
+};
+
+/**
+ * Per-call options for {@link hono}. The host supplies the four
+ * seams the package can't make decisions on:
+ *
+ * - `actor` — auth resolver. Receives the Hono context, returns the
+ *   `Actor` that flows onto `c.get("actor")` for every generated
+ *   route (via an internal {@link authenticated}).
+ * - `stream` — stream-id resolver. Receives the action name, the
+ *   validated body, and the Hono context; returns the target
+ *   stream. Singleton aggregates return a constant; per-tenant
+ *   aggregates pull from headers, path, or body.
+ * - `expectedVersion` (optional) — optimistic-concurrency resolver.
+ *   Hosts typically read it from an `If-Match` header on the
+ *   request, or from the client's last-known snapshot. Returning
+ *   `undefined` skips the check for that call — handy when only
+ *   some actions are concurrency-sensitive.
+ * - `idempotency` (optional) — when set, the route honors
+ *   `Idempotency-Key` via {@link withIdempotency}. The host
+ *   supplies the `IdempotencyStore`; `keyFrom` defaults to reading
+ *   the `Idempotency-Key` header. On a duplicate claim, the route
+ *   responds `409 Conflict` — the contract intentionally doesn't
+ *   cache the original handler's result, matching the
+ *   receiver-side "ack the duplicate" semantics.
+ * - `basePath` (optional, default `"/api"`) — Hono basePath the
+ *   routes mount under.
+ */
+export type HonoOptions = {
+  readonly actor: ActorExtractor;
+  readonly stream: (
+    action_name: string,
+    input: unknown,
+    c: Context
+  ) => string | Promise<string>;
+  readonly expectedVersion?: (
+    action_name: string,
+    input: unknown,
+    c: Context
+  ) => number | undefined | Promise<number | undefined>;
+  readonly idempotency?: {
+    readonly store: IdempotencyStore;
+    readonly keyFrom?: (c: Context) => string | undefined;
+  };
+  readonly basePath?: string;
+};
+
+/**
+ * Build a Hono middleware that runs an {@link ActorExtractor} once
+ * per call and stashes the resolved {@link Actor} under
+ * `c.set("actor", ...)` so downstream routes can read it via
+ * `c.get("actor")`. The generator at {@link hono} uses this
+ * internally; it's also exported so hosts that want to compose
+ * their own route chain (logging, tracing, custom auth flavors)
+ * can wire it directly:
+ *
+ * ```ts
+ * import { Hono } from "hono";
+ * import { authenticated, type ActMiddlewareVariables } from "@rotorsoft/act-http/hono";
+ *
+ * const api = new Hono<{ Variables: ActMiddlewareVariables }>();
+ * api.use("*", authenticated((c) => resolveUserFromJwt(c)));
+ * api.get("/me", (c) => c.json(c.get("actor"))); // typed
+ * ```
+ *
+ * Errors thrown by the extractor surface as `401 Unauthorized` with
+ * the shared {@link ApiError} envelope.
+ */
+export function authenticated(
+  extractor: ActorExtractor
+): MiddlewareHandler<{ Variables: ActMiddlewareVariables }> {
+  return async (c, next) => {
+    try {
+      const actor = await extractor(c);
+      c.set("actor", actor);
+      await next();
+    } catch (err) {
+      const body: ApiError = {
+        error: "Unauthorized",
+        detail: err instanceof Error ? err.message : undefined,
+        code: "UNAUTHORIZED",
+      };
+      return c.json(body, 401);
+    }
+  };
+}
+
+const default_key_from = (c: Context): string | undefined =>
+  c.req.header("idempotency-key");
+
+/**
+ * Build a typed Hono REST surface from a built `Act` instance.
+ *
+ * Walks `app.registry.actions` once and emits one
+ * `POST /actions/<actionName>` per action under the configured
+ * `basePath` (default `/api`). Each route:
+ *
+ * 1. Runs the internal {@link authenticated} middleware —
+ *    `options.actor` resolves the {@link Actor} once and stashes
+ *    it under `c.get("actor")`.
+ * 2. Validates the JSON body against the action's Zod schema via
+ *    `@hono/zod-validator`. Failures short-circuit with `422`.
+ * 3. Resolves the target stream via
+ *    `options.stream(name, input, c)`.
+ * 4. (Optionally) resolves `expectedVersion` for optimistic
+ *    concurrency.
+ * 5. (Optionally) claims the `Idempotency-Key` via
+ *    {@link withIdempotency} — responds `409` on duplicate.
+ * 6. Calls
+ *    `app.do(name, { stream, actor, expectedVersion? }, input)`.
+ * 7. Maps any thrown framework error onto the shared
+ *    {@link ApiError} envelope via {@link toApiError}, returning
+ *    the conventional HTTP status (`409` / `412` for concurrency,
+ *    `422` for validation, `400` for non-retryable, etc.).
+ *
+ * @param app A built `Act` orchestrator.
+ * @param options Auth, stream, expected-version, idempotency, and
+ *   base-path seams.
+ * @returns A Hono app covering every registered action under
+ *   `<basePath>/actions/<name>`.
+ */
+export function hono(
+  app: Act<Schemas, Schemas, Schemas, Record<string, Schema>>,
+  options: HonoOptions
+): Hono<{ Variables: ActMiddlewareVariables }> {
+  const base_path = options.basePath ?? "/api";
+  const api = new Hono<{ Variables: ActMiddlewareVariables }>().basePath(
+    base_path
+  );
+  api.use("*", authenticated(options.actor));
+
+  const key_from = options.idempotency?.keyFrom ?? default_key_from;
+
+  for (const [action_name, state] of Object.entries(app.registry.actions)) {
+    const schema = state.actions[action_name] as Schema;
+    api.post(
+      `/actions/${action_name}`,
+      zValidator("json", schema as never),
+      async (c) => {
+        try {
+          const input = c.req.valid("json" as never) as unknown;
+          const actor = c.get("actor");
+          const stream = await options.stream(action_name, input, c);
+          const expected_version = options.expectedVersion
+            ? await options.expectedVersion(action_name, input, c)
+            : undefined;
+          const target =
+            expected_version === undefined
+              ? { stream, actor }
+              : { stream, actor, expectedVersion: expected_version };
+
+          if (options.idempotency) {
+            const key = key_from(c);
+            if (!key) {
+              const body: ApiError = {
+                error: "BadRequest",
+                detail: "Idempotency-Key required",
+                code: "BAD_REQUEST",
+              };
+              return c.json(body, 400);
+            }
+            const outcome = await withIdempotency(
+              options.idempotency.store,
+              key,
+              () =>
+                app.do(action_name as never, target as never, input as never)
+            );
+            if (outcome.deduped) {
+              const body: ApiError = {
+                error: "Conflict",
+                detail:
+                  "Idempotency-Key already used; original result not cached",
+                code: "CONFLICT",
+              };
+              return c.json(body, 409);
+            }
+            return c.json(outcome.result);
+          }
+
+          const snapshots = await app.do(
+            action_name as never,
+            target as never,
+            input as never
+          );
+          return c.json(snapshots);
+        } catch (err) {
+          const { status, body } = toApiError(err);
+          // Hono types narrow `status` to its known status-number union;
+          // `toApiError` returns a numeric status from a closed set that
+          // matches but TypeScript can't prove it through the union.
+          return c.json(body, status as 400 | 409 | 410 | 412 | 422 | 500);
+        }
+      }
+    );
+  }
+
+  return api;
+}

--- a/libs/act-http/test/hono/index.spec.ts
+++ b/libs/act-http/test/hono/index.spec.ts
@@ -1,0 +1,418 @@
+/**
+ * Adapter-generated Hono REST surface for `@rotorsoft/act-http/hono`
+ * (#844). Mirrors the trpc sibling's coverage shape: cross-action
+ * emission, the internal actor middleware, stream extraction,
+ * expected-version threading, idempotency dedup, error mapping for
+ * all known framework errors plus the unknown / non-Error throw
+ * paths. Round-trips run through `app.request()` so no live server
+ * is needed.
+ */
+import {
+  act,
+  ConcurrencyError,
+  InvariantError,
+  NonRetryableError,
+  StreamClosedError,
+  state,
+  ValidationError,
+  ZodEmpty,
+} from "@rotorsoft/act";
+import { fixture } from "@rotorsoft/act/test";
+import { InMemoryIdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import { Hono } from "hono";
+import { describe, expect, vi } from "vitest";
+import { z } from "zod";
+import { authenticated, type HonoOptions, hono } from "../../src/hono/index.js";
+
+const Calculator = state({
+  Calculator: z.object({ display: z.string() }),
+})
+  .init(() => ({ display: "" }))
+  .emits({
+    KeyPressed: z.object({ key: z.string() }),
+    Cleared: ZodEmpty,
+  })
+  .patch({
+    KeyPressed: ({ data }, s) => ({ display: s.display + data.key }),
+    Cleared: () => ({ display: "" }),
+  })
+  .on({ PressKey: z.object({ key: z.string().min(1) }) })
+  .emit((a) => ["KeyPressed", { key: a.key }])
+  .on({ Clear: ZodEmpty })
+  .emit(() => ["Cleared", {}])
+  .build();
+
+const Ticket = state({
+  Ticket: z.object({ title: z.string(), open: z.boolean() }),
+})
+  .init(() => ({ title: "", open: false }))
+  .emits({ TicketOpened: z.object({ title: z.string() }) })
+  .patch({
+    TicketOpened: ({ data }) => ({ title: data.title, open: true }),
+  })
+  .on({ OpenTicket: z.object({ title: z.string() }) })
+  .emit((a) => ["TicketOpened", { title: a.title }])
+  .build();
+
+const builder = act().withState(Calculator).withState(Ticket);
+const test = fixture(builder);
+
+const default_options = (): HonoOptions => ({
+  actor: (request) => {
+    const c = request as {
+      req: { header: (name: string) => string | undefined };
+    };
+    return {
+      id: c.req.header("x-user-id") ?? "u-1",
+      name: c.req.header("x-user-name") ?? "alice",
+    };
+  },
+  stream: (_action, _input, c) =>
+    `tenant-${c.req.header("x-tenant") ?? "acme"}`,
+});
+
+const make_headers = (
+  overrides: Record<string, string> = {}
+): Record<string, string> => ({
+  "content-type": "application/json",
+  "x-user-id": "u-1",
+  "x-user-name": "alice",
+  "x-tenant": "acme",
+  ...overrides,
+});
+
+describe("hono(app, options) — generated REST surface", () => {
+  test("emits one POST /actions/<name> per registered action", ({ app }) => {
+    // biome-ignore lint/suspicious/noExplicitAny: Hono's `routes` array carries the registered path+method pairs.
+    const api: any = hono(app as never, default_options());
+    // Hono registers each route entry once per `app.post(...)` call;
+    // dedupe so the assertion is order/duplicate-insensitive.
+    const paths = Array.from(
+      new Set(
+        api.routes
+          .filter((r: { method: string }) => r.method === "POST")
+          .map((r: { path: string }) => r.path)
+      )
+    ).sort();
+    expect(paths).toEqual([
+      "/api/actions/Clear",
+      "/api/actions/OpenTicket",
+      "/api/actions/PressKey",
+    ]);
+  });
+
+  test("threads actor (via internal middleware) and stream into app.do", async ({
+    app,
+  }) => {
+    const do_spy = vi.spyOn(app, "do");
+    const api = hono(app as never, default_options());
+
+    const res = await api.request("/api/actions/PressKey", {
+      method: "POST",
+      headers: make_headers(),
+      body: JSON.stringify({ key: "5" }),
+    });
+    expect(res.status).toBe(200);
+    const snapshots = await res.json();
+    expect(snapshots[0].event.name).toBe("KeyPressed");
+    expect(do_spy).toHaveBeenCalledWith(
+      "PressKey",
+      {
+        stream: "tenant-acme",
+        actor: { id: "u-1", name: "alice" },
+      },
+      { key: "5" }
+    );
+  });
+
+  test("mounts under a custom basePath", async ({ app }) => {
+    const api = hono(app as never, { ...default_options(), basePath: "/v1" });
+    const res = await api.request("/v1/actions/PressKey", {
+      method: "POST",
+      headers: make_headers(),
+      body: JSON.stringify({ key: "5" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("body that fails Zod validation returns 400 with detail (via zValidator)", async ({
+    app,
+  }) => {
+    const api = hono(app as never, default_options());
+    // Empty key violates `.min(1)`. zValidator short-circuits before
+    // the handler runs; Hono's default for validation failures is 400.
+    const res = await api.request("/api/actions/PressKey", {
+      method: "POST",
+      headers: make_headers(),
+      body: JSON.stringify({ key: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  describe("expectedVersion (optimistic concurrency)", () => {
+    test("threads the resolved value through Target.expectedVersion", async ({
+      app,
+    }) => {
+      const do_spy = vi.spyOn(app, "do").mockResolvedValueOnce([]);
+      const api = hono(app as never, {
+        ...default_options(),
+        expectedVersion: (_action, _input, c) => {
+          const v = c.req.header("if-match");
+          return v === undefined ? undefined : Number.parseInt(v, 10);
+        },
+      });
+      await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers: make_headers({ "if-match": "7" }),
+        body: JSON.stringify({ key: "5" }),
+      });
+      expect(do_spy).toHaveBeenCalledWith(
+        "PressKey",
+        {
+          stream: "tenant-acme",
+          actor: { id: "u-1", name: "alice" },
+          expectedVersion: 7,
+        },
+        { key: "5" }
+      );
+    });
+
+    test("undefined resolver result skips the check on the target", async ({
+      app,
+    }) => {
+      const do_spy = vi.spyOn(app, "do").mockResolvedValueOnce([]);
+      const api = hono(app as never, {
+        ...default_options(),
+        expectedVersion: () => undefined,
+      });
+      await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers: make_headers(),
+        body: JSON.stringify({ key: "5" }),
+      });
+      expect(do_spy).toHaveBeenCalledWith(
+        "PressKey",
+        { stream: "tenant-acme", actor: { id: "u-1", name: "alice" } },
+        { key: "5" }
+      );
+    });
+  });
+
+  describe("framework error mapping (via toApiError)", () => {
+    const cases: ReadonlyArray<{
+      readonly label: string;
+      readonly throws: () => Error;
+      readonly status: number;
+      readonly code: string;
+    }> = [
+      {
+        label: "ConcurrencyError → 412 / CONCURRENCY",
+        throws: () => new ConcurrencyError("tenant-acme", 0, [], 1),
+        status: 412,
+        code: "CONCURRENCY",
+      },
+      {
+        label: "InvariantError → 409 / INVARIANT",
+        throws: () =>
+          new InvariantError(
+            "PressKey",
+            { key: "5" },
+            { stream: "tenant-acme", actor: { id: "u-1", name: "alice" } },
+            {} as never,
+            "calculator must be open"
+          ),
+        status: 409,
+        code: "INVARIANT",
+      },
+      {
+        label: "StreamClosedError → 410 / STREAM_CLOSED",
+        throws: () => new StreamClosedError("tenant-acme"),
+        status: 410,
+        code: "STREAM_CLOSED",
+      },
+      {
+        label: "NonRetryableError → 400 / NON_RETRYABLE",
+        throws: () => new NonRetryableError("permanently busted"),
+        status: 400,
+        code: "NON_RETRYABLE",
+      },
+      {
+        label: "ValidationError → 422 / VALIDATION",
+        throws: () =>
+          new ValidationError("PressKey", { key: "5" }, {
+            issues: [],
+          } as never),
+        status: 422,
+        code: "VALIDATION",
+      },
+      {
+        label: "unknown Error → 500 / INTERNAL (with detail)",
+        throws: () => new Error("disk on fire"),
+        status: 500,
+        code: "INTERNAL",
+      },
+    ];
+
+    for (const { label, throws, status, code } of cases) {
+      test(label, async ({ app }) => {
+        const api = hono(app as never, default_options());
+        vi.spyOn(app, "do").mockRejectedValueOnce(throws());
+        const res = await api.request("/api/actions/PressKey", {
+          method: "POST",
+          headers: make_headers(),
+          body: JSON.stringify({ key: "5" }),
+        });
+        expect(res.status).toBe(status);
+        const body = await res.json();
+        expect(body.code).toBe(code);
+      });
+    }
+
+    test("non-Error throws still return 500 with no detail leak", async ({
+      app,
+    }) => {
+      const api = hono(app as never, default_options());
+      vi.spyOn(app, "do").mockRejectedValueOnce("not-an-error-instance");
+      const res = await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers: make_headers(),
+        body: JSON.stringify({ key: "5" }),
+      });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.code).toBe("INTERNAL");
+      expect(body.detail).toBeUndefined();
+    });
+  });
+
+  describe("idempotency", () => {
+    test("fresh key dispatches and returns the snapshots", async ({ app }) => {
+      const api = hono(app as never, {
+        ...default_options(),
+        idempotency: { store: new InMemoryIdempotencyStore() },
+      });
+      const res = await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers: make_headers({ "idempotency-key": "fresh-1" }),
+        body: JSON.stringify({ key: "7" }),
+      });
+      expect(res.status).toBe(200);
+      const snapshots = await res.json();
+      expect(snapshots[0].event.name).toBe("KeyPressed");
+    });
+
+    test("missing Idempotency-Key returns 400", async ({ app }) => {
+      const api = hono(app as never, {
+        ...default_options(),
+        idempotency: { store: new InMemoryIdempotencyStore() },
+      });
+      const res = await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers: make_headers(),
+        body: JSON.stringify({ key: "8" }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe("BAD_REQUEST");
+    });
+
+    test("custom keyFrom overrides the default header lookup", async ({
+      app,
+    }) => {
+      const api = hono(app as never, {
+        ...default_options(),
+        idempotency: {
+          store: new InMemoryIdempotencyStore(),
+          keyFrom: (c) => c.req.header("x-trace-id"),
+        },
+      });
+      const res = await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers: make_headers({ "x-trace-id": "trace-abc" }),
+        body: JSON.stringify({ key: "9" }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    test("duplicate claim returns 409", async ({ app }) => {
+      const store = new InMemoryIdempotencyStore();
+      const api = hono(app as never, {
+        ...default_options(),
+        idempotency: { store },
+      });
+      const headers = make_headers({ "idempotency-key": "dup-1" });
+      await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ key: "1" }),
+      });
+      const res = await api.request("/api/actions/PressKey", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ key: "1" }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.code).toBe("CONFLICT");
+    });
+  });
+
+  describe("authenticated (standalone export)", () => {
+    test("stashes the resolved actor under c.get('actor')", async () => {
+      const api = new Hono<{
+        Variables: { actor: { id: string; name: string } };
+      }>();
+      api.use(
+        "*",
+        authenticated((request) => ({
+          id: (
+            request as { req: { header: (n: string) => string | undefined } }
+          ).req.header("x-uid")!,
+          name: "user",
+        }))
+      );
+      api.get("/me", (c) => c.json(c.get("actor")));
+
+      const res = await api.request("/me", { headers: { "x-uid": "alice" } });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ id: "alice", name: "user" });
+    });
+
+    test("extractor errors surface as 401 with ApiError envelope", async () => {
+      const api = new Hono<{
+        Variables: { actor: { id: string; name: string } };
+      }>();
+      api.use(
+        "*",
+        authenticated(() => {
+          throw new Error("no token");
+        })
+      );
+      api.get("/me", (c) => c.json(c.get("actor")));
+
+      const res = await api.request("/me");
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("UNAUTHORIZED");
+      expect(body.detail).toBe("no token");
+    });
+
+    test("non-Error extractor throws still return 401 (no detail leak)", async () => {
+      const api = new Hono();
+      api.use(
+        "*",
+        authenticated(() => {
+          // biome-ignore lint/suspicious/useErrorMessage: testing the non-Error branch
+          throw "raw-string-throw";
+        })
+      );
+      api.get("/me", (c) => c.text("ok"));
+
+      const res = await api.request("/me");
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("UNAUTHORIZED");
+      expect(body.detail).toBeUndefined();
+    });
+  });
+});

--- a/libs/act-http/tsup.config.ts
+++ b/libs/act-http/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/receiver/hono/index.ts",
     "src/api/index.ts",
     "src/trpc/index.ts",
+    "src/hono/index.ts",
   ],
   format: ["esm", "cjs"],
   dts: false,

--- a/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
+++ b/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
@@ -28827,6 +28827,491 @@ export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
 "
 `;
 
+exports[`@rotorsoft/act-http — public API stability > stable public surface for ./hono 1`] = `
+"// === actor.ts ===
+import type { Actor } from "@rotorsoft/act";
+
+/**
+ * Extractor function the host supplies to resolve an {@link Actor}
+ * from an incoming request. The framework keeps auth out of the
+ * package — JWT vs session vs API key is the host's call — and asks
+ * for this single closure that every transport (tRPC, Hono, OpenAPI
+ * docs) composes against.
+ *
+ * The \`request\` argument is intentionally generic. Each transport
+ * narrows it at the call site (\`IncomingMessage\` for Hono, the tRPC
+ * context object for tRPC, etc.) — keeping the contract here
+ * transport-agnostic means one extractor implementation plugs into
+ * every adapter unchanged.
+ *
+ * Async is allowed so the extractor can verify a JWT against a
+ * remote JWKS endpoint without forcing every host to synchronously
+ * cache.
+ */
+export type ActorExtractor = (request: unknown) => Actor | Promise<Actor>;
+
+// === errors.ts ===
+import {
+  ConcurrencyError,
+  InvariantError,
+  NonRetryableError,
+  StreamClosedError,
+  ValidationError,
+} from "@rotorsoft/act";
+
+/**
+ * Uniform error envelope shipped over the wire by every act-http
+ * transport. Hosts get the same shape from REST, tRPC, and OpenAPI —
+ * a client that talks to two transports doesn't have to invent two
+ * error parsers.
+ *
+ * - \`error\` — the framework error name (\`"ValidationError"\`,
+ *   \`"InvariantError"\`, …). Stable identifier, safe to switch on.
+ * - \`detail\` — the framework's message text. Human-readable; not
+ *   parsed by clients.
+ * - \`code\` — a machine-readable status code from {@link ERROR_MAP}
+ *   for clients that prefer enum-style branching over name strings.
+ */
+export type ApiError = {
+  error: string;
+  detail?: string;
+  code?: string;
+};
+
+/**
+ * Status + code pair for one known framework error.
+ */
+export type ErrorMapEntry = {
+  status: number;
+  code: string;
+};
+
+/**
+ * The single table that maps framework error types to HTTP status
+ * codes and machine-readable codes. One table, three consumers
+ * (Hono, tRPC, OpenAPI) — cross-transport consistency by
+ * construction.
+ *
+ * Operators wanting different mappings wrap the generated transport
+ * rather than mutating this — the consistency is the load-bearing
+ * property, not the specific status codes.
+ */
+export const ERROR_MAP = {
+  ValidationError: { status: 422, code: "VALIDATION" },
+  InvariantError: { status: 409, code: "INVARIANT" },
+  ConcurrencyError: { status: 412, code: "CONCURRENCY" },
+  StreamClosedError: { status: 410, code: "STREAM_CLOSED" },
+  NonRetryableError: { status: 400, code: "NON_RETRYABLE" },
+} as const satisfies Record<string, ErrorMapEntry>;
+
+const lookup_known = (
+  err: unknown
+): { name: keyof typeof ERROR_MAP } | null => {
+  if (err instanceof ValidationError) return { name: "ValidationError" };
+  if (err instanceof InvariantError) return { name: "InvariantError" };
+  if (err instanceof ConcurrencyError) return { name: "ConcurrencyError" };
+  if (err instanceof StreamClosedError) return { name: "StreamClosedError" };
+  if (err instanceof NonRetryableError) return { name: "NonRetryableError" };
+  return null;
+};
+
+/**
+ * Translate an unknown thrown value into the canonical
+ * {@link ApiError} envelope plus HTTP status. Each transport's error
+ * boundary calls this once and forwards the result to the wire.
+ *
+ * Known framework errors map per {@link ERROR_MAP}. Everything else
+ * surfaces as a 500 with \`code: "INTERNAL"\`; the \`detail\` field is
+ * populated when the throw was an \`Error\` instance, omitted
+ * otherwise (a thrown string or object doesn't get to leak its
+ * payload to the client).
+ */
+export function toApiError(err: unknown): { status: number; body: ApiError } {
+  const known = lookup_known(err);
+  if (known) {
+    const entry = ERROR_MAP[known.name];
+    return {
+      status: entry.status,
+      body: {
+        error: known.name,
+        detail: (err as Error).message,
+        code: entry.code,
+      },
+    };
+  }
+  if (err instanceof Error) {
+    return {
+      status: 500,
+      body: { error: "InternalError", detail: err.message, code: "INTERNAL" },
+    };
+  }
+  return {
+    status: 500,
+    body: { error: "InternalError", code: "INTERNAL" },
+  };
+}
+
+// === idempotency.ts ===
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+
+/**
+ * Result of a {@link withIdempotency} call.
+ *
+ * - \`{ deduped: false, result }\` — the claim was fresh; the handler
+ *   ran and produced \`result\`.
+ * - \`{ deduped: true }\` — the claim was already taken; the handler
+ *   was *not* invoked. The caller decides how to respond (typically
+ *   a 2xx with no body, matching the receiver-side convention).
+ *
+ * Note: the contract does not cache the previous response. A
+ * duplicate call returns the deduped marker only — replaying the
+ * original handler's output would require a response-caching
+ * adapter, which is out of scope here. The receiver-side convention
+ * (and the convention the generated transports follow) is "ack the
+ * duplicate; do nothing else."
+ */
+export type IdempotencyResult<T> =
+  | { deduped: false; result: T }
+  | { deduped: true };
+
+/**
+ * Wrap an action handler so the framework honors \`Idempotency-Key\`
+ * dedup. Acquires the key via {@link IdempotencyStore.claim}, runs
+ * the handler exactly when the claim was fresh, and skips the
+ * handler entirely on a duplicate.
+ *
+ * Reuses the contract \`@rotorsoft/act-ops/idempotency\` already
+ * defines for the receiver-side \`Idempotency-Key\` story. A single
+ * \`IdempotencyStore\` implementation covers both halves of the "Act
+ * over the wire" surface — receiver and generated API.
+ */
+export async function withIdempotency<T>(
+  store: IdempotencyStore,
+  key: string,
+  handler: () => Promise<T>
+): Promise<IdempotencyResult<T>> {
+  const fresh = await store.claim(key);
+  if (!fresh) {
+    return { deduped: true };
+  }
+  return { deduped: false, result: await handler() };
+}
+
+// === index.ts ===
+/**
+ * @packageDocumentation
+ * @module act-http/hono
+ *
+ * Hono subpath for the auto-generated API epic (#835). Walks the
+ * registry of a built \`Act\` once at function call and emits a Hono
+ * app with one \`POST /actions/<name>\` route per registered action,
+ * Zod-validated bodies, and the shared error envelope.
+ *
+ * Usage:
+ *
+ * \`\`\`ts
+ * import { hono } from "@rotorsoft/act-http/hono";
+ *
+ * const api = hono(app, {
+ *   actor: (c) => ({ id: c.req.header("x-user-id")!, name: "..." }),
+ *   stream: (action, input, c) => \`tenant-\${c.req.header("x-tenant")}\`,
+ * });
+ *
+ * // Mounts at /api by default — pass \`basePath\` to override.
+ * // POST /api/actions/OpenTicket  body: { title }  → 200 Snapshot[] | 4xx ApiError
+ * \`\`\`
+ *
+ * The route shape matches the flat tRPC sibling at
+ * \`@rotorsoft/act-http/trpc\`: one endpoint per action, no
+ * state-name tier. Action names are unique across the registry —
+ * the framework enforces no duplicates — so an extra namespace
+ * level would be overhead. Queries live in a follow-up; this
+ * slice is mutations only.
+ *
+ * **Actor lives on the context.** The generator wires an internal
+ * middleware that runs the host's
+ * {@link HonoOptions.actor | actor extractor} once per call and
+ * stashes the resolved {@link Actor} under \`c.get("actor")\`. Every
+ * generated route reads from there — auth resolves at one seam,
+ * downstream middleware (logging, tracing) sees the same actor.
+ * The middleware factory is also exported as {@link authenticated}
+ * for hosts that want to compose it into their own Hono chain
+ * alongside hand-written routes.
+ *
+ * Composes the shared utilities at \`@rotorsoft/act-http/api\`:
+ * {@link ActorExtractor} for the auth seam, {@link toApiError} for
+ * the uniform error → status / code mapping, {@link withIdempotency}
+ * for \`Idempotency-Key\` dedup. Three transports (tRPC, this one,
+ * OpenAPI) ride the same utilities so a client speaking two of
+ * them never sees two shapes for the same framework error.
+ */
+import { zValidator } from "@hono/zod-validator";
+import type { Act, Actor, Schema, Schemas } from "@rotorsoft/act";
+import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
+import type { Context, MiddlewareHandler } from "hono";
+import { Hono } from "hono";
+import {
+  type ActorExtractor,
+  type ApiError,
+  toApiError,
+  withIdempotency,
+} from "../api/index.js";
+
+/**
+ * Hono context variables this subpath contributes. The generic on
+ * the returned middleware threads it through so routes downstream
+ * of {@link authenticated} see \`c.get("actor")\` typed without a
+ * manual cast.
+ */
+export type ActMiddlewareVariables = {
+  actor: Actor;
+};
+
+/**
+ * Per-call options for {@link hono}. The host supplies the four
+ * seams the package can't make decisions on:
+ *
+ * - \`actor\` — auth resolver. Receives the Hono context, returns the
+ *   \`Actor\` that flows onto \`c.get("actor")\` for every generated
+ *   route (via an internal {@link authenticated}).
+ * - \`stream\` — stream-id resolver. Receives the action name, the
+ *   validated body, and the Hono context; returns the target
+ *   stream. Singleton aggregates return a constant; per-tenant
+ *   aggregates pull from headers, path, or body.
+ * - \`expectedVersion\` (optional) — optimistic-concurrency resolver.
+ *   Hosts typically read it from an \`If-Match\` header on the
+ *   request, or from the client's last-known snapshot. Returning
+ *   \`undefined\` skips the check for that call — handy when only
+ *   some actions are concurrency-sensitive.
+ * - \`idempotency\` (optional) — when set, the route honors
+ *   \`Idempotency-Key\` via {@link withIdempotency}. The host
+ *   supplies the \`IdempotencyStore\`; \`keyFrom\` defaults to reading
+ *   the \`Idempotency-Key\` header. On a duplicate claim, the route
+ *   responds \`409 Conflict\` — the contract intentionally doesn't
+ *   cache the original handler's result, matching the
+ *   receiver-side "ack the duplicate" semantics.
+ * - \`basePath\` (optional, default \`"/api"\`) — Hono basePath the
+ *   routes mount under.
+ */
+export type HonoOptions = {
+  readonly actor: ActorExtractor;
+  readonly stream: (
+    action_name: string,
+    input: unknown,
+    c: Context
+  ) => string | Promise<string>;
+  readonly expectedVersion?: (
+    action_name: string,
+    input: unknown,
+    c: Context
+  ) => number | undefined | Promise<number | undefined>;
+  readonly idempotency?: {
+    readonly store: IdempotencyStore;
+    readonly keyFrom?: (c: Context) => string | undefined;
+  };
+  readonly basePath?: string;
+};
+
+/**
+ * Build a Hono middleware that runs an {@link ActorExtractor} once
+ * per call and stashes the resolved {@link Actor} under
+ * \`c.set("actor", ...)\` so downstream routes can read it via
+ * \`c.get("actor")\`. The generator at {@link hono} uses this
+ * internally; it's also exported so hosts that want to compose
+ * their own route chain (logging, tracing, custom auth flavors)
+ * can wire it directly:
+ *
+ * \`\`\`ts
+ * import { Hono } from "hono";
+ * import { authenticated, type ActMiddlewareVariables } from "@rotorsoft/act-http/hono";
+ *
+ * const api = new Hono<{ Variables: ActMiddlewareVariables }>();
+ * api.use("*", authenticated((c) => resolveUserFromJwt(c)));
+ * api.get("/me", (c) => c.json(c.get("actor"))); // typed
+ * \`\`\`
+ *
+ * Errors thrown by the extractor surface as \`401 Unauthorized\` with
+ * the shared {@link ApiError} envelope.
+ */
+export function authenticated(
+  extractor: ActorExtractor
+): MiddlewareHandler<{ Variables: ActMiddlewareVariables }> {
+  return async (c, next) => {
+    try {
+      const actor = await extractor(c);
+      c.set("actor", actor);
+      await next();
+    } catch (err) {
+      const body: ApiError = {
+        error: "Unauthorized",
+        detail: err instanceof Error ? err.message : undefined,
+        code: "UNAUTHORIZED",
+      };
+      return c.json(body, 401);
+    }
+  };
+}
+
+const default_key_from = (c: Context): string | undefined =>
+  c.req.header("idempotency-key");
+
+/**
+ * Build a typed Hono REST surface from a built \`Act\` instance.
+ *
+ * Walks \`app.registry.actions\` once and emits one
+ * \`POST /actions/<actionName>\` per action under the configured
+ * \`basePath\` (default \`/api\`). Each route:
+ *
+ * 1. Runs the internal {@link authenticated} middleware —
+ *    \`options.actor\` resolves the {@link Actor} once and stashes
+ *    it under \`c.get("actor")\`.
+ * 2. Validates the JSON body against the action's Zod schema via
+ *    \`@hono/zod-validator\`. Failures short-circuit with \`422\`.
+ * 3. Resolves the target stream via
+ *    \`options.stream(name, input, c)\`.
+ * 4. (Optionally) resolves \`expectedVersion\` for optimistic
+ *    concurrency.
+ * 5. (Optionally) claims the \`Idempotency-Key\` via
+ *    {@link withIdempotency} — responds \`409\` on duplicate.
+ * 6. Calls
+ *    \`app.do(name, { stream, actor, expectedVersion? }, input)\`.
+ * 7. Maps any thrown framework error onto the shared
+ *    {@link ApiError} envelope via {@link toApiError}, returning
+ *    the conventional HTTP status (\`409\` / \`412\` for concurrency,
+ *    \`422\` for validation, \`400\` for non-retryable, etc.).
+ *
+ * @param app A built \`Act\` orchestrator.
+ * @param options Auth, stream, expected-version, idempotency, and
+ *   base-path seams.
+ * @returns A Hono app covering every registered action under
+ *   \`<basePath>/actions/<name>\`.
+ */
+export function hono(
+  app: Act<Schemas, Schemas, Schemas, Record<string, Schema>>,
+  options: HonoOptions
+): Hono<{ Variables: ActMiddlewareVariables }> {
+  const base_path = options.basePath ?? "/api";
+  const api = new Hono<{ Variables: ActMiddlewareVariables }>().basePath(
+    base_path
+  );
+  api.use("*", authenticated(options.actor));
+
+  const key_from = options.idempotency?.keyFrom ?? default_key_from;
+
+  for (const [action_name, state] of Object.entries(app.registry.actions)) {
+    const schema = state.actions[action_name] as Schema;
+    api.post(
+      \`/actions/\${action_name}\`,
+      zValidator("json", schema as never),
+      async (c) => {
+        try {
+          const input = c.req.valid("json" as never) as unknown;
+          const actor = c.get("actor");
+          const stream = await options.stream(action_name, input, c);
+          const expected_version = options.expectedVersion
+            ? await options.expectedVersion(action_name, input, c)
+            : undefined;
+          const target =
+            expected_version === undefined
+              ? { stream, actor }
+              : { stream, actor, expectedVersion: expected_version };
+
+          if (options.idempotency) {
+            const key = key_from(c);
+            if (!key) {
+              const body: ApiError = {
+                error: "BadRequest",
+                detail: "Idempotency-Key required",
+                code: "BAD_REQUEST",
+              };
+              return c.json(body, 400);
+            }
+            const outcome = await withIdempotency(
+              options.idempotency.store,
+              key,
+              () =>
+                app.do(action_name as never, target as never, input as never)
+            );
+            if (outcome.deduped) {
+              const body: ApiError = {
+                error: "Conflict",
+                detail:
+                  "Idempotency-Key already used; original result not cached",
+                code: "CONFLICT",
+              };
+              return c.json(body, 409);
+            }
+            return c.json(outcome.result);
+          }
+
+          const snapshots = await app.do(
+            action_name as never,
+            target as never,
+            input as never
+          );
+          return c.json(snapshots);
+        } catch (err) {
+          const { status, body } = toApiError(err);
+          // Hono types narrow \`status\` to its known status-number union;
+          // \`toApiError\` returns a numeric status from a closed set that
+          // matches but TypeScript can't prove it through the union.
+          return c.json(body, status as 400 | 409 | 410 | 412 | 422 | 500);
+        }
+      }
+    );
+  }
+
+  return api;
+}
+
+// === index.ts ===
+/**
+ * @packageDocumentation
+ * @module act-http/api
+ *
+ * Shared utilities for the act-http auto-generated API surfaces.
+ * Three concerns that every transport (tRPC, Hono, OpenAPI) has to
+ * address — actor extraction, error envelope mapping,
+ * \`Idempotency-Key\` wiring — defined once here and composed by each
+ * transport sibling subpath.
+ *
+ * - {@link ActorExtractor} — the host-supplied closure that resolves
+ *   an \`Actor\` from an incoming request. Auth (JWT, session, API
+ *   key) stays in the host; the package only asks for this one
+ *   function.
+ * - {@link ApiError}, {@link ERROR_MAP}, {@link toApiError} — the
+ *   uniform error envelope and the status/code mapping every
+ *   transport uses. Cross-transport consistency by construction.
+ * - {@link withIdempotency} — the helper that wraps action handlers
+ *   in an \`Idempotency-Key\` claim. Reuses the
+ *   \`@rotorsoft/act-ops/idempotency\` contract that
+ *   \`@rotorsoft/act-http/receiver\` already speaks, so receivers and
+ *   generated APIs share one \`IdempotencyStore\` implementation.
+ *
+ * Sibling subpaths in the same package consume the utilities here:
+ *
+ * - \`@rotorsoft/act-http/trpc\` — tRPC adapter (#843).
+ * - \`@rotorsoft/act-http/hono\` — Hono adapter (#844).
+ * - \`@rotorsoft/act-http/openapi\` — OpenAPI emitter (#845).
+ *
+ * Existing siblings unrelated to the generated-API work:
+ *
+ * - \`@rotorsoft/act-http/webhook\` — outbound POST delivery.
+ * - \`@rotorsoft/act-http/sse\` — incremental state broadcast.
+ * - \`@rotorsoft/act-http/receiver\` — inbound webhook ingestion.
+ */
+
+export type { ActorExtractor } from "./actor.js";
+export {
+  type ApiError,
+  ERROR_MAP,
+  type ErrorMapEntry,
+  toApiError,
+} from "./errors.js";
+export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
+"
+`;
+
 exports[`@rotorsoft/act-http — public API stability > stable public surface for ./receiver 1`] = `
 "// === check.ts ===
 import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@hono/node-server':
         specifier: ^2.0.4
         version: 2.0.4(hono@4.12.23)
+      '@hono/zod-validator':
+        specifier: ^0.8.0
+        version: 0.8.0(hono@4.12.23)(zod@4.4.3)
       '@rotorsoft/act-ops':
         specifier: workspace:^
         version: link:../act-ops
@@ -2498,6 +2501,12 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
+
+  '@hono/zod-validator@0.8.0':
+    resolution: {integrity: sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==}
+    peerDependencies:
+      hono: '>=4.10.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -11708,6 +11717,11 @@ snapshots:
   '@hono/node-server@2.0.4(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
+
+  '@hono/zod-validator@0.8.0(hono@4.12.23)(zod@4.4.3)':
+    dependencies:
+      hono: 4.12.23
+      zod: 4.4.3
 
   '@jest/schemas@29.6.3':
     dependencies:

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -27,6 +27,7 @@
       "@rotorsoft/act-http/receiver/trpc": [
         "./libs/act-http/src/receiver/trpc/index.ts"
       ],
+      "@rotorsoft/act-http/hono": ["./libs/act-http/src/hono/index.ts"],
       "@rotorsoft/act-http/sse": ["./libs/act-http/src/sse/index.ts"],
       "@rotorsoft/act-http/trpc": ["./libs/act-http/src/trpc/index.ts"],
       "@rotorsoft/act-http/webhook": ["./libs/act-http/src/webhook/index.ts"],


### PR DESCRIPTION
## Summary

New `@rotorsoft/act-http/hono` subpath. The `hono(app, options)` generator walks `app.registry.actions` once and emits a Hono app with one `POST /actions/<name>` per action under a configurable `basePath` (default `/api`). Bodies validate through `@hono/zod-validator` against the action's registered Zod schema. Same options shape as the tRPC sibling (#843) — same actor seam, same `expectedVersion` seam, same idempotency contract.

```ts
import { hono } from "@rotorsoft/act-http/hono";
import { serve } from "@hono/node-server";

const api = hono(app, {
  actor: (c) => resolveActorFromJwt(c),
  stream: (action, input, c) => `tenant-${c.req.header("x-tenant")}`,
  expectedVersion: (action, input, c) => {
    const v = c.req.header("if-match");
    return v ? Number.parseInt(v, 10) : undefined;
  },
});

serve({ fetch: api.fetch, port: 4000 });
```

## Cross-transport consistency

A client speaking REST plus tRPC now sees one `ApiError` envelope (`{ error, detail?, code? }`), one `Idempotency-Key` contract, and one optimistic-concurrency seam (`Target.expectedVersion`). The shared utilities at `@rotorsoft/act-http/api` make this consistency structural — both transports route through `toApiError`, `withIdempotency`, and the same `ActorExtractor` type. Adding the OpenAPI emitter (#845) next inherits the same envelope by construction.

## Why the auth lives on the context

The generator internally wires `api.use("*", authenticated(options.actor))`, so every generated route has `c.get("actor"): Actor` available, and downstream middleware (logging, tracing) sees the same actor. The `authenticated(extractor)` factory is also exported standalone so hosts composing their own Hono chain can use it without going through the generator:

```ts
import { Hono } from "hono";
import { authenticated, type ActMiddlewareVariables } from "@rotorsoft/act-http/hono";

const api = new Hono<{ Variables: ActMiddlewareVariables }>();
api.use("*", authenticated(myExtractor));
api.get("/me", (c) => c.json(c.get("actor"))); // typed
```

Extractor errors surface as `401 / UNAUTHORIZED` with the shared envelope. Mirrors the tRPC sibling's `authenticated` export so cross-adapter familiarity carries.

## Error envelope (table)

| Framework error | HTTP status | code |
|---|---|---|
| `ConcurrencyError` | 412 | `CONCURRENCY` |
| `InvariantError` | 409 | `INVARIANT` |
| `ValidationError` | 422 | `VALIDATION` |
| `StreamClosedError` | 410 | `STREAM_CLOSED` |
| `NonRetryableError` | 400 | `NON_RETRYABLE` |
| anything else | 500 | `INTERNAL` |

Non-Error throws (strings, plain objects) still return `500 / INTERNAL` but omit `detail` so the payload doesn't leak.

## Idempotency

Optional. When configured, the route reads `Idempotency-Key` from the request header by default (`keyFrom` overrides for hosts that prefer a custom convention). Duplicate claims return `409 / CONFLICT` — the contract intentionally doesn't cache the original result, matching the receiver-side "ack the duplicate" semantics and the tRPC sibling's behavior.

## Edge-runtime ready

Hono runs unchanged on Node, Bun, Cloudflare Workers, Vercel Edge, and AWS Lambda. The cookbook caveat: operators wiring `idempotency` on edge runtimes should verify the `IdempotencyStore` is edge-compatible (in-memory works per worker; cross-worker requires a distributed store). The package can't validate this at construction; the store's I/O target is opaque to act-http.

## Test plan

- [x] `pnpm test`: 20 new specs covering cross-action emission, basePath override, internal + standalone auth middleware, stream extraction, expected-version threading, idempotency dedup (header + custom keyFrom), all six framework error mappings, and the non-Error throw path. 2185 total tests pass.
- [x] `pnpm test --coverage`: 100% statements / branches / functions / lines on `libs/act-http/src/hono/index.ts`.
- [x] `pnpm typecheck`: clean.
- [x] `pnpm lint`: 0 errors (43 warnings, 3 infos all pre-existing).
- [x] Stability snapshots regenerated for the new subpath (additive only).

## Stability charter impact

**No charter-covered files touched.** `libs/act-http/*` is outside the charter; the act core types this PR consumes (`Act`, `Actor`, `Schema`, `Schemas`) are unchanged.

## Follow-ups

- **#845** — `@rotorsoft/act-http/openapi` subpath (OpenAPI 3.1 emitter; inherits the same envelope + auth seam).
- **#847** — migrate `packages/server` + `packages/calculator` to use one of these generators end-to-end.
- **Multi-transport calculator demo** — once #843, #844, #845, #847 are shipped, a new ticket scaffolds a small example app that mounts all three transports against the same Act and verifies the cross-transport-consistency claim with both server-side tests and a UI page per transport. Validates types and behavior end-to-end.

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)