### PR TITLE
feat(act-http): #846 — generated SSE subscriptions on trpc + hono

### DIFF
--- a/.claude/skills/scaffold-act-app/SKILL.md
+++ b/.claude/skills/scaffold-act-app/SKILL.md
@@ -125,7 +125,7 @@ my-app/
 │       │   │   ├── context.ts    # Request context + token verification
 │       │   │   ├── helpers.ts    # serializeEvents() for SSE payloads
 │       │   │   ├── auth.ts       # Token signing, password hashing
-│       │   │   ├── broadcast.ts      # BroadcastChannel + PresenceTracker (act-sse)
+│       │   │   ├── broadcast.ts      # BroadcastChannel + PresenceTracker (via @rotorsoft/act-http/sse)
 │       │   │   ├── auth.routes.ts    # Auth endpoints (login, signup, OAuth)
 │       │   │   ├── domain.routes.ts  # Domain mutations + queries
 │       │   │   └── events.routes.ts  # SSE subscriptions (state + events)
@@ -206,16 +206,16 @@ For production deployment (PostgresStore, background processing, automated jobs)
 - [ ] Invariants enforce all business rules
 - [ ] Reactions pass triggering event for causation tracking
 - [ ] Projections co-located with slices, with query and clear functions
-- [ ] Projections register only lifecycle event handlers when using act-sse broadcast
+- [ ] Projections register only lifecycle event handlers when using @rotorsoft/act-http/sse broadcast
 - [ ] Tests use InMemoryStore with `store().seed()` and `clear*()` in `beforeEach`, `dispose()()` in `afterAll`
 - [ ] Domain package has no infrastructure dependencies
 - [ ] All packages use `"type": "module"` and TypeScript strict mode
 - [ ] tRPC API decomposed into route files with typed middleware
-- [ ] `broadcast.ts` sets up `BroadcastChannel` + `PresenceTracker` from `@rotorsoft/act-sse`
+- [ ] `broadcast.ts` sets up `BroadcastChannel` + `PresenceTracker` from `@rotorsoft/act-http/sse`
 - [ ] `broadcastState()` called after every `app.do()` — sets `_v` from `snap.event.version`
 - [ ] SSE `onStateChange` subscription uses `broadcast.subscribe()` for incremental state push
 - [ ] SSE `onEvent` subscription wired with `app.on("settled")` for event replay
 - [ ] `app.settle()` called after mutations (non-blocking, debounced, emits "settled" after reactions)
-- [ ] Client `useStateStream` hook uses `applyBroadcastMessage()` from `@rotorsoft/act-sse`
+- [ ] Client `useStateStream` hook uses `applyPatchMessage()` from `@rotorsoft/act-http/sse`
 - [ ] Client uses `splitLink` for SSE subscriptions + HTTP for mutations/queries
 - [ ] Types compile with `npx tsc --noEmit`

--- a/.claude/skills/scaffold-act-app/act-api.md
+++ b/.claude/skills/scaffold-act-app/act-api.md
@@ -607,7 +607,7 @@ const ItemProjection = projection("items")
 - `.batch(handler)` — Register a batch handler for bulk event processing (static-target only). Receives `ReadonlyArray<BatchEvent<TEvents>>` (discriminated union) and `stream`. When defined, always called instead of individual `.do()` handlers — even for a single event.
 - `.build()` — Returns a `Projection` with `_tag: "Projection"`
 
-**Optimization:** When using `act-sse` broadcast, only register handlers for lifecycle events (entity creation, deletion, membership changes). High-frequency operational events don't need projection handlers — the broadcast cache is the source of truth. This reduces drain work and DB writes by ~95%. See [server.md](server.md) § Projection Optimization Strategies.
+**Optimization:** When using `@rotorsoft/act-http/sse` broadcast, only register handlers for lifecycle events (entity creation, deletion, membership changes). High-frequency operational events don't need projection handlers — the broadcast cache is the source of truth. This reduces drain work and DB writes by ~95%. See [server.md](server.md) § Projection Optimization Strategies.
 
 ## 13. Slice Builder — Vertical Slice Architecture
 

--- a/.claude/skills/scaffold-act-app/api.md
+++ b/.claude/skills/scaffold-act-app/api.md
@@ -2,7 +2,7 @@
 
 tRPC router in `packages/app/src/api/`, decomposed into focused route modules.
 
-> **When to skip this layer and use the generator instead.** If the app's HTTP surface is purely mechanical — one mutation per registered action, target stream resolved from headers or context, no special-cased queries beyond `app.load` / `app.query` — `@rotorsoft/act-http`'s [`/trpc`, `/hono`, and `/openapi` generators](https://rotorsoft.github.io/act-root/docs/guides/auto-generated-api) walk the registry and emit each transport for you. The hand-written shape in this guide is the right pick when the API needs middleware composition, hand-rolled queries, SSE subscription routes, or auth flavors that don't fit a single `actor(ctx)` extractor. The two patterns compose: generate the mutation surface, hand-write the SSE / auth / admin routes alongside.
+> **When to skip this layer and use the generator instead.** If the app's HTTP surface is purely mechanical — one mutation per registered action, target stream resolved from headers or context, no special-cased queries beyond `app.load` / `app.query` — `@rotorsoft/act-http`'s [`/trpc`, `/hono`, and `/openapi` generators](https://rotorsoft.github.io/act-root/docs/guides/auto-generated-api) walk the registry and emit each transport for you. As of #846 the generators also handle **real-time SSE subscriptions**: pass `sse: { channel }` and the generator emits one typed subscription per registered state name, replacing the hand-written `onStateChange` route in this layout entirely. The hand-written shape below is the right pick when the API needs admin-only routes, custom auth flavors that don't fit a single `actor(ctx)` extractor, or the global-event-log `onEvent` replay surface (which the generator doesn't cover). The two patterns compose: generate the mutation + state-subscription surface, hand-write the `onEvent` / `auth` / `admin` routes alongside.
 
 **Why decompose into many small files instead of one router?** Each file has a single responsibility and a clear dependency graph. `trpc.ts` knows nothing about auth; `context.ts` knows nothing about routes; route files know nothing about each other. This prevents circular dependencies and makes it easy to find where a specific endpoint lives. When the spec adds a new domain aggregate, you add handlers to `domain.routes.ts` without touching auth or SSE logic.
 
@@ -10,7 +10,7 @@ tRPC router in `packages/app/src/api/`, decomposed into focused route modules.
 
 **Choosing the right procedure type:** Use `publicProcedure` for unauthenticated reads (list views, SSE subscriptions). Use `authedProcedure` for any mutation that modifies state — the middleware guarantees `ctx.actor` is non-null and typed. Use `adminProcedure` for administrative operations (role assignment, user management). Never use `publicProcedure` for mutations unless the spec explicitly allows anonymous writes.
 
-**Two SSE subscriptions serve different purposes:** `onStateChange` pushes incremental state patches for a *specific stream* (one entity) — used by detail views. `onEvent` replays the *global event log* — used by admin tools and event explorers. Don't confuse them: `onStateChange` uses `broadcast.subscribe()` (act-sse), while `onEvent` uses `app.on("settled")` (framework lifecycle).
+**Two SSE subscriptions serve different purposes:** `onStateChange` pushes incremental state patches for a *specific stream* (one entity) — used by detail views. `onEvent` replays the *global event log* — used by admin tools and event explorers. Don't confuse them: `onStateChange` uses `broadcast.subscribe()` (via @rotorsoft/act-http/sse), while `onEvent` uses `app.on("settled")` (framework lifecycle).
 
 ## Overview
 
@@ -20,7 +20,7 @@ tRPC router in `packages/app/src/api/`, decomposed into focused route modules.
 | `context.ts` | Request context | Extract `AppActor` from Bearer token via `verifyToken()` |
 | `auth.ts` | Token + password crypto | HMAC-signed tokens, scrypt password hashing (zero deps) |
 | `helpers.ts` | Event serialization | `serializeEvents()` for SSE payloads |
-| `broadcast.ts` | Real-time state broadcast | `BroadcastChannel` + `PresenceTracker` from `@rotorsoft/act-sse` |
+| `broadcast.ts` | Real-time state broadcast | `BroadcastChannel` + `PresenceTracker` from `@rotorsoft/act-http/sse` |
 | `auth.routes.ts` | Auth endpoints | login, signup, me, assignRole, listUsers |
 | `domain.routes.ts` | Domain mutations + queries | `app.do()` + `broadcastState()` per mutation; query projections |
 | `events.routes.ts` | SSE subscriptions | `onStateChange` (incremental patches) + `onEvent` (replay) |
@@ -28,9 +28,9 @@ tRPC router in `packages/app/src/api/`, decomposed into focused route modules.
 
 **Key rules:**
 - Call `app.settle()` after every `app.do()` in mutations — non-blocking, returns immediately
-- Call `broadcastState(streamId, snap)` after every `app.do()` — pushes incremental patches via `act-sse`
+- Call `broadcastState(streamId, snap)` after every `app.do()` — pushes incremental patches via `@rotorsoft/act-http/sse`
 - Use `authedProcedure` / `adminProcedure` for authorization (middleware narrows `ctx.actor`)
-- `onStateChange` SSE uses `broadcast.subscribe()` from `act-sse` for real-time state push
+- `onStateChange` SSE uses `broadcast.subscribe()` from `@rotorsoft/act-http/sse` for real-time state push
 - `onEvent` SSE uses `app.on("settled", ...)` which fires only after `correlate()` + `drain()` complete
 
 ## packages/app/src/api/trpc.ts (init + middleware)
@@ -149,11 +149,11 @@ export function serializeEvents(events: Array<{ id: number; name: unknown; data:
 
 ## packages/app/src/api/broadcast.ts (broadcast setup)
 
-App-specific broadcast setup using `@rotorsoft/act-sse`. Customize `deriveState()` and `applyPresence()` for your domain.
+App-specific broadcast setup using `@rotorsoft/act-http/sse`. Customize `deriveState()` and `applyPresence()` for your domain.
 
 ```typescript
-import { BroadcastChannel, PresenceTracker } from "@rotorsoft/act-sse";
-import type { BroadcastState } from "@rotorsoft/act-sse";
+import { BroadcastChannel, PresenceTracker } from "@rotorsoft/act-http/sse";
+import type { BroadcastState } from "@rotorsoft/act-http/sse";
 
 // Extend with app-specific fields
 export type AppState = BroadcastState & {
@@ -223,7 +223,7 @@ export const domainRouter = t.router({
 
 ## packages/app/src/api/events.routes.ts (SSE subscriptions)
 
-Two subscriptions: `onStateChange` for real-time incremental state push (uses `@rotorsoft/act-sse`), and `onEvent` for event stream replay.
+Two subscriptions: `onStateChange` for real-time incremental state push (uses `@rotorsoft/act-http/sse`), and `onEvent` for event stream replay.
 
 ```typescript
 import { app } from "@my-app/domain";
@@ -232,12 +232,12 @@ import { z } from "zod";
 import { serializeEvents } from "./helpers.js";
 import { t, publicProcedure } from "./trpc.js";
 import { broadcast, presence, broadcastPresenceChange } from "./broadcast.js";
-import type { BroadcastMessage } from "@rotorsoft/act-sse";
+import type { PatchMessage } from "@rotorsoft/act-http/sse";
 
 export const eventsRouter = t.router({
   /**
    * Real-time state broadcast — incremental patches over SSE.
-   * Uses @rotorsoft/act-sse for automatic RFC 6902 patch computation.
+   * Uses @rotorsoft/act-http/sse for automatic RFC 6902 patch computation.
    */
   onStateChange: publicProcedure
     .input(z.object({ streamId: z.string(), identityId: z.string().optional() }).optional())
@@ -247,7 +247,7 @@ export const eventsRouter = t.router({
 
       const identityId = input?.identityId;
       let resolve: (() => void) | null = null;
-      let pending: BroadcastMessage | null = null;
+      let pending: PatchMessage | null = null;
 
       const cleanup = broadcast.subscribe(streamId, (msg) => {
         pending = msg;

--- a/.claude/skills/scaffold-act-app/client.md
+++ b/.claude/skills/scaffold-act-app/client.md
@@ -12,12 +12,12 @@ React + Vite frontend in `packages/app/src/client/`.
 
 **splitLink is required, not optional.** tRPC SSE subscriptions use `httpSubscriptionLink`, while mutations/queries use `httpLink`. Without `splitLink`, subscriptions will fail with HTTP errors because `httpLink` doesn't support the SSE protocol.
 
-**Version handling in useStateStream:** The hook handles 4 cases from `applyBroadcastMessage()`: `ok` (apply patch to cache), `behind` (client missed a version — invalidate and refetch), `patch-failed` (patch couldn't apply — invalidate and refetch), `stale` (client is ahead because the mutation response arrived before the SSE patch — ignore). Getting these wrong causes UI glitches or infinite refetch loops.
+**Version handling in useStateStream:** The hook handles 4 cases from `applyPatchMessage()`: `ok` (apply patch to cache), `behind` (client missed a version — invalidate and refetch), `patch-failed` (patch couldn't apply — invalidate and refetch), `stale` (client is ahead because the mutation response arrived before the SSE patch — ignore). Getting these wrong causes UI glitches or infinite refetch loops.
 
 ## Key Patterns
 
 - `App.tsx` uses `splitLink` — routes subscriptions through `httpSubscriptionLink` (SSE), mutations/queries through `httpLink`
-- `useStateStream` hook subscribes to `onStateChange` SSE, applies incremental patches via `applyBroadcastMessage()` from `@rotorsoft/act-sse`
+- `useStateStream` hook subscribes to `onStateChange` SSE, applies incremental patches via `applyPatchMessage()` from `@rotorsoft/act-http/sse`
 - `useEventStream` hook subscribes to `onEvent` SSE, deduplicates by event ID, and calls `utils.<query>.invalidate()` on relevant events
 - `useAuth` hook provides `AuthProvider` context with `signIn`, `signUp`, `signOut`, and role-based access (`isAdmin`)
 
@@ -109,14 +109,14 @@ createRoot(document.getElementById("root")!).render(
 );
 ```
 
-## packages/app/src/client/hooks/useStateStream.ts (incremental state sync via act-sse)
+## packages/app/src/client/hooks/useStateStream.ts (incremental state sync via @rotorsoft/act-http/sse)
 
 Receives incremental patches or full state from the server, applies them to the React Query cache with version validation. Falls back to full refetch on version mismatch.
 
 ```typescript
 // packages/app/src/client/hooks/useStateStream.ts
 import { useCallback, useState } from "react";
-import { applyBroadcastMessage } from "@rotorsoft/act-sse";
+import { applyPatchMessage } from "@rotorsoft/act-http/sse";
 import { trpc } from "../trpc.js";
 
 export function useStateStream(streamId: string | null, identityId?: string) {
@@ -135,7 +135,7 @@ export function useStateStream(streamId: string | null, identityId?: string) {
       onData: (msg) => {
         if (!streamId) return;
         const cached = utils.getState.getData({ streamId }) as any;
-        const result = applyBroadcastMessage(msg as any, cached);
+        const result = applyPatchMessage(msg as any, cached);
 
         if (result.ok) {
           utils.getState.setData({ streamId }, result.state as any);

--- a/.claude/skills/scaffold-act-app/domain.md
+++ b/.claude/skills/scaffold-act-app/domain.md
@@ -193,7 +193,7 @@ export const ItemSlice = slice()
 
 **clear*() helpers**: Export a `clear*()` function to reset projection state in tests.
 
-**Lifecycle-only projections**: When using `act-sse` for real-time broadcast, projections only need to persist data for **lifecycle events** (entity created, member added, completed, deleted, etc.) — not every high-frequency operational event. The broadcast cache is the source of truth for full state; the DB stores lightweight summaries for cold-start recovery and list views. See [server.md](server.md) § Projection Optimization Strategies.
+**Lifecycle-only projections**: When using `@rotorsoft/act-http/sse` for real-time broadcast, projections only need to persist data for **lifecycle events** (entity created, member added, completed, deleted, etc.) — not every high-frequency operational event. The broadcast cache is the source of truth for full state; the DB stores lightweight summaries for cold-start recovery and list views. See [server.md](server.md) § Projection Optimization Strategies.
 
 ## Drizzle Projections (PostgreSQL)
 

--- a/.claude/skills/scaffold-act-app/monorepo-template.md
+++ b/.claude/skills/scaffold-act-app/monorepo-template.md
@@ -152,7 +152,7 @@ export default defineConfig({
   "dependencies": {
     "@my-app/domain": "workspace:*",
     "@rotorsoft/act": "^0.20.0",
-    "@rotorsoft/act-sse": "^0.1.0",
+    "@rotorsoft/act-http/sse": "^0.1.0",
     "@tanstack/react-query": "^5.90.21",
     "@trpc/client": "11.10.0",
     "@trpc/react-query": "11.10.0",
@@ -270,6 +270,6 @@ pnpm -F @my-app/domain add @rotorsoft/act drizzle-orm postgres zod
 pnpm -F @my-app/domain add -D drizzle-kit
 
 # App (server + client combined)
-pnpm -F @my-app/app add @my-app/domain @rotorsoft/act @rotorsoft/act-sse @trpc/server @trpc/client @trpc/react-query @tanstack/react-query cors react react-dom zod
+pnpm -F @my-app/app add @my-app/domain @rotorsoft/act @rotorsoft/act-http/sse @trpc/server @trpc/client @trpc/react-query @tanstack/react-query cors react react-dom zod
 pnpm -F @my-app/app add -D @types/cors @types/react @types/react-dom @vitejs/plugin-react typescript vite
 ```

--- a/.claude/skills/scaffold-act-app/server.md
+++ b/.claude/skills/scaffold-act-app/server.md
@@ -370,9 +370,9 @@ Set `LOG_LEVEL=debug` or `LOG_LEVEL=trace` for verbose framework logging (uses p
 
 ## Real-Time Application Patterns
 
-These patterns apply when building apps that need live state push (SSE/WebSockets) on top of act's event sourcing. Use `@rotorsoft/act-sse` for incremental state broadcast.
+These patterns apply when building apps that need live state push (SSE/WebSockets) on top of act's event sourcing. Use `@rotorsoft/act-http/sse` for incremental state broadcast.
 
-Install: `pnpm -F @my-app/app add @rotorsoft/act-sse`
+Install: `pnpm -F @my-app/app add @rotorsoft/act-http/sse`
 
 ### `app.do()` Returns One Snapshot Per Event — Use the Last One
 
@@ -395,9 +395,9 @@ async function doAction(action: string, target: any, payload: any) {
 }
 ```
 
-### Incremental State Broadcast with `@rotorsoft/act-sse`
+### Incremental State Broadcast with `@rotorsoft/act-http/sse`
 
-Instead of sending the full aggregate state to every client after each action, `act-sse` computes RFC 6902 JSON Patches between consecutive states and sends only the diff — falling back to full state when the patch is too large or the client needs to resync.
+Instead of sending the full aggregate state to every client after each action, `@rotorsoft/act-http/sse` computes RFC 6902 JSON Patches between consecutive states and sends only the diff — falling back to full state when the patch is too large or the client needs to resync.
 
 **Version contract:** `_v` is always set from `snap.event.version` — the event store's monotonic stream version. No separate version counters.
 
@@ -417,7 +417,7 @@ Instead of sending the full aggregate state to every client after each action, `
       └── push to all SSE subscribers
       │
       ▼
-  Client: applyBroadcastMessage(msg, cached)
+  Client: applyPatchMessage(msg, cached)
       │
       ├── full   → accept if _v ≥ cachedV
       ├── patch  → apply if _baseV === cachedV
@@ -428,8 +428,8 @@ Instead of sending the full aggregate state to every client after each action, `
 ### Server-Side Setup
 
 ```typescript
-import { BroadcastChannel, PresenceTracker } from "@rotorsoft/act-sse";
-import type { BroadcastState } from "@rotorsoft/act-sse";
+import { BroadcastChannel, PresenceTracker } from "@rotorsoft/act-http/sse";
+import type { BroadcastState } from "@rotorsoft/act-http/sse";
 
 // Extend BroadcastState with your app-specific fields
 type MyAppState = BroadcastState & {
@@ -464,12 +464,12 @@ function broadcastPresenceChange(streamId: string) {
 ### Client-Side Patch Application
 
 ```typescript
-import { applyBroadcastMessage } from "@rotorsoft/act-sse";
+import { applyPatchMessage } from "@rotorsoft/act-http/sse";
 
 // In SSE onData handler (React Query):
 onData: (msg) => {
   const cached = utils.getState.getData({ streamId });
-  const result = applyBroadcastMessage(msg, cached);
+  const result = applyPatchMessage(msg, cached);
 
   if (result.ok) {
     utils.getState.setData({ streamId }, result.state);
@@ -483,7 +483,7 @@ onData: (msg) => {
 ### SSE Subscription Pattern (tRPC)
 
 ```typescript
-import type { BroadcastMessage } from "@rotorsoft/act-sse";
+import type { PatchMessage } from "@rotorsoft/act-http/sse";
 
 onStateChange: publicProcedure
   .input(z.object({ streamId: z.string(), identityId: z.string().optional() }))
@@ -491,7 +491,7 @@ onStateChange: publicProcedure
     const { streamId, identityId } = input;
 
     let resolve: (() => void) | null = null;
-    let pending: BroadcastMessage<MyAppState> | null = null;
+    let pending: PatchMessage<MyAppState> | null = null;
 
     const cleanup = broadcast.subscribe(streamId, (msg) => {
       pending = msg;
@@ -689,10 +689,10 @@ The snapshot from `app.do()` has all event patches applied — it is the authori
 
 **Rule: The hot path (API responses, SSE push, in-memory cache) must use aggregate snapshots, never projection state.**
 
-The `BroadcastChannel` from `act-sse` maintains an LRU cache seeded from aggregate snapshots. Projections should maintain their own cache to avoid double-apply bugs.
+The `BroadcastChannel` from `@rotorsoft/act-http/sse` maintains an LRU cache seeded from aggregate snapshots. Projections should maintain their own cache to avoid double-apply bugs.
 
 ```typescript
-// Hot path: broadcast from aggregate snapshot (uses act-sse internally)
+// Hot path: broadcast from aggregate snapshot (uses @rotorsoft/act-http/sse internally)
 const snap = await doAction("Update", target, payload);
 broadcastState(streamId, snap);
 

--- a/docs/docs/guides/auto-generated-api.md
+++ b/docs/docs/guides/auto-generated-api.md
@@ -295,6 +295,80 @@ openapi(app, { info, servers, idempotency: true });
 
 Behavior: fresh claim → handler runs, response normal. Duplicate claim → `409 CONFLICT` with `code: "CONFLICT"` and `detail: "Idempotency-Key already used; original result not cached"`. Same shape on tRPC (the procedure throws `CONFLICT`). See the [External integration guide](./external-integration.md) for the surrounding pattern — this is the same `IdempotencyStore` contract that powers receivers.
 
+## Real-time subscriptions
+
+Both `trpc(app, { sse })` and `hono(app, { sse })` accept an optional SSE wiring that walks the registry and emits **one subscription per unique state name**, all reading from a host-supplied `BroadcastChannel`. The host continues to own publication; the generator owns subscription, accounting, cleanup, and the wire format — so the loop you used to hand-write (open SSE response, subscribe to channel, forward patches, manage heartbeat, decrement counter on close) collapses to one option.
+
+```ts
+import { BroadcastChannel } from "@rotorsoft/act-http/sse";
+import { trpc } from "@rotorsoft/act-http/trpc";
+import { hono } from "@rotorsoft/act-http/hono";
+
+const broadcast = new BroadcastChannel<MyState>();
+
+// Server-side: after every app.do(...), publish the derived state.
+const snaps = await app.do(action, target, payload);
+broadcast.publish(
+  target.stream,
+  deriveState(snaps),
+  snaps.map((s) => s.patch).filter(Boolean)
+);
+
+// tRPC — emits one subscription per registered state under
+// `router.subscribe.<stateName>`.
+const router = trpc(app, {
+  actor,
+  stream,
+  sse: { channel: broadcast },
+});
+// Client:
+//   trpc.subscribe.Ticket.useSubscription({ stream: "ticket-42" })
+
+// Hono — emits one streaming `GET /api/sse/<stateName>?stream=<id>`
+// per registered state.
+const api = hono(app, {
+  actor,
+  stream,
+  sse: { channel: broadcast },
+});
+// Client:
+//   new EventSource("/api/sse/Ticket?stream=ticket-42")
+```
+
+### What the generator owns
+
+For every subscription, on every open:
+
+1. Run the `actor` extractor (`401` / `UNAUTHORIZED` on throw).
+2. Acquire one slot on the per-process counter. Full counter →
+   - Hono: `503 / SSE_BUSY` with `Retry-After: 1` (header set **before** the response body starts so it's a clean reject, not a hung stream).
+   - tRPC: `TRPCError({ code: "TOO_MANY_REQUESTS" })`.
+3. Yield `{ kind: "state", data }` once if `channel.get_state(streamId)` has a cached value (re-connect / cold-start affordance — the client doesn't need a separate `getById` query).
+4. Subscribe to the channel for `streamId` and forward every publication as `{ kind: "patch", data }`.
+5. Run a keep-alive ping every `heartbeatMs` (default 30 s). Below the 60 s idle timeout most reverse proxies impose.
+6. Tear down on `iter.return()` / disconnect / abort: unsubscribe, release the slot, clear the heartbeat. The teardown runs from a `finally` block so a crashed handler doesn't leak count.
+
+The shared loop is exported as `runSseSubscription` from `@rotorsoft/act-http/api` for adopters who want to build a different transport (WebSocket, a custom long-poll bridge) on the same accounting + cancellation discipline.
+
+### Defaults and validation
+
+`SseOptions = { channel, maxConnections?, heartbeatMs? }`. Defaults sized for typical business-app dashboards:
+
+| Knob | Default | Range | Why |
+|---|---|---|---|
+| `maxConnections` | `500` | `[1, 10_000]` | Comfortable for hundreds of human viewers; above 10k the FD ceiling and memory force horizontal scaling regardless of tuning. |
+| `heartbeatMs` | `30_000` | `[15_000, 300_000]` | Sub-15s wastes bandwidth on business workloads; above 5 min risks proxy idle drops. |
+
+Out-of-range knobs throw `RangeError` at transport construction — misconfiguration surfaces at startup, not at first connection.
+
+### Why SSE, not WebSocket
+
+Projection patches are one-way (server → client) and rebuildable from the event log — exactly the workload SSE was designed for. SSE rides plain HTTP, traverses corporate proxies cleanly, auto-reconnects on disconnect, needs no protocol upgrade. WebSocket would buy duplex we don't use; long-polling would burn round-trips. The `BroadcastChannel` primitive at `@rotorsoft/act-http/sse` was already shipping this contract — the new generator wiring just lifts it into the auto-generated transport.
+
+### Horizontal scaling
+
+SSE doesn't multiplex across processes. Each worker enforces its own `maxConnections` cap. For deployments where active viewers exceed the per-process ceiling, operators run multiple processes behind a **sticky** load balancer (one subscriber per process, no failover for an open connection) and let the channel publication run per-worker as well. There is no cross-process channel; the `BroadcastChannel` is in-memory.
+
 ## Deployment recipes
 
 The three generators were designed to run on every fetch-shaped runtime. Pick the recipe that matches your shape.

--- a/libs/act-http/README.md
+++ b/libs/act-http/README.md
@@ -235,6 +235,38 @@ The same shared `ApiError` envelope underwrites cross-transport consistency: it'
 
 Output is deterministic given the same registry — entries land in `Object.entries(app.registry.actions)` iteration order. CI can snapshot the result to catch unintended API-surface changes; one merge that quietly changes a Zod schema or adds a new action surfaces as a doc diff in the same PR.
 
+### `trpc` + `hono` SSE subscriptions — live state from the generators
+
+Both generators accept an optional `sse` option that walks the registry once and emits a typed subscription per unique state name, all reading from a host-supplied `BroadcastChannel`. Hosts continue to own publication (`channel.publish(streamId, state, patches)` after each `app.do(...)`); the generators own subscription, accounting, cleanup, and the wire format.
+
+```ts
+import { BroadcastChannel } from "@rotorsoft/act-http/sse";
+import { trpc } from "@rotorsoft/act-http/trpc";
+import { hono } from "@rotorsoft/act-http/hono";
+
+const broadcast = new BroadcastChannel<MyState>();
+
+// Server-side: after every app.do(...), publish the derived state.
+const snaps = await app.do(action, target, payload);
+broadcast.publish(target.stream, deriveState(snaps), snaps.map((s) => s.patch).filter(Boolean));
+
+// tRPC — emits `router.subscribe.<stateName>.useSubscription({ stream })`.
+const router = trpc(app, {
+  actor,
+  stream,
+  sse: { channel: broadcast, maxConnections: 500, heartbeatMs: 30_000 },
+});
+
+// Hono — emits `GET /api/sse/<stateName>?stream=<id>` per registered state.
+const api = hono(app, {
+  actor,
+  stream,
+  sse: { channel: broadcast },
+});
+```
+
+Defaults are sized for typical business-app dashboards: `maxConnections = 500` (range `[1, 10_000]`), `heartbeatMs = 30_000` (range `[15_000, 300_000]`). The 501st concurrent open returns `503 / SSE_BUSY` with `Retry-After: 1` (Hono) or throws `TOO_MANY_REQUESTS` (tRPC). Streams cleaned up via the consumer's `iter.return()` / disconnect both run the loop's `finally` block: unsubscribe from the channel, release the slot, clear the heartbeat. See [@rotorsoft/act-http/sse](#sse--live-state-broadcast) below for the channel/cache primitives this wires.
+
 ### `sse` — live state broadcast
 
 ```ts
@@ -298,7 +330,11 @@ Shared utilities consumed by every transport in the auto-generated API umbrella 
 - **`ERROR_MAP`** — `as const` table mapping framework error types to `{ status, code }`. `ValidationError → 422 / VALIDATION`, `InvariantError → 409 / INVARIANT`, `ConcurrencyError → 412 / CONCURRENCY`, `StreamClosedError → 410 / STREAM_CLOSED`, `NonRetryableError → 400 / NON_RETRYABLE`.
 - **`toApiError(err) → { status, body }`** — the single mapping helper every transport calls in its error boundary. Known framework errors map per `ERROR_MAP`; everything else surfaces as 500 / `INTERNAL` (with `detail` only when the throw was an `Error` — thrown strings or objects don't leak payloads).
 - **`withIdempotency(store, key, handler)`** — wraps an action handler in an `Idempotency-Key` claim. Reuses `@rotorsoft/act-ops/idempotency` — same contract `@rotorsoft/act-http/receiver` already speaks, so one `IdempotencyStore` covers both halves of the "Act over the wire" surface. Returns `{ deduped: false, result }` on fresh claim, `{ deduped: true }` on duplicate (handler is not called).
-- **Types**: `IdempotencyResult<T>`, `ErrorMapEntry`.
+- **`SseOptions`** — `{ channel: BroadcastChannel<S>, maxConnections?, heartbeatMs? }`. Shared SSE wiring options consumed by both `trpc(app, { sse })` and `hono(app, { sse })`. Defaults: `maxConnections=500` (validated `[1, 10_000]`), `heartbeatMs=30_000` (validated `[15_000, 300_000]`). Out-of-range values throw `RangeError` at transport construction so misconfiguration surfaces at startup, not at first connection.
+- **`SseConnectionCounter`** — per-process slot counter. The 501st concurrent open is refused (`503 / SSE_BUSY` with `Retry-After: 1` on Hono, `TOO_MANY_REQUESTS` on tRPC). Internal — both transports construct one each, shared by every state-name's subscription on a single generator instance.
+- **`runSseSubscription(channel, streamId, accounting?, signal?, on_cap_exceeded?)`** — the shared subscription loop both transports run. Acquires one slot (when an `accounting` is supplied), yields the cached state if present, then forwards every channel publication as a `{ kind: "patch", data }` frame until the consumer breaks or the signal aborts. Used internally; exported for adopters who want to build their own transport surface against the same accounting / cancellation discipline.
+- **`resolveSseConfig(options)`** + **`DEFAULT_SSE_HEARTBEAT_MS`** / **`DEFAULT_SSE_MAX_CONNECTIONS`** — validation helper and exposed defaults.
+- **Types**: `IdempotencyResult<T>`, `ErrorMapEntry`, `SseConfig`, `SseAccounting`, `SseSubscriptionFrame<S>`.
 
 ### `/trpc` subpath
 
@@ -306,7 +342,7 @@ Auto-generated tRPC router for the act-http-api epic (#835).
 
 - **`trpc(app, options) → Router`** — generator function. Walks `app.registry.actions` once and emits a flat top-level mutation per action. Each procedure runs the internal `authenticated(options.actor)` middleware (so `ctx.actor: Actor` is set on the downstream context), resolves the target stream via `options.stream(action, input, ctx)`, and calls `app.do(action, { stream, actor }, input)`. Known framework errors map through `toApiError` to the conventional tRPC codes; unknown throws surface as `INTERNAL_SERVER_ERROR`.
 - **`authenticated(extractor) → middleware`** — standalone export of the auth middleware the generator uses internally. Hosts composing their own procedure chain (logging + tracing + custom auth flavors) use `t.procedure.use(authenticated(extractor))` to inject `ctx.actor` without going through the generator. The middleware is structurally-typed so any host `t` instance accepts it.
-- **`TrpcOptions<Ctx>`** — `{ actor, stream, expectedVersion?, idempotency? }`. `actor` is the `ActorExtractor` from `@rotorsoft/act-http/api`. `stream` returns the target stream per call. `expectedVersion` is optional — `(action, input, ctx) => number | undefined` — when set, the procedure threads the resolved value through `Target.expectedVersion` so `app.do` enforces optimistic concurrency; hosts typically read it from an `If-Match` header or the client's last-known snapshot, and returning `undefined` skips the check for that call. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom: (ctx) => string | undefined }` — when set, the procedure honors `Idempotency-Key` via `withIdempotency`. Duplicate claims throw `CONFLICT` (the contract intentionally doesn't cache the original handler's result).
+- **`TrpcOptions<Ctx>`** — `{ actor, stream, expectedVersion?, idempotency?, sse? }`. `actor` is the `ActorExtractor` from `@rotorsoft/act-http/api`. `stream` returns the target stream per call. `expectedVersion` is optional — `(action, input, ctx) => number | undefined` — when set, the procedure threads the resolved value through `Target.expectedVersion` so `app.do` enforces optimistic concurrency; hosts typically read it from an `If-Match` header or the client's last-known snapshot, and returning `undefined` skips the check for that call. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom: (ctx) => string | undefined }` — when set, the procedure honors `Idempotency-Key` via `withIdempotency`. Duplicate claims throw `CONFLICT` (the contract intentionally doesn't cache the original handler's result). `sse` is optional — when set, the generator emits one subscription per unique registered state name under the nested `router.subscribe.<stateName>` namespace; each yields `{ kind: "state", data }` once (when the channel has a cached state) and then `{ kind: "patch", data }` per channel publication until the consumer breaks. The cap surfaces as `TOO_MANY_REQUESTS`.
 
 ### `/hono` subpath
 
@@ -314,7 +350,7 @@ Auto-generated REST surface for the act-http-api epic (#835).
 
 - **`hono(app, options) → Hono`** — generator function. Walks `app.registry.actions` once and registers a `POST /actions/<actionName>` per action under `basePath` (default `/api`). Body is validated with `@hono/zod-validator` against the action's Zod schema; failures short-circuit with `400`. The internal `authenticated(options.actor)` middleware stashes the resolved `Actor` under `c.get("actor")`. Routes return `200 Snapshot[]` on success, `4xx ApiError` envelope (with the conventional HTTP status) on framework errors, `500 / INTERNAL` on unknown throws.
 - **`authenticated(extractor) → MiddlewareHandler`** — standalone export of the auth middleware the generator uses internally. Hosts composing their own Hono chain wire `api.use("*", authenticated(extractor))` and downstream routes read `c.get("actor"): Actor`. Errors thrown by the extractor surface as `401 / UNAUTHORIZED`.
-- **`HonoOptions`** — `{ actor, stream, expectedVersion?, idempotency?, basePath? }`. `actor` is the `ActorExtractor`. `stream` returns the target stream per call. `expectedVersion` threads `Target.expectedVersion` for optimistic concurrency — returning `undefined` skips the check. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom?: (c) => string | undefined }` — when set, the route honors `Idempotency-Key` via `withIdempotency`; default `keyFrom` reads the `Idempotency-Key` header. Duplicate claims return `409 / CONFLICT`. `basePath` defaults to `/api`.
+- **`HonoOptions`** — `{ actor, stream, expectedVersion?, idempotency?, sse?, basePath? }`. `actor` is the `ActorExtractor`. `stream` returns the target stream per call. `expectedVersion` threads `Target.expectedVersion` for optimistic concurrency — returning `undefined` skips the check. `idempotency` is optional — `{ store: IdempotencyStore; keyFrom?: (c) => string | undefined }` — when set, the route honors `Idempotency-Key` via `withIdempotency`; default `keyFrom` reads the `Idempotency-Key` header. Duplicate claims return `409 / CONFLICT`. `sse` is optional — when set, the generator emits one `GET <basePath>/sse/<stateName>?stream=<id>` route per unique registered state name; each route opens a `text/event-stream`, yields the cached state (`event: state`) when present, then forwards every channel publication as `event: patch`. The connection cap surfaces as `503 / SSE_BUSY` with `Retry-After: 1`. A heartbeat ping every `heartbeatMs` keeps proxies from idling the connection out. `basePath` defaults to `/api`.
 - **`ActMiddlewareVariables`** — `{ actor: Actor }`. Use as the `Variables` generic on a host Hono instance to get `c.get("actor")` typed downstream of `authenticated`.
 
 ### `/openapi` subpath

--- a/libs/act-http/src/api/index.ts
+++ b/libs/act-http/src/api/index.ts
@@ -45,6 +45,7 @@ export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
 export {
   DEFAULT_SSE_HEARTBEAT_MS,
   DEFAULT_SSE_MAX_CONNECTIONS,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   type SseAccounting,

--- a/libs/act-http/src/api/index.ts
+++ b/libs/act-http/src/api/index.ts
@@ -42,3 +42,14 @@ export {
   toApiError,
 } from "./errors.js";
 export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
+export {
+  DEFAULT_SSE_HEARTBEAT_MS,
+  DEFAULT_SSE_MAX_CONNECTIONS,
+  resolveSseConfig,
+  runSseSubscription,
+  type SseAccounting,
+  type SseConfig,
+  SseConnectionCounter,
+  type SseOptions,
+  type SseSubscriptionFrame,
+} from "./sse-wiring.js";

--- a/libs/act-http/src/api/sse-wiring.ts
+++ b/libs/act-http/src/api/sse-wiring.ts
@@ -165,6 +165,21 @@ export class SseConnectionCounter {
 }
 
 /**
+ * Wrap a fire-and-forget Promise-returning operation so its
+ * rejection is swallowed in place of leaking an unhandled
+ * rejection. Used by the Hono heartbeat tick (the interval callback
+ * isn't `await`ed, so its rejection has nowhere to go) and by any
+ * other "best-effort write" the transports run.
+ *
+ * Pure: same input → same output, no side effects on the caller.
+ * Returns the chained Promise so the caller can also `await`
+ * completion if they want to (the Hono heartbeat doesn't).
+ */
+export function fireAndForget<T>(op: () => Promise<T>): Promise<T | undefined> {
+  return op().catch(() => undefined);
+}
+
+/**
  * Frame yielded by the per-state SSE subscription generator. The
  * initial cached state (when present) arrives as `kind: "state"`;
  * every subsequent broadcast publication arrives as `kind: "patch"`

--- a/libs/act-http/src/api/sse-wiring.ts
+++ b/libs/act-http/src/api/sse-wiring.ts
@@ -1,0 +1,241 @@
+import type { BroadcastChannel } from "../sse/broadcast.js";
+import type { BroadcastState } from "../sse/types.js";
+
+/**
+ * SSE wiring options shared by the auto-generated `trpc` and `hono`
+ * transports. When supplied, each transport emits one streaming
+ * subscription per registered state name, all reading from the same
+ * host-supplied {@link BroadcastChannel}.
+ *
+ * The host owns publication: every `app.do(...)` call site must
+ * forward the resulting snapshots to `channel.publish(...)` for
+ * subscribers to see updates. The framework deliberately doesn't
+ * auto-publish because the derived state usually needs app-specific
+ * overlays (presence, computed fields) that only the host can supply.
+ *
+ * Defaults are sized for typical business-app dashboards (dozens to
+ * hundreds of human viewers per process). Both numeric knobs are
+ * validated at transport-function construction; out-of-range values
+ * throw `RangeError` immediately so misconfiguration surfaces at
+ * startup instead of at first connection.
+ */
+export type SseOptions = {
+  /**
+   * The {@link BroadcastChannel} the generator's subscriptions hook
+   * into. Host owns its lifecycle; the generator does not construct
+   * one for you because the channel's `<S>` shape is app-specific and
+   * passing it in keeps the type chain typed end-to-end at the host.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the generator — narrowing it would force every state into one structural bound that doesn't fit real apps
+  readonly channel: BroadcastChannel<any>;
+  /**
+   * Hard cap on concurrent open subscriptions per generator
+   * instance. The 501st simultaneous open returns `503` (Hono) or
+   * throws `TOO_MANY_REQUESTS` (tRPC) — never a silent stall.
+   *
+   * Default `500`. Validated range `[1, 10_000]`. Above 10k the
+   * framework refuses to construct: at that point the FD ceiling
+   * and per-connection memory force horizontal scaling regardless
+   * of tuning, so the right move is sticky LB + per-process cap,
+   * not a higher single-process limit.
+   */
+  readonly maxConnections?: number;
+  /**
+   * Keep-alive cadence in milliseconds. Most reverse proxies idle
+   * connections out after ~60 seconds; the default `30_000` stays
+   * comfortably under.
+   *
+   * Validated range `[15_000, 300_000]`. Under 15 s wastes
+   * bandwidth on a business workload; over 5 min risks proxy drops.
+   */
+  readonly heartbeatMs?: number;
+};
+
+/**
+ * Resolved SSE configuration after validation and default expansion.
+ * Internal — the resolved values are what every transport actually
+ * runs against.
+ *
+ * @internal
+ */
+export type SseConfig = {
+  readonly channel: BroadcastChannel<BroadcastState>;
+  readonly maxConnections: number;
+  readonly heartbeatMs: number;
+};
+
+/**
+ * Default cap on concurrent open subscriptions per generator
+ * instance. Sized for typical business-app dashboards (dozens to a
+ * few hundred viewers); high enough not to surprise small
+ * deployments, low enough not to mask a missing horizontal-scale
+ * strategy on big ones.
+ */
+export const DEFAULT_SSE_MAX_CONNECTIONS = 500;
+
+/**
+ * Default keep-alive cadence (30 s). Sits comfortably under the
+ * 60 s idle timeout most reverse proxies impose.
+ */
+export const DEFAULT_SSE_HEARTBEAT_MS = 30_000;
+
+const MAX_CONNECTIONS_MIN = 1;
+const MAX_CONNECTIONS_MAX = 10_000;
+const HEARTBEAT_MS_MIN = 15_000;
+const HEARTBEAT_MS_MAX = 300_000;
+
+/**
+ * Validate and apply defaults to host-supplied {@link SseOptions}.
+ *
+ * Throws `RangeError` when either numeric knob is outside its
+ * documented range. Pure: same input → same output, no side
+ * effects, no I/O. Each transport calls this once at the start of
+ * `hono(...)` / `trpc(...)`.
+ */
+export function resolveSseConfig(options: SseOptions): SseConfig {
+  const max_connections = options.maxConnections ?? DEFAULT_SSE_MAX_CONNECTIONS;
+  const heartbeat_ms = options.heartbeatMs ?? DEFAULT_SSE_HEARTBEAT_MS;
+  if (
+    !Number.isFinite(max_connections) ||
+    max_connections < MAX_CONNECTIONS_MIN ||
+    max_connections > MAX_CONNECTIONS_MAX
+  ) {
+    throw new RangeError(
+      `sse.maxConnections must be in [${MAX_CONNECTIONS_MIN}, ${MAX_CONNECTIONS_MAX}], got ${max_connections}`
+    );
+  }
+  if (
+    !Number.isFinite(heartbeat_ms) ||
+    heartbeat_ms < HEARTBEAT_MS_MIN ||
+    heartbeat_ms > HEARTBEAT_MS_MAX
+  ) {
+    throw new RangeError(
+      `sse.heartbeatMs must be in [${HEARTBEAT_MS_MIN}, ${HEARTBEAT_MS_MAX}], got ${heartbeat_ms}`
+    );
+  }
+  return {
+    channel: options.channel,
+    maxConnections: max_connections,
+    heartbeatMs: heartbeat_ms,
+  };
+}
+
+/**
+ * Per-generator concurrent-open counter. Constructed once inside
+ * `hono(...)` / `trpc(...)` and consulted at every subscription
+ * open: failure to acquire means the cap has been hit and the
+ * transport reports `503` / `TOO_MANY_REQUESTS` to the caller.
+ *
+ * The counter is intentionally process-local. SSE doesn't multiplex
+ * across processes; operators wanting more than `maxConnections`
+ * viewers run multiple processes behind a sticky load balancer.
+ */
+export class SseConnectionCounter {
+  public readonly limit: number;
+  private _open = 0;
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  /**
+   * Reserve one slot. Returns `true` when accepted (caller must
+   * eventually {@link release} the slot, even on error paths) or
+   * `false` when the cap is already reached.
+   */
+  acquire(): boolean {
+    if (this._open >= this.limit) return false;
+    this._open++;
+    return true;
+  }
+
+  /**
+   * Free a previously-{@link acquire}d slot. Always runs from a
+   * `finally` block in the transport's subscription handler so
+   * crashed handlers don't leak count.
+   */
+  release(): void {
+    if (this._open > 0) this._open--;
+  }
+
+  /** Currently-open count. Test/observability hook. */
+  get open(): number {
+    return this._open;
+  }
+}
+
+/**
+ * Frame yielded by the per-state SSE subscription generator. The
+ * initial cached state (when present) arrives as `kind: "state"`;
+ * every subsequent broadcast publication arrives as `kind: "patch"`
+ * with the channel's `PatchMessage` payload.
+ */
+export type SseSubscriptionFrame<S> =
+  | { readonly kind: "state"; readonly data: S }
+  | { readonly kind: "patch"; readonly data: unknown };
+
+/**
+ * Subscription accounting hook. Implementations have a chance to
+ * acquire a slot before the loop starts and to release it once the
+ * loop's `finally` block runs — used by the tRPC side to enforce
+ * `maxConnections` from inside the generator, where it can throw
+ * `TRPCError` cleanly. Hono enforces the cap outside the loop (so a
+ * full counter returns `503` *before* streamSSE writes headers), then
+ * passes `undefined` here.
+ */
+export type SseAccounting = {
+  acquire(): boolean;
+  release(): void;
+};
+
+/**
+ * The shared subscription loop both transports run. Optionally
+ * acquires one slot on the supplied {@link SseAccounting}, yields the
+ * cached state (when present), then forwards every channel
+ * publication as a `kind: "patch"` frame until either the consumer
+ * breaks (calling `iter.return()`) or the supplied abort signal fires.
+ *
+ * Exported as the testable seam — the Hono and tRPC sibling
+ * generators wrap this so the signal-driven cleanup and counter
+ * accounting live in one place.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the loop — narrowing it would force every state into one structural bound that doesn't fit real apps
+export async function* runSseSubscription<S extends { _v: number } = any>(
+  channel: BroadcastChannel<S>,
+  stream_id: string,
+  accounting: SseAccounting | undefined,
+  signal: AbortSignal | undefined,
+  on_cap_exceeded?: () => never
+): AsyncGenerator<SseSubscriptionFrame<S>> {
+  if (accounting && !accounting.acquire() && on_cap_exceeded) {
+    on_cap_exceeded();
+  }
+  const pending: unknown[] = [];
+  let resolve_wait: (() => void) | null = null;
+  const unsubscribe = channel.subscribe(stream_id, (msg) => {
+    pending.push(msg);
+    resolve_wait?.();
+  });
+  const on_abort = () => resolve_wait?.();
+  signal?.addEventListener("abort", on_abort);
+  try {
+    const cached = channel.get_state(stream_id);
+    if (cached !== undefined) {
+      yield { kind: "state", data: cached };
+    }
+    while (!signal?.aborted) {
+      if (pending.length === 0) {
+        await new Promise<void>((resolve) => {
+          resolve_wait = resolve;
+        });
+        if (signal?.aborted) break;
+      }
+      const msg = pending.shift();
+      yield { kind: "patch", data: msg };
+    }
+  } finally {
+    signal?.removeEventListener("abort", on_abort);
+    unsubscribe();
+    accounting?.release();
+  }
+}

--- a/libs/act-http/src/hono/index.ts
+++ b/libs/act-http/src/hono/index.ts
@@ -54,6 +54,7 @@ import { streamSSE } from "hono/streaming";
 import {
   type ActorExtractor,
   type ApiError,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   SseConnectionCounter,
@@ -282,9 +283,9 @@ export function hono<TApp extends ActSurface = ActSurface>(
         return streamSSE(c, async (sse_stream) => {
           sse_stream.onAbort(() => controller.abort());
           const heartbeat = setInterval(() => {
-            sse_stream
-              .writeSSE({ event: "ping", data: "" })
-              .catch(() => undefined);
+            fireAndForget(() =>
+              sse_stream.writeSSE({ event: "ping", data: "" })
+            );
           }, sse_config.heartbeatMs);
           try {
             for await (const frame of runSseSubscription(

--- a/libs/act-http/src/hono/index.ts
+++ b/libs/act-http/src/hono/index.ts
@@ -50,9 +50,14 @@ import type { Actor, Target } from "@rotorsoft/act";
 import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
 import type { Context, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import {
   type ActorExtractor,
   type ApiError,
+  resolveSseConfig,
+  runSseSubscription,
+  SseConnectionCounter,
+  type SseOptions,
   toApiError,
   withIdempotency,
 } from "../api/index.js";
@@ -109,6 +114,23 @@ export type HonoOptions = {
     readonly store: IdempotencyStore;
     readonly keyFrom?: (c: Context) => string | undefined;
   };
+  /**
+   * Optional SSE wiring. When set, the generator emits one
+   * `GET <basePath>/sse/<stateName>?stream=<streamId>` per unique
+   * state name in the registry. The endpoint runs the host
+   * {@link actor} extractor, looks up the streamId from
+   * `?stream=...`, opens a `text/event-stream`, yields the cached
+   * state (if any), and forwards every patch published to the
+   * shared {@link SseOptions.channel}. A heartbeat keeps proxies
+   * from idling the connection out; the per-process connection cap
+   * returns `503 Service Unavailable` (with `Retry-After: 1`) when
+   * full so operators never see silent stalls.
+   *
+   * Off by default — most APIs don't expose live state to every
+   * client, and opening one is widening both the auth and cost
+   * surface.
+   */
+  readonly sse?: SseOptions;
   readonly basePath?: string;
 };
 
@@ -219,6 +241,71 @@ export function hono<TApp extends ActSurface = ActSurface>(
   api.use("*", authenticated(options.actor));
 
   const key_from = options.idempotency?.keyFrom ?? default_key_from;
+
+  // Wire SSE subscriptions before the mutation routes so the
+  // `/sse/*` paths sit alongside `/actions/*`. The cap counter is
+  // shared by every state-name's GET route on this generator
+  // instance so a noisy room on one state doesn't get a free pass
+  // on another.
+  if (options.sse) {
+    const sse_config = resolveSseConfig(options.sse);
+    const sse_counter = new SseConnectionCounter(sse_config.maxConnections);
+    const state_names = new Set<string>();
+    for (const action of Object.values(app.registry.actions)) {
+      state_names.add(action.name);
+    }
+    for (const state_name of state_names) {
+      api.get(`/sse/${state_name}`, async (c) => {
+        const stream_id = c.req.query("stream");
+        if (!stream_id) {
+          const body: ApiError = {
+            error: "BadRequest",
+            detail: "stream query parameter is required",
+            code: "BAD_REQUEST",
+          };
+          return c.json(body, 400);
+        }
+        if (!sse_counter.acquire()) {
+          c.header("Retry-After", "1");
+          const body: ApiError = {
+            error: "ServiceUnavailable",
+            detail: "max concurrent SSE connections reached",
+            code: "SSE_BUSY",
+          };
+          return c.json(body, 503);
+        }
+        // The route already acquired the slot above so streamSSE
+        // could return `503` before writing headers if the cap was
+        // full. The shared loop runs without accounting; the route
+        // releases the slot in `finally`.
+        const controller = new AbortController();
+        return streamSSE(c, async (sse_stream) => {
+          sse_stream.onAbort(() => controller.abort());
+          const heartbeat = setInterval(() => {
+            sse_stream
+              .writeSSE({ event: "ping", data: "" })
+              .catch(() => undefined);
+          }, sse_config.heartbeatMs);
+          try {
+            for await (const frame of runSseSubscription(
+              sse_config.channel,
+              stream_id,
+              undefined,
+              controller.signal
+            )) {
+              await sse_stream.writeSSE({
+                event: frame.kind,
+                data: JSON.stringify(frame.data),
+              });
+            }
+          } finally {
+            clearInterval(heartbeat);
+            sse_counter.release();
+          }
+        });
+      });
+    }
+  }
 
   for (const [action_name, state] of Object.entries(app.registry.actions)) {
     const schema = state.actions[action_name];

--- a/libs/act-http/src/trpc/index.ts
+++ b/libs/act-http/src/trpc/index.ts
@@ -60,8 +60,13 @@ import {
   type TRPCBuiltRouter,
   TRPCError,
 } from "@trpc/server";
+import { z } from "zod";
 import {
   type ActorExtractor,
+  resolveSseConfig,
+  runSseSubscription,
+  SseConnectionCounter,
+  type SseOptions,
   toApiError,
   withIdempotency,
 } from "../api/index.js";
@@ -115,6 +120,22 @@ export type TrpcOptions<Ctx> = {
     readonly store: IdempotencyStore;
     readonly keyFrom: (ctx: Ctx) => string | undefined;
   };
+  /**
+   * Optional SSE wiring. When set, the generator emits one
+   * subscription per unique state name in the registry, grouped on
+   * the returned router as
+   * `router.subscribe.<stateName>.useSubscription({ stream })`.
+   * Each subscription yields `{ kind: "state", data }` once with
+   * the cached state (when present) and then `{ kind: "patch",
+   * data }` for every patch the shared
+   * {@link SseOptions.channel} publishes. The per-process
+   * connection cap surfaces as a `TOO_MANY_REQUESTS` `TRPCError`.
+   *
+   * Off by default — most APIs don't expose live state to every
+   * client, and opening one is widening both the auth and cost
+   * surface.
+   */
+  readonly sse?: SseOptions;
 };
 
 /**
@@ -362,6 +383,35 @@ export function trpc<
           throw to_trpc_error(err);
         }
       });
+  }
+
+  if (options.sse) {
+    const sse_config = resolveSseConfig(options.sse);
+    const sse_counter = new SseConnectionCounter(sse_config.maxConnections);
+    const state_names = new Set<string>();
+    for (const action of Object.values(app.registry.actions)) {
+      state_names.add(action.name);
+    }
+    const sse_handlers: Record<string, unknown> = {};
+    for (const state_name of state_names) {
+      sse_handlers[state_name] = t.procedure
+        .input(z.object({ stream: z.string().min(1) }))
+        .subscription(({ input, signal }) =>
+          runSseSubscription(
+            sse_config.channel,
+            input.stream,
+            sse_counter,
+            signal,
+            () => {
+              throw new TRPCError({
+                code: "TOO_MANY_REQUESTS",
+                message: "max concurrent SSE subscriptions reached",
+              });
+            }
+          )
+        );
+    }
+    handlers.subscribe = t.router(sse_handlers as never) as never;
   }
 
   // The runtime router IS structurally compatible with

--- a/libs/act-http/test/api/sse-wiring.spec.ts
+++ b/libs/act-http/test/api/sse-wiring.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SSE_HEARTBEAT_MS,
+  DEFAULT_SSE_MAX_CONNECTIONS,
+  resolveSseConfig,
+  runSseSubscription,
+  SseConnectionCounter,
+  type SseSubscriptionFrame,
+} from "../../src/api/sse-wiring.js";
+import { BroadcastChannel } from "../../src/sse/index.js";
+
+describe("resolveSseConfig", () => {
+  const channel = new BroadcastChannel();
+
+  it("applies defaults when knobs are omitted", () => {
+    const cfg = resolveSseConfig({ channel });
+    expect(cfg.channel).toBe(channel);
+    expect(cfg.maxConnections).toBe(DEFAULT_SSE_MAX_CONNECTIONS);
+    expect(cfg.heartbeatMs).toBe(DEFAULT_SSE_HEARTBEAT_MS);
+  });
+
+  it("preserves caller-supplied knobs", () => {
+    const cfg = resolveSseConfig({
+      channel,
+      maxConnections: 100,
+      heartbeatMs: 60_000,
+    });
+    expect(cfg.maxConnections).toBe(100);
+    expect(cfg.heartbeatMs).toBe(60_000);
+  });
+
+  it("rejects maxConnections below the floor", () => {
+    expect(() => resolveSseConfig({ channel, maxConnections: 0 })).toThrow(
+      RangeError
+    );
+  });
+
+  it("rejects maxConnections above the ceiling", () => {
+    expect(() => resolveSseConfig({ channel, maxConnections: 10_001 })).toThrow(
+      RangeError
+    );
+  });
+
+  it("rejects non-finite maxConnections (NaN/Infinity)", () => {
+    expect(() =>
+      resolveSseConfig({ channel, maxConnections: Number.NaN })
+    ).toThrow(RangeError);
+    expect(() =>
+      resolveSseConfig({ channel, maxConnections: Number.POSITIVE_INFINITY })
+    ).toThrow(RangeError);
+  });
+
+  it("rejects heartbeatMs below the floor", () => {
+    expect(() => resolveSseConfig({ channel, heartbeatMs: 14_999 })).toThrow(
+      RangeError
+    );
+  });
+
+  it("rejects heartbeatMs above the ceiling", () => {
+    expect(() => resolveSseConfig({ channel, heartbeatMs: 300_001 })).toThrow(
+      RangeError
+    );
+  });
+
+  it("rejects non-finite heartbeatMs", () => {
+    expect(() =>
+      resolveSseConfig({ channel, heartbeatMs: Number.NaN })
+    ).toThrow(RangeError);
+  });
+});
+
+describe("SseConnectionCounter", () => {
+  it("acquires up to the limit, then refuses", () => {
+    const counter = new SseConnectionCounter(2);
+    expect(counter.acquire()).toBe(true);
+    expect(counter.acquire()).toBe(true);
+    expect(counter.acquire()).toBe(false);
+    expect(counter.open).toBe(2);
+  });
+
+  it("release frees a slot", () => {
+    const counter = new SseConnectionCounter(1);
+    expect(counter.acquire()).toBe(true);
+    expect(counter.acquire()).toBe(false);
+    counter.release();
+    expect(counter.open).toBe(0);
+    expect(counter.acquire()).toBe(true);
+  });
+
+  it("release below zero is a no-op (defensive)", () => {
+    const counter = new SseConnectionCounter(1);
+    counter.release(); // never acquired
+    counter.release();
+    expect(counter.open).toBe(0);
+  });
+});
+
+describe("runSseSubscription", () => {
+  type S = { _v: number; n: number };
+
+  /**
+   * Drain up to `count` frames from the generator. Resolves whatever
+   * arrives before either the count is met or the generator
+   * completes. Always returns the generator to its `finally` block.
+   */
+  async function take(
+    gen: AsyncGenerator<SseSubscriptionFrame<S>>,
+    count: number
+  ): Promise<SseSubscriptionFrame<S>[]> {
+    const frames: SseSubscriptionFrame<S>[] = [];
+    for await (const frame of gen) {
+      frames.push(frame);
+      if (frames.length >= count) break;
+    }
+    return frames;
+  }
+
+  it("yields cached state first, then patches as they publish", async () => {
+    const channel = new BroadcastChannel<S>();
+    channel.publish("k", { _v: 1, n: 1 }, [{ n: 1 }]);
+    const counter = new SseConnectionCounter(5);
+    const gen = runSseSubscription(channel, "k", counter, undefined);
+
+    setTimeout(() => channel.publish("k", { _v: 2, n: 2 }, [{ n: 2 }]), 10);
+    const frames = await take(gen, 2);
+    expect(frames[0]).toMatchObject({ kind: "state", data: { _v: 1 } });
+    expect(frames[1]).toMatchObject({ kind: "patch" });
+    expect(counter.open).toBe(0);
+  });
+
+  it("calls on_cap_exceeded when the counter is full", () => {
+    const channel = new BroadcastChannel<S>();
+    const counter = new SseConnectionCounter(0);
+    const gen = runSseSubscription(channel, "k", counter, undefined, () => {
+      throw new Error("cap");
+    });
+    return expect(gen.next()).rejects.toThrow(/cap/);
+  });
+
+  it("aborting the signal during the wait drains the loop", async () => {
+    const channel = new BroadcastChannel<S>();
+    channel.publish("k", { _v: 1, n: 1 }, [{ n: 1 }]);
+    const counter = new SseConnectionCounter(1);
+    const ctrl = new AbortController();
+    const gen = runSseSubscription(channel, "k", counter, ctrl.signal);
+
+    const first = await gen.next();
+    expect(first.value).toMatchObject({ kind: "state" });
+    // The loop is now awaiting the next publish — abort releases it
+    // and the if-aborted check breaks the loop, running the finally.
+    setTimeout(() => ctrl.abort(), 5);
+    const drained = await gen.next();
+    expect(drained.done).toBe(true);
+    expect(counter.open).toBe(0);
+  });
+
+  it("skips the cached-state yield when no state has been published", async () => {
+    const channel = new BroadcastChannel<S>();
+    const counter = new SseConnectionCounter(1);
+    const gen = runSseSubscription(channel, "k", counter, undefined);
+    setTimeout(() => channel.publish("k", { _v: 1, n: 1 }, [{ n: 1 }]), 5);
+    const frames = await take(gen, 1);
+    expect(frames[0]).toMatchObject({ kind: "patch" });
+    expect(counter.open).toBe(0);
+  });
+
+  it("releases the counter even when the consumer breaks early", async () => {
+    const channel = new BroadcastChannel<S>();
+    channel.publish("k", { _v: 1, n: 1 }, [{ n: 1 }]);
+    const counter = new SseConnectionCounter(1);
+    const gen = runSseSubscription(channel, "k", counter, undefined);
+    const first = await gen.next();
+    expect(first.value).toMatchObject({ kind: "state" });
+    // Caller bails out without iterating further.
+    await gen.return(undefined);
+    expect(counter.open).toBe(0);
+  });
+});

--- a/libs/act-http/test/api/sse-wiring.spec.ts
+++ b/libs/act-http/test/api/sse-wiring.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SSE_HEARTBEAT_MS,
   DEFAULT_SSE_MAX_CONNECTIONS,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   SseConnectionCounter,
@@ -95,6 +96,26 @@ describe("SseConnectionCounter", () => {
   });
 });
 
+describe("fireAndForget", () => {
+  it("resolves to the op's value on success", async () => {
+    const out = await fireAndForget(() => Promise.resolve(42));
+    expect(out).toBe(42);
+  });
+
+  it("swallows rejection and resolves to undefined", async () => {
+    const out = await fireAndForget(() => Promise.reject(new Error("closed")));
+    expect(out).toBeUndefined();
+  });
+
+  it("doesn't leak an unhandled rejection when the caller drops the result", async () => {
+    // Intentionally do not await — fireAndForget should still
+    // attach the .catch so Node's unhandled-rejection hook stays quiet.
+    fireAndForget(() => Promise.reject(new Error("dropped")));
+    // Give microtasks a chance to settle.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+});
+
 describe("runSseSubscription", () => {
   type S = { _v: number; n: number };
 
@@ -161,6 +182,24 @@ describe("runSseSubscription", () => {
     setTimeout(() => channel.publish("k", { _v: 1, n: 1 }, [{ n: 1 }]), 5);
     const frames = await take(gen, 1);
     expect(frames[0]).toMatchObject({ kind: "patch" });
+    expect(counter.open).toBe(0);
+  });
+
+  it("drains queued patches without re-awaiting when multiple arrive between yields", async () => {
+    const channel = new BroadcastChannel<S>();
+    const counter = new SseConnectionCounter(5);
+    const gen = runSseSubscription(channel, "k", counter, undefined);
+    // Two synchronous publications — both queue before the consumer
+    // can pull the first. The second-iteration `pending.length === 0`
+    // check goes false, so the loop skips the await and shifts the
+    // already-queued patch out without re-arming `resolve_wait`.
+    setTimeout(() => {
+      channel.publish("k", { _v: 1, n: 1 }, [{ n: 1 }]);
+      channel.publish("k", { _v: 2, n: 2 }, [{ n: 2 }]);
+    }, 5);
+    const frames = await take(gen, 2);
+    expect(frames[0]).toMatchObject({ kind: "patch" });
+    expect(frames[1]).toMatchObject({ kind: "patch" });
     expect(counter.open).toBe(0);
   });
 

--- a/libs/act-http/test/hono/sse.spec.ts
+++ b/libs/act-http/test/hono/sse.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * SSE wiring on the auto-generated Hono surface (#846). Covers the
+ * subscription-open / cached-state / patch / disconnect lifecycle
+ * plus the error paths the cap counter and missing-stream guard
+ * produce. Run end-to-end through `app.request()` so no live server
+ * is needed.
+ */
+import { act, state, ZodEmpty } from "@rotorsoft/act";
+import { fixture } from "@rotorsoft/act/test";
+import { describe, expect, vi } from "vitest";
+import { z } from "zod";
+import { type HonoOptions, hono } from "../../src/hono/index.js";
+import { BroadcastChannel } from "../../src/sse/index.js";
+
+const Calculator = state({
+  Calculator: z.object({ display: z.string() }),
+})
+  .init(() => ({ display: "" }))
+  .emits({
+    KeyPressed: z.object({ key: z.string() }),
+    Cleared: ZodEmpty,
+  })
+  .patch({
+    KeyPressed: ({ data }, s) => ({ display: s.display + data.key }),
+    Cleared: () => ({ display: "" }),
+  })
+  .on({ PressKey: z.object({ key: z.string().min(1) }) })
+  .emit((a) => ["KeyPressed", { key: a.key }])
+  .on({ Clear: ZodEmpty })
+  .emit(() => ["Cleared", {}])
+  .build();
+
+const Ticket = state({
+  Ticket: z.object({ title: z.string() }),
+})
+  .init(() => ({ title: "" }))
+  .emits({ TicketOpened: z.object({ title: z.string() }) })
+  .patch({ TicketOpened: ({ data }) => ({ title: data.title }) })
+  .on({ OpenTicket: z.object({ title: z.string() }) })
+  .emit((a) => ["TicketOpened", { title: a.title }])
+  .build();
+
+const builder = act().withState(Calculator).withState(Ticket);
+const test = fixture(builder);
+
+// biome-ignore lint/suspicious/noExplicitAny: tests intentionally use a wide channel shape so the helper composes with empty and typed states alike
+const default_options = (channel: BroadcastChannel<any>): HonoOptions => ({
+  actor: () => ({ id: "u-1", name: "alice" }),
+  stream: () => "calc-1",
+  sse: { channel },
+});
+
+/**
+ * Drain SSE frames from a streamed `Response`. Resolves on the first
+ * `expected` event names that arrive, or rejects after `timeoutMs`
+ * if the stream is too slow / blocked. Closes the underlying reader
+ * before returning so the server-side stream sees a disconnect.
+ */
+async function read_sse_frames(
+  res: Response,
+  expected: ReadonlyArray<string>,
+  timeoutMs = 1000
+): Promise<{ event: string; data: string }[]> {
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error("response has no body");
+  const decoder = new TextDecoder();
+  const frames: { event: string; data: string }[] = [];
+  let buffer = "";
+  const deadline = Date.now() + timeoutMs;
+
+  try {
+    while (frames.length < expected.length) {
+      if (Date.now() > deadline) {
+        throw new Error(
+          `timed out waiting for SSE frames; got ${frames
+            .map((f) => f.event)
+            .join(",")}, expected ${expected.join(",")}`
+        );
+      }
+      const read_result = await Promise.race([
+        reader.read(),
+        new Promise<{ done: true; value: undefined }>((resolve) =>
+          setTimeout(() => resolve({ done: true, value: undefined }), 50)
+        ),
+      ]);
+      if (read_result.done) continue;
+      buffer += decoder.decode(read_result.value, { stream: true });
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        const lines = part.split("\n");
+        let event = "message";
+        let data = "";
+        for (const line of lines) {
+          if (line.startsWith("event:")) event = line.slice(6).trim();
+          else if (line.startsWith("data:")) data = line.slice(5).trim();
+        }
+        frames.push({ event, data });
+        if (frames.length >= expected.length) break;
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  return frames;
+}
+
+describe("hono(app, { sse }) — generated SSE endpoints", () => {
+  test("emits one GET /sse/<stateName> per unique state name", ({ app }) => {
+    const channel = new BroadcastChannel();
+    const api = hono(app as never, default_options(channel)) as unknown as {
+      routes: Array<{ method: string; path: string }>;
+    };
+    const sse_paths = Array.from(
+      new Set(
+        api.routes
+          .filter((r) => r.method === "GET" && r.path.startsWith("/api/sse/"))
+          .map((r) => r.path)
+      )
+    ).sort();
+    expect(sse_paths).toEqual(["/api/sse/Calculator", "/api/sse/Ticket"]);
+  });
+
+  test("no /sse/* routes when sse option is absent", ({ app }) => {
+    const api = hono(app as never, {
+      actor: () => ({ id: "u-1", name: "alice" }),
+      stream: () => "calc-1",
+    }) as unknown as { routes: Array<{ method: string; path: string }> };
+    const sse_paths = api.routes.filter(
+      (r) => r.method === "GET" && r.path.startsWith("/api/sse/")
+    );
+    expect(sse_paths).toEqual([]);
+  });
+
+  test("missing ?stream query returns 400 / BAD_REQUEST", async ({ app }) => {
+    const channel = new BroadcastChannel();
+    const api = hono(app as never, default_options(channel));
+    const res = await api.request("/api/sse/Calculator");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("BAD_REQUEST");
+  });
+
+  test("yields cached state on open, then patches as they publish", async ({
+    app: _app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    channel.publish("calc-1", { _v: 1, display: "1" }, [{ display: "1" }]);
+
+    const api = hono(_app as never, default_options(channel));
+    const res = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    // Publish a follow-up patch so the subscriber has something to drain.
+    setTimeout(() => {
+      channel.publish("calc-1", { _v: 2, display: "12" }, [{ display: "12" }]);
+    }, 10);
+
+    const frames = await read_sse_frames(res, ["state", "patch"]);
+    expect(frames[0].event).toBe("state");
+    expect(JSON.parse(frames[0].data)).toMatchObject({
+      _v: 1,
+      display: "1",
+    });
+    expect(frames[1].event).toBe("patch");
+  });
+
+  test("emits patches even when no cached state existed at open", async ({
+    app: _app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const api = hono(_app as never, default_options(channel));
+    const res = await api.request("/api/sse/Calculator?stream=calc-1");
+
+    setTimeout(() => {
+      channel.publish("calc-1", { _v: 1, display: "x" }, [{ display: "x" }]);
+    }, 10);
+
+    const frames = await read_sse_frames(res, ["patch"]);
+    expect(frames[0].event).toBe("patch");
+  });
+
+  test("connection cap returns 503 with Retry-After when full", async ({
+    app: _app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const api = hono(_app as never, {
+      actor: () => ({ id: "u-1", name: "alice" }),
+      stream: () => "calc-1",
+      sse: { channel, maxConnections: 1 },
+    });
+
+    const first = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(first.status).toBe(200);
+
+    const blocked = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(blocked.status).toBe(503);
+    expect(blocked.headers.get("Retry-After")).toBe("1");
+    const body = await blocked.json();
+    expect(body.code).toBe("SSE_BUSY");
+
+    await first.body?.cancel();
+  });
+
+  test("releasing a connection allows a new one through", async ({
+    app: _app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const api = hono(_app as never, {
+      actor: () => ({ id: "u-1", name: "alice" }),
+      stream: () => "calc-1",
+      sse: { channel, maxConnections: 1 },
+    });
+
+    const first = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(first.status).toBe(200);
+
+    // Cancel the first reader → server sees abort → counter releases.
+    await first.body?.cancel();
+    // Give the abort listener a tick to fire and release the slot.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const next = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(next.status).toBe(200);
+    await next.body?.cancel();
+  });
+
+  test("401 when the actor extractor throws", async ({ app: _app }) => {
+    const channel = new BroadcastChannel();
+    const api = hono(_app as never, {
+      actor: () => {
+        throw new Error("nope");
+      },
+      stream: () => "calc-1",
+      sse: { channel },
+    });
+    const res = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(res.status).toBe(401);
+  });
+
+  test("heartbeat ping fires once heartbeatMs elapses", async ({
+    app: _app,
+  }) => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const api = hono(_app as never, {
+      actor: () => ({ id: "u-1", name: "alice" }),
+      stream: () => "calc-1",
+      sse: { channel, heartbeatMs: 15_000 },
+    });
+    const res = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(res.status).toBe(200);
+    // Advance past one heartbeat interval — the timer callback runs
+    // and writes a ping frame; we just need the path covered.
+    vi.advanceTimersByTime(20_000);
+    vi.useRealTimers();
+    await res.body?.cancel();
+  });
+
+  test("heartbeat-write rejection is swallowed (catch path)", async ({
+    app: _app,
+  }) => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const api = hono(_app as never, {
+      actor: () => ({ id: "u-1", name: "alice" }),
+      stream: () => "calc-1",
+      sse: { channel, heartbeatMs: 15_000 },
+    });
+    const res = await api.request("/api/sse/Calculator?stream=calc-1");
+    expect(res.status).toBe(200);
+    // Cancel the consumer-side body so the underlying writable
+    // closes; subsequent `writeSSE` calls reject. Then advance the
+    // fake interval to fire the heartbeat — its write rejects and
+    // the production handler's `.catch(() => undefined)` guard
+    // swallows the rejection.
+    await res.body?.cancel();
+    await vi.advanceTimersByTimeAsync(16_000);
+    vi.useRealTimers();
+  });
+});

--- a/libs/act-http/test/trpc/sse.spec.ts
+++ b/libs/act-http/test/trpc/sse.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * SSE subscription wiring on the auto-generated tRPC router (#846).
+ * Verifies the per-state subscription is grouped under
+ * `router.subscribe.<stateName>`, the yield order (cached `state`
+ * first, then `patch` per publication), cap enforcement
+ * (TOO_MANY_REQUESTS), and clean teardown on abort.
+ */
+import { act, state, ZodEmpty } from "@rotorsoft/act";
+import { fixture } from "@rotorsoft/act/test";
+import { initTRPC, TRPCError } from "@trpc/server";
+import { describe, expect } from "vitest";
+import { z } from "zod";
+import { BroadcastChannel } from "../../src/sse/index.js";
+import { type TrpcOptions, trpc } from "../../src/trpc/index.js";
+
+const Calculator = state({
+  Calculator: z.object({ display: z.string() }),
+})
+  .init(() => ({ display: "" }))
+  .emits({
+    KeyPressed: z.object({ key: z.string() }),
+    Cleared: ZodEmpty,
+  })
+  .patch({
+    KeyPressed: ({ data }, s) => ({ display: s.display + data.key }),
+    Cleared: () => ({ display: "" }),
+  })
+  .on({ PressKey: z.object({ key: z.string().min(1) }) })
+  .emit((a) => ["KeyPressed", { key: a.key }])
+  .on({ Clear: ZodEmpty })
+  .emit(() => ["Cleared", {}])
+  .build();
+
+const Ticket = state({
+  Ticket: z.object({ title: z.string() }),
+})
+  .init(() => ({ title: "" }))
+  .emits({ TicketOpened: z.object({ title: z.string() }) })
+  .patch({ TicketOpened: ({ data }) => ({ title: data.title }) })
+  .on({ OpenTicket: z.object({ title: z.string() }) })
+  .emit((a) => ["TicketOpened", { title: a.title }])
+  .build();
+
+const builder = act().withState(Calculator).withState(Ticket);
+const test = fixture(builder);
+
+type Ctx = { actorId: string };
+
+const default_options = (
+  // biome-ignore lint/suspicious/noExplicitAny: tests intentionally use a wide channel shape so the helper composes with empty and typed states alike
+  channel: BroadcastChannel<any>,
+  sse_overrides: Record<string, number> = {}
+): TrpcOptions<Ctx> => ({
+  actor: (ctx) => ({ id: (ctx as Ctx).actorId, name: (ctx as Ctx).actorId }),
+  stream: () => "calc-1",
+  sse: { channel, ...sse_overrides },
+});
+
+type SubscriptionFrame =
+  | { kind: "state"; data: unknown }
+  | { kind: "patch"; data: unknown };
+
+/**
+ * Drain the first `n` frames from an async-iterable subscription.
+ * Resolves whatever frames arrive before the abort signal fires.
+ */
+async function take_frames(
+  iter: AsyncIterable<SubscriptionFrame>,
+  n: number,
+  abort?: AbortController
+): Promise<SubscriptionFrame[]> {
+  const frames: SubscriptionFrame[] = [];
+  for await (const frame of iter) {
+    frames.push(frame);
+    if (frames.length >= n) {
+      abort?.abort();
+      break;
+    }
+  }
+  return frames;
+}
+
+describe("trpc(app, { sse }) — generated subscriptions", () => {
+  test("groups one subscription per unique state under router.subscribe", ({
+    app,
+  }) => {
+    const channel = new BroadcastChannel();
+    const router = trpc<Ctx>(app as never, default_options(channel));
+    const def = (router as { _def: { procedures: Record<string, unknown> } })
+      ._def.procedures;
+    // Nested routers flatten into `_def.procedures` with dot notation.
+    const sub_keys = Object.keys(def)
+      .filter((k) => k.startsWith("subscribe."))
+      .sort();
+    expect(sub_keys).toEqual(["subscribe.Calculator", "subscribe.Ticket"]);
+  });
+
+  test("no router.subscribe when sse option is absent", ({ app }) => {
+    const router = trpc<Ctx>(app as never, {
+      actor: () => ({ id: "u-1", name: "alice" }),
+      stream: () => "calc-1",
+    });
+    const def = (router as { _def: { procedures: Record<string, unknown> } })
+      ._def.procedures;
+    const sub_keys = Object.keys(def).filter((k) => k.startsWith("subscribe."));
+    expect(sub_keys).toEqual([]);
+  });
+
+  test("yields cached state first, then patches as they publish", async ({
+    app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    channel.publish("calc-1", { _v: 1, display: "1" }, [{ display: "1" }]);
+
+    const router = trpc<Ctx>(app as never, default_options(channel));
+    const t = initTRPC.context<Ctx>().create();
+    const caller = t.createCallerFactory(router)({ actorId: "u-1" });
+
+    const sub = (
+      caller as unknown as {
+        subscribe: {
+          Calculator: (input: {
+            stream: string;
+          }) => Promise<AsyncIterable<SubscriptionFrame>>;
+        };
+      }
+    ).subscribe.Calculator({ stream: "calc-1" });
+    const iter = await sub;
+
+    setTimeout(() => {
+      channel.publish("calc-1", { _v: 2, display: "12" }, [{ display: "12" }]);
+    }, 10);
+
+    const abort = new AbortController();
+    const frames = await take_frames(iter, 2, abort);
+    expect(frames[0]).toMatchObject({ kind: "state" });
+    expect(frames[1]).toMatchObject({ kind: "patch" });
+  });
+
+  test("skips the cached-state yield when no state has been published", async ({
+    app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const router = trpc<Ctx>(app as never, default_options(channel));
+    const t = initTRPC.context<Ctx>().create();
+    const caller = t.createCallerFactory(router)({ actorId: "u-1" });
+
+    const iter = await (
+      caller as unknown as {
+        subscribe: {
+          Calculator: (input: {
+            stream: string;
+          }) => Promise<AsyncIterable<SubscriptionFrame>>;
+        };
+      }
+    ).subscribe.Calculator({ stream: "calc-1" });
+
+    setTimeout(() => {
+      channel.publish("calc-1", { _v: 1, display: "1" }, [{ display: "1" }]);
+    }, 10);
+
+    const abort = new AbortController();
+    const frames = await take_frames(iter, 1, abort);
+    expect(frames[0]).toMatchObject({ kind: "patch" });
+  });
+
+  test("connection cap throws TOO_MANY_REQUESTS when full", async ({ app }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    // Seed state so the first subscription's generator body actually
+    // runs to its first yield — that's when `acquire()` lands.
+    channel.publish("calc-1", { _v: 1, display: "1" }, [{ display: "1" }]);
+
+    const router = trpc<Ctx>(
+      app as never,
+      default_options(channel, { maxConnections: 1 })
+    );
+    const t = initTRPC.context<Ctx>().create();
+    const caller = t.createCallerFactory(router)({ actorId: "u-1" });
+
+    const sub_proc = (
+      caller as unknown as {
+        subscribe: {
+          Calculator: (input: {
+            stream: string;
+          }) => Promise<AsyncIterable<SubscriptionFrame>>;
+        };
+      }
+    ).subscribe.Calculator;
+
+    const iter1 = await sub_proc({ stream: "calc-1" });
+    const reader1 = iter1[Symbol.asyncIterator]();
+    // Draining one frame guarantees `acquire()` has run — the slot
+    // is held while the generator awaits the next publish.
+    const first = await reader1.next();
+    expect(first.value).toMatchObject({ kind: "state" });
+
+    await expect(async () => {
+      const iter2 = await sub_proc({ stream: "calc-2" });
+      const reader2 = iter2[Symbol.asyncIterator]();
+      await reader2.next();
+    }).rejects.toMatchObject({ code: "TOO_MANY_REQUESTS" });
+
+    await reader1.return?.(undefined);
+  });
+
+  test("cap counter releases on abort so a follow-up open succeeds", async ({
+    app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    channel.publish("calc-1", { _v: 1, display: "1" }, [{ display: "1" }]);
+
+    const router = trpc<Ctx>(
+      app as never,
+      default_options(channel, { maxConnections: 1 })
+    );
+    const t = initTRPC.context<Ctx>().create();
+    const caller = t.createCallerFactory(router)({ actorId: "u-1" });
+
+    const sub_proc = (
+      caller as unknown as {
+        subscribe: {
+          Calculator: (input: {
+            stream: string;
+          }) => Promise<AsyncIterable<SubscriptionFrame>>;
+        };
+      }
+    ).subscribe.Calculator;
+
+    const iter1 = await sub_proc({ stream: "calc-1" });
+    const reader1 = iter1[Symbol.asyncIterator]();
+    // Land in the loop so the slot is acquired.
+    await reader1.next();
+    // Tear down — runs the generator's `finally` block, releasing.
+    await reader1.return?.(undefined);
+
+    // Slot is free; the second open's generator should run cleanly.
+    const iter2 = await sub_proc({ stream: "calc-1" });
+    const reader2 = iter2[Symbol.asyncIterator]();
+    const re_open = await reader2.next();
+    expect(re_open.value).toMatchObject({ kind: "state" });
+    await reader2.return?.(undefined);
+  });
+
+  test("aborting the signal during the wait drains the generator", async ({
+    app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    channel.publish("calc-1", { _v: 1, display: "1" }, [{ display: "1" }]);
+    const router = trpc<Ctx>(app as never, default_options(channel));
+    const t = initTRPC.context<Ctx>().create();
+    const caller = t.createCallerFactory(router)({ actorId: "u-1" });
+
+    const sub_proc = (
+      caller as unknown as {
+        subscribe: {
+          Calculator: (input: {
+            stream: string;
+          }) => Promise<AsyncIterable<SubscriptionFrame>>;
+        };
+      }
+    ).subscribe.Calculator;
+
+    const iter = await sub_proc({ stream: "calc-1" });
+    const reader = iter[Symbol.asyncIterator]();
+    // First yield = cached state.
+    await reader.next();
+    // Tell the generator to stop — triggers the `finally` cleanup
+    // and exercises the `on_abort` listener path.
+    const closed = reader.return?.(undefined);
+    await closed;
+  });
+
+  test("validates the input shape (stream is required, non-empty)", async ({
+    app,
+  }) => {
+    const channel = new BroadcastChannel<{ _v: number; display: string }>();
+    const router = trpc<Ctx>(app as never, default_options(channel));
+    const t = initTRPC.context<Ctx>().create();
+    const caller = t.createCallerFactory(router)({ actorId: "u-1" });
+
+    await expect(
+      (
+        caller as unknown as {
+          subscribe: {
+            Calculator: (input: { stream: string }) => Promise<unknown>;
+          };
+        }
+      ).subscribe.Calculator({ stream: "" })
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
+++ b/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
@@ -28632,6 +28632,135 @@ import type { Actor } from "@rotorsoft/act";
  */
 export type ActorExtractor = (request: unknown) => Actor | Promise<Actor>;
 
+// === broadcast.ts ===
+import { patch as apply_patch } from "@rotorsoft/act-patch";
+import { StateCache } from "./state-cache.js";
+import type { BroadcastState, PatchMessage, Subscriber } from "./types.js";
+
+/**
+ * Server-side broadcast channel for incremental state sync over SSE.
+ *
+ * Manages per-stream subscriber sets and an LRU state cache. When state
+ * changes, forwards domain patches (from event handlers) to all subscribers
+ * as version-keyed messages.
+ *
+ * ## Usage
+ *
+ * \`\`\`typescript
+ * const broadcast = new BroadcastChannel<MyState>();
+ *
+ * // After every app.do():
+ * const snaps = await app.do(...);
+ * const patches = snaps.map(s => s.patch).filter(Boolean);
+ * const state = deriveState(snaps.at(-1));
+ * broadcast.publish(streamId, state, patches);
+ *
+ * // In SSE subscription:
+ * const cleanup = broadcast.subscribe(streamId, (msg) => {
+ *   pending = msg;
+ *   resolve?.();
+ * });
+ *
+ * // Initial state for reconnects:
+ * const cached = broadcast.get_state(streamId);
+ * \`\`\`
+ *
+ * ## Version Contract
+ *
+ * The \`_v\` field on state MUST be set from \`snap.event.version\` (the event
+ * store's monotonic stream version) BEFORE calling \`publish()\`. This is the
+ * single source of truth for ordering — no separate version counters.
+ */
+export class BroadcastChannel<S extends BroadcastState = BroadcastState> {
+  private channels = new Map<string, Set<Subscriber<S>>>();
+  private state_cache: StateCache<S>;
+
+  constructor(options?: { cache_size?: number }) {
+    this.state_cache = new StateCache<S>(options?.cache_size ?? 50);
+  }
+
+  /**
+   * Publish domain patches from a commit.
+   * patches[i] corresponds to version baseV + i + 1.
+   *
+   * @param streamId - The event store stream ID
+   * @param state - Full state with \`_v\` set from \`snap.event.version\`
+   * @param patches - Array of domain patches, one per emitted event
+   */
+  publish(
+    streamId: string,
+    state: S,
+    patches: Partial<S>[] = []
+  ): PatchMessage<S> {
+    this.state_cache.set(streamId, state);
+
+    const baseV = state._v - patches.length;
+    const msg: PatchMessage<S> = {};
+    patches.forEach((p, i) => {
+      msg[baseV + i + 1] = p;
+    });
+
+    const subs = this.channels.get(streamId);
+    if (subs?.size) {
+      for (const cb of subs) cb(msg);
+    }
+    return msg;
+  }
+
+  /**
+   * Publish a state update that doesn't change the event version
+   * (e.g. presence overlay, computed field refresh).
+   * Uses the same version as the cached state, single entry.
+   */
+  publish_overlay(
+    streamId: string,
+    overlay_patch: Partial<S>
+  ): PatchMessage<S> | undefined {
+    const prev = this.state_cache.get(streamId);
+    if (!prev) return undefined;
+
+    const state = apply_patch(prev, overlay_patch) as S;
+    this.state_cache.set(streamId, state);
+
+    const msg: PatchMessage<S> = { [state._v]: overlay_patch };
+    const subs = this.channels.get(streamId);
+    if (subs?.size) {
+      for (const cb of subs) cb(msg);
+    }
+    return msg;
+  }
+
+  /**
+   * Subscribe to broadcast messages for a stream.
+   * Returns a cleanup function that removes the subscription.
+   */
+  subscribe(streamId: string, cb: Subscriber<S>): () => void {
+    if (!this.channels.has(streamId)) this.channels.set(streamId, new Set());
+    this.channels.get(streamId)!.add(cb);
+    return () => {
+      this.channels.get(streamId)?.delete(cb);
+      if (this.channels.get(streamId)?.size === 0) {
+        this.channels.delete(streamId);
+      }
+    };
+  }
+
+  /** Get the number of subscribers for a stream. */
+  get_subscriber_count(streamId: string): number {
+    return this.channels.get(streamId)?.size ?? 0;
+  }
+
+  /** Get the cached state for a stream (for reconnects / initial SSE yield). */
+  get_state(streamId: string): S | undefined {
+    return this.state_cache.get(streamId);
+  }
+
+  /** Direct access to the state cache (for app-specific reads like presence). */
+  get cache(): StateCache<S> {
+    return this.state_cache;
+  }
+}
+
 // === errors.ts ===
 import {
   ConcurrencyError,
@@ -28824,6 +28953,350 @@ export {
   toApiError,
 } from "./errors.js";
 export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
+export {
+  DEFAULT_SSE_HEARTBEAT_MS,
+  DEFAULT_SSE_MAX_CONNECTIONS,
+  resolveSseConfig,
+  runSseSubscription,
+  type SseAccounting,
+  type SseConfig,
+  SseConnectionCounter,
+  type SseOptions,
+  type SseSubscriptionFrame,
+} from "./sse-wiring.js";
+
+// === sse-wiring.ts ===
+import type { BroadcastChannel } from "../sse/broadcast.js";
+import type { BroadcastState } from "../sse/types.js";
+
+/**
+ * SSE wiring options shared by the auto-generated \`trpc\` and \`hono\`
+ * transports. When supplied, each transport emits one streaming
+ * subscription per registered state name, all reading from the same
+ * host-supplied {@link BroadcastChannel}.
+ *
+ * The host owns publication: every \`app.do(...)\` call site must
+ * forward the resulting snapshots to \`channel.publish(...)\` for
+ * subscribers to see updates. The framework deliberately doesn't
+ * auto-publish because the derived state usually needs app-specific
+ * overlays (presence, computed fields) that only the host can supply.
+ *
+ * Defaults are sized for typical business-app dashboards (dozens to
+ * hundreds of human viewers per process). Both numeric knobs are
+ * validated at transport-function construction; out-of-range values
+ * throw \`RangeError\` immediately so misconfiguration surfaces at
+ * startup instead of at first connection.
+ */
+export type SseOptions = {
+  /**
+   * The {@link BroadcastChannel} the generator's subscriptions hook
+   * into. Host owns its lifecycle; the generator does not construct
+   * one for you because the channel's \`<S>\` shape is app-specific and
+   * passing it in keeps the type chain typed end-to-end at the host.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the generator — narrowing it would force every state into one structural bound that doesn't fit real apps
+  readonly channel: BroadcastChannel<any>;
+  /**
+   * Hard cap on concurrent open subscriptions per generator
+   * instance. The 501st simultaneous open returns \`503\` (Hono) or
+   * throws \`TOO_MANY_REQUESTS\` (tRPC) — never a silent stall.
+   *
+   * Default \`500\`. Validated range \`[1, 10_000]\`. Above 10k the
+   * framework refuses to construct: at that point the FD ceiling
+   * and per-connection memory force horizontal scaling regardless
+   * of tuning, so the right move is sticky LB + per-process cap,
+   * not a higher single-process limit.
+   */
+  readonly maxConnections?: number;
+  /**
+   * Keep-alive cadence in milliseconds. Most reverse proxies idle
+   * connections out after ~60 seconds; the default \`30_000\` stays
+   * comfortably under.
+   *
+   * Validated range \`[15_000, 300_000]\`. Under 15 s wastes
+   * bandwidth on a business workload; over 5 min risks proxy drops.
+   */
+  readonly heartbeatMs?: number;
+};
+
+/**
+ * Resolved SSE configuration after validation and default expansion.
+ * Internal — the resolved values are what every transport actually
+ * runs against.
+ *
+ * @internal
+ */
+export type SseConfig = {
+  readonly channel: BroadcastChannel<BroadcastState>;
+  readonly maxConnections: number;
+  readonly heartbeatMs: number;
+};
+
+/**
+ * Default cap on concurrent open subscriptions per generator
+ * instance. Sized for typical business-app dashboards (dozens to a
+ * few hundred viewers); high enough not to surprise small
+ * deployments, low enough not to mask a missing horizontal-scale
+ * strategy on big ones.
+ */
+export const DEFAULT_SSE_MAX_CONNECTIONS = 500;
+
+/**
+ * Default keep-alive cadence (30 s). Sits comfortably under the
+ * 60 s idle timeout most reverse proxies impose.
+ */
+export const DEFAULT_SSE_HEARTBEAT_MS = 30_000;
+
+const MAX_CONNECTIONS_MIN = 1;
+const MAX_CONNECTIONS_MAX = 10_000;
+const HEARTBEAT_MS_MIN = 15_000;
+const HEARTBEAT_MS_MAX = 300_000;
+
+/**
+ * Validate and apply defaults to host-supplied {@link SseOptions}.
+ *
+ * Throws \`RangeError\` when either numeric knob is outside its
+ * documented range. Pure: same input → same output, no side
+ * effects, no I/O. Each transport calls this once at the start of
+ * \`hono(...)\` / \`trpc(...)\`.
+ */
+export function resolveSseConfig(options: SseOptions): SseConfig {
+  const max_connections = options.maxConnections ?? DEFAULT_SSE_MAX_CONNECTIONS;
+  const heartbeat_ms = options.heartbeatMs ?? DEFAULT_SSE_HEARTBEAT_MS;
+  if (
+    !Number.isFinite(max_connections) ||
+    max_connections < MAX_CONNECTIONS_MIN ||
+    max_connections > MAX_CONNECTIONS_MAX
+  ) {
+    throw new RangeError(
+      \`sse.maxConnections must be in [\${MAX_CONNECTIONS_MIN}, \${MAX_CONNECTIONS_MAX}], got \${max_connections}\`
+    );
+  }
+  if (
+    !Number.isFinite(heartbeat_ms) ||
+    heartbeat_ms < HEARTBEAT_MS_MIN ||
+    heartbeat_ms > HEARTBEAT_MS_MAX
+  ) {
+    throw new RangeError(
+      \`sse.heartbeatMs must be in [\${HEARTBEAT_MS_MIN}, \${HEARTBEAT_MS_MAX}], got \${heartbeat_ms}\`
+    );
+  }
+  return {
+    channel: options.channel,
+    maxConnections: max_connections,
+    heartbeatMs: heartbeat_ms,
+  };
+}
+
+/**
+ * Per-generator concurrent-open counter. Constructed once inside
+ * \`hono(...)\` / \`trpc(...)\` and consulted at every subscription
+ * open: failure to acquire means the cap has been hit and the
+ * transport reports \`503\` / \`TOO_MANY_REQUESTS\` to the caller.
+ *
+ * The counter is intentionally process-local. SSE doesn't multiplex
+ * across processes; operators wanting more than \`maxConnections\`
+ * viewers run multiple processes behind a sticky load balancer.
+ */
+export class SseConnectionCounter {
+  public readonly limit: number;
+  private _open = 0;
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  /**
+   * Reserve one slot. Returns \`true\` when accepted (caller must
+   * eventually {@link release} the slot, even on error paths) or
+   * \`false\` when the cap is already reached.
+   */
+  acquire(): boolean {
+    if (this._open >= this.limit) return false;
+    this._open++;
+    return true;
+  }
+
+  /**
+   * Free a previously-{@link acquire}d slot. Always runs from a
+   * \`finally\` block in the transport's subscription handler so
+   * crashed handlers don't leak count.
+   */
+  release(): void {
+    if (this._open > 0) this._open--;
+  }
+
+  /** Currently-open count. Test/observability hook. */
+  get open(): number {
+    return this._open;
+  }
+}
+
+/**
+ * Frame yielded by the per-state SSE subscription generator. The
+ * initial cached state (when present) arrives as \`kind: "state"\`;
+ * every subsequent broadcast publication arrives as \`kind: "patch"\`
+ * with the channel's \`PatchMessage\` payload.
+ */
+export type SseSubscriptionFrame<S> =
+  | { readonly kind: "state"; readonly data: S }
+  | { readonly kind: "patch"; readonly data: unknown };
+
+/**
+ * Subscription accounting hook. Implementations have a chance to
+ * acquire a slot before the loop starts and to release it once the
+ * loop's \`finally\` block runs — used by the tRPC side to enforce
+ * \`maxConnections\` from inside the generator, where it can throw
+ * \`TRPCError\` cleanly. Hono enforces the cap outside the loop (so a
+ * full counter returns \`503\` *before* streamSSE writes headers), then
+ * passes \`undefined\` here.
+ */
+export type SseAccounting = {
+  acquire(): boolean;
+  release(): void;
+};
+
+/**
+ * The shared subscription loop both transports run. Optionally
+ * acquires one slot on the supplied {@link SseAccounting}, yields the
+ * cached state (when present), then forwards every channel
+ * publication as a \`kind: "patch"\` frame until either the consumer
+ * breaks (calling \`iter.return()\`) or the supplied abort signal fires.
+ *
+ * Exported as the testable seam — the Hono and tRPC sibling
+ * generators wrap this so the signal-driven cleanup and counter
+ * accounting live in one place.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the loop — narrowing it would force every state into one structural bound that doesn't fit real apps
+export async function* runSseSubscription<S extends { _v: number } = any>(
+  channel: BroadcastChannel<S>,
+  stream_id: string,
+  accounting: SseAccounting | undefined,
+  signal: AbortSignal | undefined,
+  on_cap_exceeded?: () => never
+): AsyncGenerator<SseSubscriptionFrame<S>> {
+  if (accounting && !accounting.acquire() && on_cap_exceeded) {
+    on_cap_exceeded();
+  }
+  const pending: unknown[] = [];
+  let resolve_wait: (() => void) | null = null;
+  const unsubscribe = channel.subscribe(stream_id, (msg) => {
+    pending.push(msg);
+    resolve_wait?.();
+  });
+  const on_abort = () => resolve_wait?.();
+  signal?.addEventListener("abort", on_abort);
+  try {
+    const cached = channel.get_state(stream_id);
+    if (cached !== undefined) {
+      yield { kind: "state", data: cached };
+    }
+    while (!signal?.aborted) {
+      if (pending.length === 0) {
+        await new Promise<void>((resolve) => {
+          resolve_wait = resolve;
+        });
+        if (signal?.aborted) break;
+      }
+      const msg = pending.shift();
+      yield { kind: "patch", data: msg };
+    }
+  } finally {
+    signal?.removeEventListener("abort", on_abort);
+    unsubscribe();
+    accounting?.release();
+  }
+}
+
+// === state-cache.ts ===
+import type { BroadcastState } from "./types.js";
+
+/**
+ * Generic LRU cache for aggregate state objects.
+ *
+ * Keyed by stream ID. Each entry stores the full state (with \`_v\` from the
+ * event store). Used as the "previous state" baseline for computing patches,
+ * and as the fast path for reconnects.
+ *
+ * The cache is shared between the broadcast hot path and read queries.
+ * Projections should maintain their own cache to avoid double-apply bugs.
+ */
+export class StateCache<S extends BroadcastState = BroadcastState> {
+  private cache = new Map<string, S>();
+  private maxSize: number;
+
+  constructor(maxSize = 50) {
+    this.maxSize = maxSize;
+  }
+
+  /** Get a cached state, promoting it to MRU position. */
+  get(key: string): S | undefined {
+    const s = this.cache.get(key);
+    if (s) {
+      this.cache.delete(key);
+      this.cache.set(key, s);
+    }
+    return s;
+  }
+
+  /** Set a cached state, evicting the LRU entry if at capacity. */
+  set(key: string, state: S): void {
+    this.cache.delete(key);
+    this.cache.set(key, state);
+    if (this.cache.size > this.maxSize) {
+      this.cache.delete(this.cache.keys().next().value!);
+    }
+  }
+
+  /** Remove a cached entry. */
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  /** Check if a key exists in the cache. */
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Current number of cached entries. */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Direct access to the underlying map (for iteration). */
+  entries(): IterableIterator<[string, S]> {
+    return this.cache.entries();
+  }
+}
+
+// === types.ts ===
+import type { DeepPartial } from "@rotorsoft/act-patch";
+
+/**
+ * Base constraint for state objects managed by the broadcast system.
+ * Apps extend this with their own domain state shape.
+ */
+export type BroadcastState = Record<string, unknown> & {
+  /** Event store stream version — set by the broadcast layer from snap.event.version */
+  _v: number;
+};
+
+/**
+ * SSE message: version-keyed domain patches.
+ * Keys are stringified version numbers, values are domain patches (deep partials).
+ * Multi-event commits produce multiple version-keyed entries.
+ */
+export type PatchMessage<S extends BroadcastState = BroadcastState> = Record<
+  number,
+  DeepPartial<S>
+>;
+
+/**
+ * Subscriber callback — receives version-keyed patch messages.
+ */
+export type Subscriber<S extends BroadcastState = BroadcastState> = (
+  msg: PatchMessage<S>
+) => void;
 "
 `;
 
@@ -28849,6 +29322,135 @@ import type { Actor } from "@rotorsoft/act";
  * cache.
  */
 export type ActorExtractor = (request: unknown) => Actor | Promise<Actor>;
+
+// === broadcast.ts ===
+import { patch as apply_patch } from "@rotorsoft/act-patch";
+import { StateCache } from "./state-cache.js";
+import type { BroadcastState, PatchMessage, Subscriber } from "./types.js";
+
+/**
+ * Server-side broadcast channel for incremental state sync over SSE.
+ *
+ * Manages per-stream subscriber sets and an LRU state cache. When state
+ * changes, forwards domain patches (from event handlers) to all subscribers
+ * as version-keyed messages.
+ *
+ * ## Usage
+ *
+ * \`\`\`typescript
+ * const broadcast = new BroadcastChannel<MyState>();
+ *
+ * // After every app.do():
+ * const snaps = await app.do(...);
+ * const patches = snaps.map(s => s.patch).filter(Boolean);
+ * const state = deriveState(snaps.at(-1));
+ * broadcast.publish(streamId, state, patches);
+ *
+ * // In SSE subscription:
+ * const cleanup = broadcast.subscribe(streamId, (msg) => {
+ *   pending = msg;
+ *   resolve?.();
+ * });
+ *
+ * // Initial state for reconnects:
+ * const cached = broadcast.get_state(streamId);
+ * \`\`\`
+ *
+ * ## Version Contract
+ *
+ * The \`_v\` field on state MUST be set from \`snap.event.version\` (the event
+ * store's monotonic stream version) BEFORE calling \`publish()\`. This is the
+ * single source of truth for ordering — no separate version counters.
+ */
+export class BroadcastChannel<S extends BroadcastState = BroadcastState> {
+  private channels = new Map<string, Set<Subscriber<S>>>();
+  private state_cache: StateCache<S>;
+
+  constructor(options?: { cache_size?: number }) {
+    this.state_cache = new StateCache<S>(options?.cache_size ?? 50);
+  }
+
+  /**
+   * Publish domain patches from a commit.
+   * patches[i] corresponds to version baseV + i + 1.
+   *
+   * @param streamId - The event store stream ID
+   * @param state - Full state with \`_v\` set from \`snap.event.version\`
+   * @param patches - Array of domain patches, one per emitted event
+   */
+  publish(
+    streamId: string,
+    state: S,
+    patches: Partial<S>[] = []
+  ): PatchMessage<S> {
+    this.state_cache.set(streamId, state);
+
+    const baseV = state._v - patches.length;
+    const msg: PatchMessage<S> = {};
+    patches.forEach((p, i) => {
+      msg[baseV + i + 1] = p;
+    });
+
+    const subs = this.channels.get(streamId);
+    if (subs?.size) {
+      for (const cb of subs) cb(msg);
+    }
+    return msg;
+  }
+
+  /**
+   * Publish a state update that doesn't change the event version
+   * (e.g. presence overlay, computed field refresh).
+   * Uses the same version as the cached state, single entry.
+   */
+  publish_overlay(
+    streamId: string,
+    overlay_patch: Partial<S>
+  ): PatchMessage<S> | undefined {
+    const prev = this.state_cache.get(streamId);
+    if (!prev) return undefined;
+
+    const state = apply_patch(prev, overlay_patch) as S;
+    this.state_cache.set(streamId, state);
+
+    const msg: PatchMessage<S> = { [state._v]: overlay_patch };
+    const subs = this.channels.get(streamId);
+    if (subs?.size) {
+      for (const cb of subs) cb(msg);
+    }
+    return msg;
+  }
+
+  /**
+   * Subscribe to broadcast messages for a stream.
+   * Returns a cleanup function that removes the subscription.
+   */
+  subscribe(streamId: string, cb: Subscriber<S>): () => void {
+    if (!this.channels.has(streamId)) this.channels.set(streamId, new Set());
+    this.channels.get(streamId)!.add(cb);
+    return () => {
+      this.channels.get(streamId)?.delete(cb);
+      if (this.channels.get(streamId)?.size === 0) {
+        this.channels.delete(streamId);
+      }
+    };
+  }
+
+  /** Get the number of subscribers for a stream. */
+  get_subscriber_count(streamId: string): number {
+    return this.channels.get(streamId)?.size ?? 0;
+  }
+
+  /** Get the cached state for a stream (for reconnects / initial SSE yield). */
+  get_state(streamId: string): S | undefined {
+    return this.state_cache.get(streamId);
+  }
+
+  /** Direct access to the state cache (for app-specific reads like presence). */
+  get cache(): StateCache<S> {
+    return this.state_cache;
+  }
+}
 
 // === errors.ts ===
 import {
@@ -29050,9 +29652,14 @@ import type { Actor, Target } from "@rotorsoft/act";
 import type { IdempotencyStore } from "@rotorsoft/act-ops/idempotency";
 import type { Context, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import {
   type ActorExtractor,
   type ApiError,
+  resolveSseConfig,
+  runSseSubscription,
+  SseConnectionCounter,
+  type SseOptions,
   toApiError,
   withIdempotency,
 } from "../api/index.js";
@@ -29109,6 +29716,23 @@ export type HonoOptions = {
     readonly store: IdempotencyStore;
     readonly keyFrom?: (c: Context) => string | undefined;
   };
+  /**
+   * Optional SSE wiring. When set, the generator emits one
+   * \`GET <basePath>/sse/<stateName>?stream=<streamId>\` per unique
+   * state name in the registry. The endpoint runs the host
+   * {@link actor} extractor, looks up the streamId from
+   * \`?stream=...\`, opens a \`text/event-stream\`, yields the cached
+   * state (if any), and forwards every patch published to the
+   * shared {@link SseOptions.channel}. A heartbeat keeps proxies
+   * from idling the connection out; the per-process connection cap
+   * returns \`503 Service Unavailable\` (with \`Retry-After: 1\`) when
+   * full so operators never see silent stalls.
+   *
+   * Off by default — most APIs don't expose live state to every
+   * client, and opening one is widening both the auth and cost
+   * surface.
+   */
+  readonly sse?: SseOptions;
   readonly basePath?: string;
 };
 
@@ -29219,6 +29843,71 @@ export function hono<TApp extends ActSurface = ActSurface>(
   api.use("*", authenticated(options.actor));
 
   const key_from = options.idempotency?.keyFrom ?? default_key_from;
+
+  // Wire SSE subscriptions before the mutation routes so the
+  // \`/sse/*\` paths sit alongside \`/actions/*\`. The cap counter is
+  // shared by every state-name's GET route on this generator
+  // instance so a noisy room on one state doesn't get a free pass
+  // on another.
+  if (options.sse) {
+    const sse_config = resolveSseConfig(options.sse);
+    const sse_counter = new SseConnectionCounter(sse_config.maxConnections);
+    const state_names = new Set<string>();
+    for (const action of Object.values(app.registry.actions)) {
+      state_names.add(action.name);
+    }
+    for (const state_name of state_names) {
+      api.get(\`/sse/\${state_name}\`, async (c) => {
+        const stream_id = c.req.query("stream");
+        if (!stream_id) {
+          const body: ApiError = {
+            error: "BadRequest",
+            detail: "stream query parameter is required",
+            code: "BAD_REQUEST",
+          };
+          return c.json(body, 400);
+        }
+        if (!sse_counter.acquire()) {
+          c.header("Retry-After", "1");
+          const body: ApiError = {
+            error: "ServiceUnavailable",
+            detail: "max concurrent SSE connections reached",
+            code: "SSE_BUSY",
+          };
+          return c.json(body, 503);
+        }
+        // The route already acquired the slot above so streamSSE
+        // could return \`503\` before writing headers if the cap was
+        // full. The shared loop runs without accounting; the route
+        // releases the slot in \`finally\`.
+        const controller = new AbortController();
+        return streamSSE(c, async (sse_stream) => {
+          sse_stream.onAbort(() => controller.abort());
+          const heartbeat = setInterval(() => {
+            sse_stream
+              .writeSSE({ event: "ping", data: "" })
+              .catch(() => undefined);
+          }, sse_config.heartbeatMs);
+          try {
+            for await (const frame of runSseSubscription(
+              sse_config.channel,
+              stream_id,
+              undefined,
+              controller.signal
+            )) {
+              await sse_stream.writeSSE({
+                event: frame.kind,
+                data: JSON.stringify(frame.data),
+              });
+            }
+          } finally {
+            clearInterval(heartbeat);
+            sse_counter.release();
+          }
+        });
+      });
+    }
+  }
 
   for (const [action_name, state] of Object.entries(app.registry.actions)) {
     const schema = state.actions[action_name];
@@ -29331,6 +30020,350 @@ export {
   toApiError,
 } from "./errors.js";
 export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
+export {
+  DEFAULT_SSE_HEARTBEAT_MS,
+  DEFAULT_SSE_MAX_CONNECTIONS,
+  resolveSseConfig,
+  runSseSubscription,
+  type SseAccounting,
+  type SseConfig,
+  SseConnectionCounter,
+  type SseOptions,
+  type SseSubscriptionFrame,
+} from "./sse-wiring.js";
+
+// === sse-wiring.ts ===
+import type { BroadcastChannel } from "../sse/broadcast.js";
+import type { BroadcastState } from "../sse/types.js";
+
+/**
+ * SSE wiring options shared by the auto-generated \`trpc\` and \`hono\`
+ * transports. When supplied, each transport emits one streaming
+ * subscription per registered state name, all reading from the same
+ * host-supplied {@link BroadcastChannel}.
+ *
+ * The host owns publication: every \`app.do(...)\` call site must
+ * forward the resulting snapshots to \`channel.publish(...)\` for
+ * subscribers to see updates. The framework deliberately doesn't
+ * auto-publish because the derived state usually needs app-specific
+ * overlays (presence, computed fields) that only the host can supply.
+ *
+ * Defaults are sized for typical business-app dashboards (dozens to
+ * hundreds of human viewers per process). Both numeric knobs are
+ * validated at transport-function construction; out-of-range values
+ * throw \`RangeError\` immediately so misconfiguration surfaces at
+ * startup instead of at first connection.
+ */
+export type SseOptions = {
+  /**
+   * The {@link BroadcastChannel} the generator's subscriptions hook
+   * into. Host owns its lifecycle; the generator does not construct
+   * one for you because the channel's \`<S>\` shape is app-specific and
+   * passing it in keeps the type chain typed end-to-end at the host.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the generator — narrowing it would force every state into one structural bound that doesn't fit real apps
+  readonly channel: BroadcastChannel<any>;
+  /**
+   * Hard cap on concurrent open subscriptions per generator
+   * instance. The 501st simultaneous open returns \`503\` (Hono) or
+   * throws \`TOO_MANY_REQUESTS\` (tRPC) — never a silent stall.
+   *
+   * Default \`500\`. Validated range \`[1, 10_000]\`. Above 10k the
+   * framework refuses to construct: at that point the FD ceiling
+   * and per-connection memory force horizontal scaling regardless
+   * of tuning, so the right move is sticky LB + per-process cap,
+   * not a higher single-process limit.
+   */
+  readonly maxConnections?: number;
+  /**
+   * Keep-alive cadence in milliseconds. Most reverse proxies idle
+   * connections out after ~60 seconds; the default \`30_000\` stays
+   * comfortably under.
+   *
+   * Validated range \`[15_000, 300_000]\`. Under 15 s wastes
+   * bandwidth on a business workload; over 5 min risks proxy drops.
+   */
+  readonly heartbeatMs?: number;
+};
+
+/**
+ * Resolved SSE configuration after validation and default expansion.
+ * Internal — the resolved values are what every transport actually
+ * runs against.
+ *
+ * @internal
+ */
+export type SseConfig = {
+  readonly channel: BroadcastChannel<BroadcastState>;
+  readonly maxConnections: number;
+  readonly heartbeatMs: number;
+};
+
+/**
+ * Default cap on concurrent open subscriptions per generator
+ * instance. Sized for typical business-app dashboards (dozens to a
+ * few hundred viewers); high enough not to surprise small
+ * deployments, low enough not to mask a missing horizontal-scale
+ * strategy on big ones.
+ */
+export const DEFAULT_SSE_MAX_CONNECTIONS = 500;
+
+/**
+ * Default keep-alive cadence (30 s). Sits comfortably under the
+ * 60 s idle timeout most reverse proxies impose.
+ */
+export const DEFAULT_SSE_HEARTBEAT_MS = 30_000;
+
+const MAX_CONNECTIONS_MIN = 1;
+const MAX_CONNECTIONS_MAX = 10_000;
+const HEARTBEAT_MS_MIN = 15_000;
+const HEARTBEAT_MS_MAX = 300_000;
+
+/**
+ * Validate and apply defaults to host-supplied {@link SseOptions}.
+ *
+ * Throws \`RangeError\` when either numeric knob is outside its
+ * documented range. Pure: same input → same output, no side
+ * effects, no I/O. Each transport calls this once at the start of
+ * \`hono(...)\` / \`trpc(...)\`.
+ */
+export function resolveSseConfig(options: SseOptions): SseConfig {
+  const max_connections = options.maxConnections ?? DEFAULT_SSE_MAX_CONNECTIONS;
+  const heartbeat_ms = options.heartbeatMs ?? DEFAULT_SSE_HEARTBEAT_MS;
+  if (
+    !Number.isFinite(max_connections) ||
+    max_connections < MAX_CONNECTIONS_MIN ||
+    max_connections > MAX_CONNECTIONS_MAX
+  ) {
+    throw new RangeError(
+      \`sse.maxConnections must be in [\${MAX_CONNECTIONS_MIN}, \${MAX_CONNECTIONS_MAX}], got \${max_connections}\`
+    );
+  }
+  if (
+    !Number.isFinite(heartbeat_ms) ||
+    heartbeat_ms < HEARTBEAT_MS_MIN ||
+    heartbeat_ms > HEARTBEAT_MS_MAX
+  ) {
+    throw new RangeError(
+      \`sse.heartbeatMs must be in [\${HEARTBEAT_MS_MIN}, \${HEARTBEAT_MS_MAX}], got \${heartbeat_ms}\`
+    );
+  }
+  return {
+    channel: options.channel,
+    maxConnections: max_connections,
+    heartbeatMs: heartbeat_ms,
+  };
+}
+
+/**
+ * Per-generator concurrent-open counter. Constructed once inside
+ * \`hono(...)\` / \`trpc(...)\` and consulted at every subscription
+ * open: failure to acquire means the cap has been hit and the
+ * transport reports \`503\` / \`TOO_MANY_REQUESTS\` to the caller.
+ *
+ * The counter is intentionally process-local. SSE doesn't multiplex
+ * across processes; operators wanting more than \`maxConnections\`
+ * viewers run multiple processes behind a sticky load balancer.
+ */
+export class SseConnectionCounter {
+  public readonly limit: number;
+  private _open = 0;
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  /**
+   * Reserve one slot. Returns \`true\` when accepted (caller must
+   * eventually {@link release} the slot, even on error paths) or
+   * \`false\` when the cap is already reached.
+   */
+  acquire(): boolean {
+    if (this._open >= this.limit) return false;
+    this._open++;
+    return true;
+  }
+
+  /**
+   * Free a previously-{@link acquire}d slot. Always runs from a
+   * \`finally\` block in the transport's subscription handler so
+   * crashed handlers don't leak count.
+   */
+  release(): void {
+    if (this._open > 0) this._open--;
+  }
+
+  /** Currently-open count. Test/observability hook. */
+  get open(): number {
+    return this._open;
+  }
+}
+
+/**
+ * Frame yielded by the per-state SSE subscription generator. The
+ * initial cached state (when present) arrives as \`kind: "state"\`;
+ * every subsequent broadcast publication arrives as \`kind: "patch"\`
+ * with the channel's \`PatchMessage\` payload.
+ */
+export type SseSubscriptionFrame<S> =
+  | { readonly kind: "state"; readonly data: S }
+  | { readonly kind: "patch"; readonly data: unknown };
+
+/**
+ * Subscription accounting hook. Implementations have a chance to
+ * acquire a slot before the loop starts and to release it once the
+ * loop's \`finally\` block runs — used by the tRPC side to enforce
+ * \`maxConnections\` from inside the generator, where it can throw
+ * \`TRPCError\` cleanly. Hono enforces the cap outside the loop (so a
+ * full counter returns \`503\` *before* streamSSE writes headers), then
+ * passes \`undefined\` here.
+ */
+export type SseAccounting = {
+  acquire(): boolean;
+  release(): void;
+};
+
+/**
+ * The shared subscription loop both transports run. Optionally
+ * acquires one slot on the supplied {@link SseAccounting}, yields the
+ * cached state (when present), then forwards every channel
+ * publication as a \`kind: "patch"\` frame until either the consumer
+ * breaks (calling \`iter.return()\`) or the supplied abort signal fires.
+ *
+ * Exported as the testable seam — the Hono and tRPC sibling
+ * generators wrap this so the signal-driven cleanup and counter
+ * accounting live in one place.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the loop — narrowing it would force every state into one structural bound that doesn't fit real apps
+export async function* runSseSubscription<S extends { _v: number } = any>(
+  channel: BroadcastChannel<S>,
+  stream_id: string,
+  accounting: SseAccounting | undefined,
+  signal: AbortSignal | undefined,
+  on_cap_exceeded?: () => never
+): AsyncGenerator<SseSubscriptionFrame<S>> {
+  if (accounting && !accounting.acquire() && on_cap_exceeded) {
+    on_cap_exceeded();
+  }
+  const pending: unknown[] = [];
+  let resolve_wait: (() => void) | null = null;
+  const unsubscribe = channel.subscribe(stream_id, (msg) => {
+    pending.push(msg);
+    resolve_wait?.();
+  });
+  const on_abort = () => resolve_wait?.();
+  signal?.addEventListener("abort", on_abort);
+  try {
+    const cached = channel.get_state(stream_id);
+    if (cached !== undefined) {
+      yield { kind: "state", data: cached };
+    }
+    while (!signal?.aborted) {
+      if (pending.length === 0) {
+        await new Promise<void>((resolve) => {
+          resolve_wait = resolve;
+        });
+        if (signal?.aborted) break;
+      }
+      const msg = pending.shift();
+      yield { kind: "patch", data: msg };
+    }
+  } finally {
+    signal?.removeEventListener("abort", on_abort);
+    unsubscribe();
+    accounting?.release();
+  }
+}
+
+// === state-cache.ts ===
+import type { BroadcastState } from "./types.js";
+
+/**
+ * Generic LRU cache for aggregate state objects.
+ *
+ * Keyed by stream ID. Each entry stores the full state (with \`_v\` from the
+ * event store). Used as the "previous state" baseline for computing patches,
+ * and as the fast path for reconnects.
+ *
+ * The cache is shared between the broadcast hot path and read queries.
+ * Projections should maintain their own cache to avoid double-apply bugs.
+ */
+export class StateCache<S extends BroadcastState = BroadcastState> {
+  private cache = new Map<string, S>();
+  private maxSize: number;
+
+  constructor(maxSize = 50) {
+    this.maxSize = maxSize;
+  }
+
+  /** Get a cached state, promoting it to MRU position. */
+  get(key: string): S | undefined {
+    const s = this.cache.get(key);
+    if (s) {
+      this.cache.delete(key);
+      this.cache.set(key, s);
+    }
+    return s;
+  }
+
+  /** Set a cached state, evicting the LRU entry if at capacity. */
+  set(key: string, state: S): void {
+    this.cache.delete(key);
+    this.cache.set(key, state);
+    if (this.cache.size > this.maxSize) {
+      this.cache.delete(this.cache.keys().next().value!);
+    }
+  }
+
+  /** Remove a cached entry. */
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  /** Check if a key exists in the cache. */
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Current number of cached entries. */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Direct access to the underlying map (for iteration). */
+  entries(): IterableIterator<[string, S]> {
+    return this.cache.entries();
+  }
+}
+
+// === types.ts ===
+import type { DeepPartial } from "@rotorsoft/act-patch";
+
+/**
+ * Base constraint for state objects managed by the broadcast system.
+ * Apps extend this with their own domain state shape.
+ */
+export type BroadcastState = Record<string, unknown> & {
+  /** Event store stream version — set by the broadcast layer from snap.event.version */
+  _v: number;
+};
+
+/**
+ * SSE message: version-keyed domain patches.
+ * Keys are stringified version numbers, values are domain patches (deep partials).
+ * Multi-event commits produce multiple version-keyed entries.
+ */
+export type PatchMessage<S extends BroadcastState = BroadcastState> = Record<
+  number,
+  DeepPartial<S>
+>;
+
+/**
+ * Subscriber callback — receives version-keyed patch messages.
+ */
+export type Subscriber<S extends BroadcastState = BroadcastState> = (
+  msg: PatchMessage<S>
+) => void;
 "
 `;
 
@@ -32048,6 +33081,135 @@ import type { Actor } from "@rotorsoft/act";
  */
 export type ActorExtractor = (request: unknown) => Actor | Promise<Actor>;
 
+// === broadcast.ts ===
+import { patch as apply_patch } from "@rotorsoft/act-patch";
+import { StateCache } from "./state-cache.js";
+import type { BroadcastState, PatchMessage, Subscriber } from "./types.js";
+
+/**
+ * Server-side broadcast channel for incremental state sync over SSE.
+ *
+ * Manages per-stream subscriber sets and an LRU state cache. When state
+ * changes, forwards domain patches (from event handlers) to all subscribers
+ * as version-keyed messages.
+ *
+ * ## Usage
+ *
+ * \`\`\`typescript
+ * const broadcast = new BroadcastChannel<MyState>();
+ *
+ * // After every app.do():
+ * const snaps = await app.do(...);
+ * const patches = snaps.map(s => s.patch).filter(Boolean);
+ * const state = deriveState(snaps.at(-1));
+ * broadcast.publish(streamId, state, patches);
+ *
+ * // In SSE subscription:
+ * const cleanup = broadcast.subscribe(streamId, (msg) => {
+ *   pending = msg;
+ *   resolve?.();
+ * });
+ *
+ * // Initial state for reconnects:
+ * const cached = broadcast.get_state(streamId);
+ * \`\`\`
+ *
+ * ## Version Contract
+ *
+ * The \`_v\` field on state MUST be set from \`snap.event.version\` (the event
+ * store's monotonic stream version) BEFORE calling \`publish()\`. This is the
+ * single source of truth for ordering — no separate version counters.
+ */
+export class BroadcastChannel<S extends BroadcastState = BroadcastState> {
+  private channels = new Map<string, Set<Subscriber<S>>>();
+  private state_cache: StateCache<S>;
+
+  constructor(options?: { cache_size?: number }) {
+    this.state_cache = new StateCache<S>(options?.cache_size ?? 50);
+  }
+
+  /**
+   * Publish domain patches from a commit.
+   * patches[i] corresponds to version baseV + i + 1.
+   *
+   * @param streamId - The event store stream ID
+   * @param state - Full state with \`_v\` set from \`snap.event.version\`
+   * @param patches - Array of domain patches, one per emitted event
+   */
+  publish(
+    streamId: string,
+    state: S,
+    patches: Partial<S>[] = []
+  ): PatchMessage<S> {
+    this.state_cache.set(streamId, state);
+
+    const baseV = state._v - patches.length;
+    const msg: PatchMessage<S> = {};
+    patches.forEach((p, i) => {
+      msg[baseV + i + 1] = p;
+    });
+
+    const subs = this.channels.get(streamId);
+    if (subs?.size) {
+      for (const cb of subs) cb(msg);
+    }
+    return msg;
+  }
+
+  /**
+   * Publish a state update that doesn't change the event version
+   * (e.g. presence overlay, computed field refresh).
+   * Uses the same version as the cached state, single entry.
+   */
+  publish_overlay(
+    streamId: string,
+    overlay_patch: Partial<S>
+  ): PatchMessage<S> | undefined {
+    const prev = this.state_cache.get(streamId);
+    if (!prev) return undefined;
+
+    const state = apply_patch(prev, overlay_patch) as S;
+    this.state_cache.set(streamId, state);
+
+    const msg: PatchMessage<S> = { [state._v]: overlay_patch };
+    const subs = this.channels.get(streamId);
+    if (subs?.size) {
+      for (const cb of subs) cb(msg);
+    }
+    return msg;
+  }
+
+  /**
+   * Subscribe to broadcast messages for a stream.
+   * Returns a cleanup function that removes the subscription.
+   */
+  subscribe(streamId: string, cb: Subscriber<S>): () => void {
+    if (!this.channels.has(streamId)) this.channels.set(streamId, new Set());
+    this.channels.get(streamId)!.add(cb);
+    return () => {
+      this.channels.get(streamId)?.delete(cb);
+      if (this.channels.get(streamId)?.size === 0) {
+        this.channels.delete(streamId);
+      }
+    };
+  }
+
+  /** Get the number of subscribers for a stream. */
+  get_subscriber_count(streamId: string): number {
+    return this.channels.get(streamId)?.size ?? 0;
+  }
+
+  /** Get the cached state for a stream (for reconnects / initial SSE yield). */
+  get_state(streamId: string): S | undefined {
+    return this.state_cache.get(streamId);
+  }
+
+  /** Direct access to the state cache (for app-specific reads like presence). */
+  get cache(): StateCache<S> {
+    return this.state_cache;
+  }
+}
+
 // === errors.ts ===
 import {
   ConcurrencyError,
@@ -32258,8 +33420,13 @@ import {
   type TRPCBuiltRouter,
   TRPCError,
 } from "@trpc/server";
+import { z } from "zod";
 import {
   type ActorExtractor,
+  resolveSseConfig,
+  runSseSubscription,
+  SseConnectionCounter,
+  type SseOptions,
   toApiError,
   withIdempotency,
 } from "../api/index.js";
@@ -32313,6 +33480,22 @@ export type TrpcOptions<Ctx> = {
     readonly store: IdempotencyStore;
     readonly keyFrom: (ctx: Ctx) => string | undefined;
   };
+  /**
+   * Optional SSE wiring. When set, the generator emits one
+   * subscription per unique state name in the registry, grouped on
+   * the returned router as
+   * \`router.subscribe.<stateName>.useSubscription({ stream })\`.
+   * Each subscription yields \`{ kind: "state", data }\` once with
+   * the cached state (when present) and then \`{ kind: "patch",
+   * data }\` for every patch the shared
+   * {@link SseOptions.channel} publishes. The per-process
+   * connection cap surfaces as a \`TOO_MANY_REQUESTS\` \`TRPCError\`.
+   *
+   * Off by default — most APIs don't expose live state to every
+   * client, and opening one is widening both the auth and cost
+   * surface.
+   */
+  readonly sse?: SseOptions;
 };
 
 /**
@@ -32562,6 +33745,35 @@ export function trpc<
       });
   }
 
+  if (options.sse) {
+    const sse_config = resolveSseConfig(options.sse);
+    const sse_counter = new SseConnectionCounter(sse_config.maxConnections);
+    const state_names = new Set<string>();
+    for (const action of Object.values(app.registry.actions)) {
+      state_names.add(action.name);
+    }
+    const sse_handlers: Record<string, unknown> = {};
+    for (const state_name of state_names) {
+      sse_handlers[state_name] = t.procedure
+        .input(z.object({ stream: z.string().min(1) }))
+        .subscription(({ input, signal }) =>
+          runSseSubscription(
+            sse_config.channel,
+            input.stream,
+            sse_counter,
+            signal,
+            () => {
+              throw new TRPCError({
+                code: "TOO_MANY_REQUESTS",
+                message: "max concurrent SSE subscriptions reached",
+              });
+            }
+          )
+        );
+    }
+    handlers.subscribe = t.router(sse_handlers as never) as never;
+  }
+
   // The runtime router IS structurally compatible with
   // \`GeneratedRouter<TApp>\` (one mutation per action key), but tRPC's
   // \`BuiltRouter\` carries an internal \`Unwrap<Ctx>\` that the d.ts
@@ -32616,6 +33828,350 @@ export {
   toApiError,
 } from "./errors.js";
 export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
+export {
+  DEFAULT_SSE_HEARTBEAT_MS,
+  DEFAULT_SSE_MAX_CONNECTIONS,
+  resolveSseConfig,
+  runSseSubscription,
+  type SseAccounting,
+  type SseConfig,
+  SseConnectionCounter,
+  type SseOptions,
+  type SseSubscriptionFrame,
+} from "./sse-wiring.js";
+
+// === sse-wiring.ts ===
+import type { BroadcastChannel } from "../sse/broadcast.js";
+import type { BroadcastState } from "../sse/types.js";
+
+/**
+ * SSE wiring options shared by the auto-generated \`trpc\` and \`hono\`
+ * transports. When supplied, each transport emits one streaming
+ * subscription per registered state name, all reading from the same
+ * host-supplied {@link BroadcastChannel}.
+ *
+ * The host owns publication: every \`app.do(...)\` call site must
+ * forward the resulting snapshots to \`channel.publish(...)\` for
+ * subscribers to see updates. The framework deliberately doesn't
+ * auto-publish because the derived state usually needs app-specific
+ * overlays (presence, computed fields) that only the host can supply.
+ *
+ * Defaults are sized for typical business-app dashboards (dozens to
+ * hundreds of human viewers per process). Both numeric knobs are
+ * validated at transport-function construction; out-of-range values
+ * throw \`RangeError\` immediately so misconfiguration surfaces at
+ * startup instead of at first connection.
+ */
+export type SseOptions = {
+  /**
+   * The {@link BroadcastChannel} the generator's subscriptions hook
+   * into. Host owns its lifecycle; the generator does not construct
+   * one for you because the channel's \`<S>\` shape is app-specific and
+   * passing it in keeps the type chain typed end-to-end at the host.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the generator — narrowing it would force every state into one structural bound that doesn't fit real apps
+  readonly channel: BroadcastChannel<any>;
+  /**
+   * Hard cap on concurrent open subscriptions per generator
+   * instance. The 501st simultaneous open returns \`503\` (Hono) or
+   * throws \`TOO_MANY_REQUESTS\` (tRPC) — never a silent stall.
+   *
+   * Default \`500\`. Validated range \`[1, 10_000]\`. Above 10k the
+   * framework refuses to construct: at that point the FD ceiling
+   * and per-connection memory force horizontal scaling regardless
+   * of tuning, so the right move is sticky LB + per-process cap,
+   * not a higher single-process limit.
+   */
+  readonly maxConnections?: number;
+  /**
+   * Keep-alive cadence in milliseconds. Most reverse proxies idle
+   * connections out after ~60 seconds; the default \`30_000\` stays
+   * comfortably under.
+   *
+   * Validated range \`[15_000, 300_000]\`. Under 15 s wastes
+   * bandwidth on a business workload; over 5 min risks proxy drops.
+   */
+  readonly heartbeatMs?: number;
+};
+
+/**
+ * Resolved SSE configuration after validation and default expansion.
+ * Internal — the resolved values are what every transport actually
+ * runs against.
+ *
+ * @internal
+ */
+export type SseConfig = {
+  readonly channel: BroadcastChannel<BroadcastState>;
+  readonly maxConnections: number;
+  readonly heartbeatMs: number;
+};
+
+/**
+ * Default cap on concurrent open subscriptions per generator
+ * instance. Sized for typical business-app dashboards (dozens to a
+ * few hundred viewers); high enough not to surprise small
+ * deployments, low enough not to mask a missing horizontal-scale
+ * strategy on big ones.
+ */
+export const DEFAULT_SSE_MAX_CONNECTIONS = 500;
+
+/**
+ * Default keep-alive cadence (30 s). Sits comfortably under the
+ * 60 s idle timeout most reverse proxies impose.
+ */
+export const DEFAULT_SSE_HEARTBEAT_MS = 30_000;
+
+const MAX_CONNECTIONS_MIN = 1;
+const MAX_CONNECTIONS_MAX = 10_000;
+const HEARTBEAT_MS_MIN = 15_000;
+const HEARTBEAT_MS_MAX = 300_000;
+
+/**
+ * Validate and apply defaults to host-supplied {@link SseOptions}.
+ *
+ * Throws \`RangeError\` when either numeric knob is outside its
+ * documented range. Pure: same input → same output, no side
+ * effects, no I/O. Each transport calls this once at the start of
+ * \`hono(...)\` / \`trpc(...)\`.
+ */
+export function resolveSseConfig(options: SseOptions): SseConfig {
+  const max_connections = options.maxConnections ?? DEFAULT_SSE_MAX_CONNECTIONS;
+  const heartbeat_ms = options.heartbeatMs ?? DEFAULT_SSE_HEARTBEAT_MS;
+  if (
+    !Number.isFinite(max_connections) ||
+    max_connections < MAX_CONNECTIONS_MIN ||
+    max_connections > MAX_CONNECTIONS_MAX
+  ) {
+    throw new RangeError(
+      \`sse.maxConnections must be in [\${MAX_CONNECTIONS_MIN}, \${MAX_CONNECTIONS_MAX}], got \${max_connections}\`
+    );
+  }
+  if (
+    !Number.isFinite(heartbeat_ms) ||
+    heartbeat_ms < HEARTBEAT_MS_MIN ||
+    heartbeat_ms > HEARTBEAT_MS_MAX
+  ) {
+    throw new RangeError(
+      \`sse.heartbeatMs must be in [\${HEARTBEAT_MS_MIN}, \${HEARTBEAT_MS_MAX}], got \${heartbeat_ms}\`
+    );
+  }
+  return {
+    channel: options.channel,
+    maxConnections: max_connections,
+    heartbeatMs: heartbeat_ms,
+  };
+}
+
+/**
+ * Per-generator concurrent-open counter. Constructed once inside
+ * \`hono(...)\` / \`trpc(...)\` and consulted at every subscription
+ * open: failure to acquire means the cap has been hit and the
+ * transport reports \`503\` / \`TOO_MANY_REQUESTS\` to the caller.
+ *
+ * The counter is intentionally process-local. SSE doesn't multiplex
+ * across processes; operators wanting more than \`maxConnections\`
+ * viewers run multiple processes behind a sticky load balancer.
+ */
+export class SseConnectionCounter {
+  public readonly limit: number;
+  private _open = 0;
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  /**
+   * Reserve one slot. Returns \`true\` when accepted (caller must
+   * eventually {@link release} the slot, even on error paths) or
+   * \`false\` when the cap is already reached.
+   */
+  acquire(): boolean {
+    if (this._open >= this.limit) return false;
+    this._open++;
+    return true;
+  }
+
+  /**
+   * Free a previously-{@link acquire}d slot. Always runs from a
+   * \`finally\` block in the transport's subscription handler so
+   * crashed handlers don't leak count.
+   */
+  release(): void {
+    if (this._open > 0) this._open--;
+  }
+
+  /** Currently-open count. Test/observability hook. */
+  get open(): number {
+    return this._open;
+  }
+}
+
+/**
+ * Frame yielded by the per-state SSE subscription generator. The
+ * initial cached state (when present) arrives as \`kind: "state"\`;
+ * every subsequent broadcast publication arrives as \`kind: "patch"\`
+ * with the channel's \`PatchMessage\` payload.
+ */
+export type SseSubscriptionFrame<S> =
+  | { readonly kind: "state"; readonly data: S }
+  | { readonly kind: "patch"; readonly data: unknown };
+
+/**
+ * Subscription accounting hook. Implementations have a chance to
+ * acquire a slot before the loop starts and to release it once the
+ * loop's \`finally\` block runs — used by the tRPC side to enforce
+ * \`maxConnections\` from inside the generator, where it can throw
+ * \`TRPCError\` cleanly. Hono enforces the cap outside the loop (so a
+ * full counter returns \`503\` *before* streamSSE writes headers), then
+ * passes \`undefined\` here.
+ */
+export type SseAccounting = {
+  acquire(): boolean;
+  release(): void;
+};
+
+/**
+ * The shared subscription loop both transports run. Optionally
+ * acquires one slot on the supplied {@link SseAccounting}, yields the
+ * cached state (when present), then forwards every channel
+ * publication as a \`kind: "patch"\` frame until either the consumer
+ * breaks (calling \`iter.return()\`) or the supplied abort signal fires.
+ *
+ * Exported as the testable seam — the Hono and tRPC sibling
+ * generators wrap this so the signal-driven cleanup and counter
+ * accounting live in one place.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the channel's BroadcastState shape is opaque to the loop — narrowing it would force every state into one structural bound that doesn't fit real apps
+export async function* runSseSubscription<S extends { _v: number } = any>(
+  channel: BroadcastChannel<S>,
+  stream_id: string,
+  accounting: SseAccounting | undefined,
+  signal: AbortSignal | undefined,
+  on_cap_exceeded?: () => never
+): AsyncGenerator<SseSubscriptionFrame<S>> {
+  if (accounting && !accounting.acquire() && on_cap_exceeded) {
+    on_cap_exceeded();
+  }
+  const pending: unknown[] = [];
+  let resolve_wait: (() => void) | null = null;
+  const unsubscribe = channel.subscribe(stream_id, (msg) => {
+    pending.push(msg);
+    resolve_wait?.();
+  });
+  const on_abort = () => resolve_wait?.();
+  signal?.addEventListener("abort", on_abort);
+  try {
+    const cached = channel.get_state(stream_id);
+    if (cached !== undefined) {
+      yield { kind: "state", data: cached };
+    }
+    while (!signal?.aborted) {
+      if (pending.length === 0) {
+        await new Promise<void>((resolve) => {
+          resolve_wait = resolve;
+        });
+        if (signal?.aborted) break;
+      }
+      const msg = pending.shift();
+      yield { kind: "patch", data: msg };
+    }
+  } finally {
+    signal?.removeEventListener("abort", on_abort);
+    unsubscribe();
+    accounting?.release();
+  }
+}
+
+// === state-cache.ts ===
+import type { BroadcastState } from "./types.js";
+
+/**
+ * Generic LRU cache for aggregate state objects.
+ *
+ * Keyed by stream ID. Each entry stores the full state (with \`_v\` from the
+ * event store). Used as the "previous state" baseline for computing patches,
+ * and as the fast path for reconnects.
+ *
+ * The cache is shared between the broadcast hot path and read queries.
+ * Projections should maintain their own cache to avoid double-apply bugs.
+ */
+export class StateCache<S extends BroadcastState = BroadcastState> {
+  private cache = new Map<string, S>();
+  private maxSize: number;
+
+  constructor(maxSize = 50) {
+    this.maxSize = maxSize;
+  }
+
+  /** Get a cached state, promoting it to MRU position. */
+  get(key: string): S | undefined {
+    const s = this.cache.get(key);
+    if (s) {
+      this.cache.delete(key);
+      this.cache.set(key, s);
+    }
+    return s;
+  }
+
+  /** Set a cached state, evicting the LRU entry if at capacity. */
+  set(key: string, state: S): void {
+    this.cache.delete(key);
+    this.cache.set(key, state);
+    if (this.cache.size > this.maxSize) {
+      this.cache.delete(this.cache.keys().next().value!);
+    }
+  }
+
+  /** Remove a cached entry. */
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  /** Check if a key exists in the cache. */
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Current number of cached entries. */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Direct access to the underlying map (for iteration). */
+  entries(): IterableIterator<[string, S]> {
+    return this.cache.entries();
+  }
+}
+
+// === types.ts ===
+import type { DeepPartial } from "@rotorsoft/act-patch";
+
+/**
+ * Base constraint for state objects managed by the broadcast system.
+ * Apps extend this with their own domain state shape.
+ */
+export type BroadcastState = Record<string, unknown> & {
+  /** Event store stream version — set by the broadcast layer from snap.event.version */
+  _v: number;
+};
+
+/**
+ * SSE message: version-keyed domain patches.
+ * Keys are stringified version numbers, values are domain patches (deep partials).
+ * Multi-event commits produce multiple version-keyed entries.
+ */
+export type PatchMessage<S extends BroadcastState = BroadcastState> = Record<
+  number,
+  DeepPartial<S>
+>;
+
+/**
+ * Subscriber callback — receives version-keyed patch messages.
+ */
+export type Subscriber<S extends BroadcastState = BroadcastState> = (
+  msg: PatchMessage<S>
+) => void;
 "
 `;
 

--- a/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
+++ b/libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap
@@ -28956,6 +28956,7 @@ export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
 export {
   DEFAULT_SSE_HEARTBEAT_MS,
   DEFAULT_SSE_MAX_CONNECTIONS,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   type SseAccounting,
@@ -29130,6 +29131,21 @@ export class SseConnectionCounter {
   get open(): number {
     return this._open;
   }
+}
+
+/**
+ * Wrap a fire-and-forget Promise-returning operation so its
+ * rejection is swallowed in place of leaking an unhandled
+ * rejection. Used by the Hono heartbeat tick (the interval callback
+ * isn't \`await\`ed, so its rejection has nowhere to go) and by any
+ * other "best-effort write" the transports run.
+ *
+ * Pure: same input → same output, no side effects on the caller.
+ * Returns the chained Promise so the caller can also \`await\`
+ * completion if they want to (the Hono heartbeat doesn't).
+ */
+export function fireAndForget<T>(op: () => Promise<T>): Promise<T | undefined> {
+  return op().catch(() => undefined);
 }
 
 /**
@@ -29656,6 +29672,7 @@ import { streamSSE } from "hono/streaming";
 import {
   type ActorExtractor,
   type ApiError,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   SseConnectionCounter,
@@ -29884,9 +29901,9 @@ export function hono<TApp extends ActSurface = ActSurface>(
         return streamSSE(c, async (sse_stream) => {
           sse_stream.onAbort(() => controller.abort());
           const heartbeat = setInterval(() => {
-            sse_stream
-              .writeSSE({ event: "ping", data: "" })
-              .catch(() => undefined);
+            fireAndForget(() =>
+              sse_stream.writeSSE({ event: "ping", data: "" })
+            );
           }, sse_config.heartbeatMs);
           try {
             for await (const frame of runSseSubscription(
@@ -30023,6 +30040,7 @@ export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
 export {
   DEFAULT_SSE_HEARTBEAT_MS,
   DEFAULT_SSE_MAX_CONNECTIONS,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   type SseAccounting,
@@ -30197,6 +30215,21 @@ export class SseConnectionCounter {
   get open(): number {
     return this._open;
   }
+}
+
+/**
+ * Wrap a fire-and-forget Promise-returning operation so its
+ * rejection is swallowed in place of leaking an unhandled
+ * rejection. Used by the Hono heartbeat tick (the interval callback
+ * isn't \`await\`ed, so its rejection has nowhere to go) and by any
+ * other "best-effort write" the transports run.
+ *
+ * Pure: same input → same output, no side effects on the caller.
+ * Returns the chained Promise so the caller can also \`await\`
+ * completion if they want to (the Hono heartbeat doesn't).
+ */
+export function fireAndForget<T>(op: () => Promise<T>): Promise<T | undefined> {
+  return op().catch(() => undefined);
 }
 
 /**
@@ -33831,6 +33864,7 @@ export { type IdempotencyResult, withIdempotency } from "./idempotency.js";
 export {
   DEFAULT_SSE_HEARTBEAT_MS,
   DEFAULT_SSE_MAX_CONNECTIONS,
+  fireAndForget,
   resolveSseConfig,
   runSseSubscription,
   type SseAccounting,
@@ -34005,6 +34039,21 @@ export class SseConnectionCounter {
   get open(): number {
     return this._open;
   }
+}
+
+/**
+ * Wrap a fire-and-forget Promise-returning operation so its
+ * rejection is swallowed in place of leaking an unhandled
+ * rejection. Used by the Hono heartbeat tick (the interval callback
+ * isn't \`await\`ed, so its rejection has nowhere to go) and by any
+ * other "best-effort write" the transports run.
+ *
+ * Pure: same input → same output, no side effects on the caller.
+ * Returns the chained Promise so the caller can also \`await\`
+ * completion if they want to (the Hono heartbeat doesn't).
+ */
+export function fireAndForget<T>(op: () => Promise<T>): Promise<T | undefined> {
+  return op().catch(() => undefined);
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #846 and the act-http-api epic (#835). Adds an opt-in `sse` option to both `trpc(app, options)` and `hono(app, options)` that walks the registry once and emits one typed subscription per unique state name, all reading from a host-supplied `BroadcastChannel`. Hosts keep owning publication (`channel.publish(...)` after each `app.do(...)`); the generator owns subscription, accounting, cleanup, and the wire format.

## API shape

\`\`\`ts
import { BroadcastChannel } from "@rotorsoft/act-http/sse";
import { trpc } from "@rotorsoft/act-http/trpc";
import { hono } from "@rotorsoft/act-http/hono";

const broadcast = new BroadcastChannel<MyState>();

const router = trpc(app, { actor, stream, sse: { channel: broadcast } });
// → router.subscribe.<stateName>.useSubscription({ stream })

const api = hono(app, { actor, stream, sse: { channel: broadcast } });
// → GET /api/sse/<stateName>?stream=<id>  (text/event-stream)
\`\`\`

## What the generator owns

- Actor extraction (401 / UNAUTHORIZED on throw).
- Per-process slot cap (\`maxConnections\`, default 500, range \`[1, 10_000]\`). Full counter → 503 / SSE_BUSY + \`Retry-After: 1\` (Hono) or \`TRPCError({ code: "TOO_MANY_REQUESTS" })\` (tRPC).
- Initial \`{ kind: "state" }\` yield from the channel's cache (cold-start affordance — no separate \`getById\` query needed).
- \`{ kind: "patch" }\` per channel publication.
- Heartbeat ping every \`heartbeatMs\` (default 30 s, range \`[15_000, 300_000]\`) — under the 60 s idle timeout most reverse proxies impose.
- Teardown via the loop's \`finally\` block: unsubscribe, release the slot, clear the heartbeat. Runs on \`iter.return()\`, signal abort, and crashed handlers alike.

Out-of-range knobs throw \`RangeError\` at transport construction — misconfiguration surfaces at startup, not at first connection.

## Shared seam

\`runSseSubscription\` from \`@rotorsoft/act-http/api\` is exported so adopters who want to build a different transport (WebSocket, custom long-poll) ride the same accounting + cancellation discipline. The Hono and tRPC sibling generators each wrap it.

## Tests + coverage

- **Unit** (\`test/api/sse-wiring.spec.ts\`, 16 tests): default expansion, range failures, NaN/Infinity guard, counter acquire/release, sub-zero release no-op, \`runSseSubscription\` cached-then-patch, cap exceeded, signal-driven drain, no-cached-state path, consumer-break cleanup.
- **Hono integration** (\`test/hono/sse.spec.ts\`, 10 tests): per-state emission, no-sse omits routes, missing \`?stream\` → 400, cached + patch yields, no-cached + patch yields, cap → 503 + Retry-After, slot release allows reopen, actor-throw → 401, heartbeat fires, write-rejection swallowed.
- **tRPC integration** (\`test/trpc/sse.spec.ts\`, 8 tests): nested \`subscribe.<stateName>\` keys, no-sse omits, cached + patch yields, no-cached + patch yields, cap enforced, slot release allows reopen, abort drains generator, input validation rejects empty stream.

Workspace coverage: **99.98% statements / 99.96% branches / 99.91% functions / 99.98% lines**. The single uncovered line is a defensive \`.catch(() => undefined)\` on Hono heartbeat write (line 287) — deterministic exercise requires real-time WHATWG-stream cancellation propagation that fake timers don't model. Same pattern as the existing defensive line at \`webhook/index.ts:90\`.

## Docs + migration

- \`libs/act-http/README.md\` — new "tRPC + Hono SSE subscriptions" Quick start section, plus API reference entries on every subpath.
- \`docs/docs/guides/auto-generated-api.md\` — new "Real-time subscriptions" section covering what the generator owns, defaults + validation, why SSE not WebSocket, horizontal scaling.
- \`.claude/skills/scaffold-act-app/\` — \`api.md\` callout now points at the generator-emitted state-subscription as the default for per-stream live state, with the hand-written \`onEvent\` route remaining for the global-event-log replay surface the generator doesn't cover. Every \`@rotorsoft/act-sse\` reference across the skill is updated to \`@rotorsoft/act-http/sse\` (the consolidated package the original lives under).

## Test plan

- [x] \`pnpm typecheck\` — clean across the workspace
- [x] \`pnpm test\` — 2242 / 2242 passing, 99.98% coverage
- [x] \`pnpm lint\` on changed files — clean
- [x] \`pnpm build\` — every package emits without TS errors
- [x] Charter-covered surfaces untouched
- [x] Stability snapshots regenerated (\`libs/act-tck/test/__snapshots__/all-packages-stability.spec.ts.snap\`)
- [ ] CI green
- [ ] Manual: spin up the multi-transport demo + add an SSE consumer using \`new EventSource("/api/sse/Calculator?stream=calc-1")\`

## Stability charter impact

None. Additive options on \`TrpcOptions\` / \`HonoOptions\` (both default off), new named exports from \`@rotorsoft/act-http/api\`. No charter-covered surface modified.

## Follow-ups

- Closes the act-http-api epic (#835) — no remaining sub-tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)