### PR TITLE
fix(act-pg,act-sqlite,calculator): stackblitz-installable workspace deps

### DIFF
--- a/libs/act-pg/package.json
+++ b/libs/act-pg/package.json
@@ -48,7 +48,7 @@
     "stress": "tsx test/stress/runner.ts"
   },
   "dependencies": {
-    "@rotorsoft/act-crypto": "workspace:*",
+    "@rotorsoft/act-crypto": "workspace:^",
     "pg": "^8.21.0"
   },
   "peerDependencies": {

--- a/libs/act-sqlite/package.json
+++ b/libs/act-sqlite/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@libsql/client": "^0.17.3",
-    "@rotorsoft/act-crypto": "workspace:*"
+    "@rotorsoft/act-crypto": "workspace:^"
   },
   "peerDependencies": {
     "@rotorsoft/act": "workspace:^",

--- a/packages/calculator/package.json
+++ b/packages/calculator/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@rotorsoft/act": ">=1.10.1",
-    "@rotorsoft/act-http": "workspace:*",
     "@trpc/server": "11.17.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         specifier: workspace:^
         version: link:../act
       '@rotorsoft/act-crypto':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../act-crypto
       pg:
         specifier: ^8.21.0
@@ -351,7 +351,7 @@ importers:
         specifier: workspace:^
         version: link:../act
       '@rotorsoft/act-crypto':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../act-crypto
       zod:
         specifier: ^4.4.3
@@ -384,9 +384,6 @@ importers:
       '@rotorsoft/act':
         specifier: '>=1.10.1'
         version: link:../../libs/act
-      '@rotorsoft/act-http':
-        specifier: workspace:*
-        version: link:../../libs/act-http
       '@trpc/server':
         specifier: 11.17.0
         version: 11.17.0(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Stackblitz installs for the calculator and performance demos were broken; this fixes both in one PR.

## What broke

### 1. \`@rotorsoft/act-pg\` and \`@rotorsoft/act-sqlite\` publish bug

Both declared \`@rotorsoft/act-crypto: workspace:*\`. \`pnpm publish\` rewrites that to the **literal** version in act-crypto's package.json at publish time. When act-pg / act-sqlite were first published, act-crypto's local version was the pre-publish baseline \`0.0.0\`, so the published act-pg / act-sqlite versions are pinned to \`@rotorsoft/act-crypto@0.0.0\` — forever. semantic-release later bumped act-crypto to \`0.1.0\`. The \`0.0.0\` version does not exist on npm, so any consumer install fails:

\`\`\`
npm error code ETARGET
npm error notarget No matching version found for @rotorsoft/act-crypto@0.0.0.
\`\`\`

(The user hit this trying to install the performance demo on stackblitz.)

**Fix:** switch to \`workspace:^\`, lining up with every other workspace dep in the repo. \`pnpm publish\` then resolves to \`^0.1.0\` — a real version on the registry.

### 2. \`packages/calculator\` had an unused \`workspace:*\` dep

\`packages/calculator/package.json\` listed \`@rotorsoft/act-http: workspace:*\` from #847's prep, but the calculator never actually imports anything from act-http (the demo's hand-written tRPC router uses \`@trpc/server\` directly). npm and stackblitz can't resolve the \`workspace:*\` protocol and fail with:

\`\`\`
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type \"workspace:\": workspace:*
\`\`\`

**Fix:** remove the unused dep.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm -F @rotorsoft/act-pg test\` — 168/168 passing
- [x] \`pnpm -F @rotorsoft/act-sqlite test\` — 140/140 passing
- [x] Calculator source has zero \`@rotorsoft/act-http\` imports (only doc-comments mention it)
- [ ] CI green
- [ ] After merge: semantic-release publishes act-pg + act-sqlite patch versions with the fixed dep specifier; verify a fresh \`npm install @rotorsoft/act-pg\` resolves cleanly

## Stability charter impact

None. Package metadata only, no source touched. The published dep-spec is \`^\` instead of an exact \`0.0.0\` — strictly more permissive.

## Follow-ups

- Re-test both stackblitz demos after the patch release lands.
- Audit any other \`workspace:*\` specs in published-package package.json files (\`grep -rn "workspace:\\*" libs/\*/package.json\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)