### PR TITLE
docs: add recipes/ folder + close act-ops milestone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,23 @@ If schemas aren't being captured for an event, the parser is best-effort: it wal
 | Adding a new `@rotorsoft/act-*` package | [docs/docs/guides/contributing-new-package.md](docs/docs/guides/contributing-new-package.md) |
 | Inspecting contracts with the `act` CLI | [docs/docs/guides/contracts-cli.md](docs/docs/guides/contracts-cli.md) |
 
+### Operator recipes
+
+When an Act application hits the edges (events table growing without bound, cooldowns after terminal state, regulated retention windows, partition-drop archival), the playbook lives in [`recipes/`](recipes/README.md) at the repo root — separate from `libs/` (framework code), `docs/` (framework reference), and `book/` (design-history essays).
+
+| Topic | File |
+|---|---|
+| Top-level operator landing + envelope of safe operation | [recipes/README.md](recipes/README.md) |
+| Scaling decision tree (symptoms → recipe) | [recipes/scaling/README.md](recipes/scaling/README.md) |
+| Close-the-books patterns (`.autocloses({...})`) | [recipes/scaling/close-the-books/README.md](recipes/scaling/close-the-books/README.md) |
+| Cold-tier archival (`.archives(...)` + S3 / JSONL) | [recipes/scaling/archival/README.md](recipes/scaling/archival/README.md) |
+| Partitioning gating page (the "don't" page) | [recipes/scaling/partitioning/README.md](recipes/scaling/partitioning/README.md) |
+| HASH-on-stream partition recipe (SQL + run.sh) | [recipes/scaling/partitioning/hash-on-stream/](recipes/scaling/partitioning/hash-on-stream/README.md) |
+| RANGE-on-id (single-aggregate giants, docs only) | [recipes/scaling/partitioning/range-on-id/](recipes/scaling/partitioning/range-on-id/README.md) |
+| RANGE-on-created (bulk archival via DROP PARTITION) | [recipes/scaling/partitioning/range-on-created/](recipes/scaling/partitioning/range-on-created/README.md) |
+
+Recipe conventions: each folder has a README + optional runnable artifacts (`.sql` files using `{{schema}}` / `{{table}}` placeholders, `run.sh` wrappers, `.ts` samples that compile against the live `@rotorsoft/act` API). The framework code stays unchanged — recipes are operator playbooks, not framework features. New recipes land here when an operator hits a real wall the existing pages don't cover.
+
 ### Performance evidence
 
 Per-package `PERFORMANCE.md` files track benchmark history with before/after numbers per optimization. READMEs link to them; READMEs themselves stay narrative.

--- a/biome.json
+++ b/biome.json
@@ -94,6 +94,7 @@
         "**/*.bench.ts",
         "packages/**",
         "performance/**",
+        "recipes/**",
         "libs/act-diagram/src/server/**"
       ],
       "linter": {

--- a/libs/act-pg/PARTITIONING.md
+++ b/libs/act-pg/PARTITIONING.md
@@ -1,111 +1,13 @@
 # Partitioning the events table
 
-> **TL;DR — don't.** For almost every Act application, the right answer to "my events table is growing" is `Act.close()`, not partitioning. Partitioning is an **extreme-case escape valve** for the narrow set of workloads where the default storage adapter genuinely can't serve the business. Read this page if and only if you've already ruled out close-the-books as a solution.
+> **This page moved to [`/recipes/scaling/partitioning/`](../../recipes/scaling/partitioning/README.md).**
 
-## Why this page leads with "don't"
+Partitioning is one of several operational recipes for Act applications that have outgrown the default storage path. It lives in the repo's [`recipes/`](../../recipes/README.md) folder alongside the other strategies (`.autocloses({...})` to retire streams, `.archives(...)` to ship history to cold storage before truncate, range-by-created partition drops for regulatory disposal).
 
-Partitioning is operationally heavy. It adds migration downtime, ongoing planner overhead, a more complex query plan for every cross-stream read, and (for range strategies) ongoing partition-maintenance toil. It also fights against event sourcing's central invariant — global `id` ordering — in ways that are easy to under-appreciate until you measure them.
+The page that lived here is now the gating page at [`recipes/scaling/partitioning/README.md`](../../recipes/scaling/partitioning/README.md) — same content, plus the three strategy recipes split into their own folders with SQL templates and runnable shell wrappers:
 
-If you reach for partitioning before you have a workload that genuinely needs it, you'll pay the operational cost without the operational win. So this page is structured as a series of gates: each section is a chance to stop, conclude "partitioning isn't the answer for me," and close the tab.
+- **HASH on `stream`** — [`recipes/scaling/partitioning/hash-on-stream/`](../../recipes/scaling/partitioning/hash-on-stream/README.md)
+- **RANGE on `id`** (single-aggregate giants) — [`recipes/scaling/partitioning/range-on-id/`](../../recipes/scaling/partitioning/range-on-id/README.md)
+- **RANGE on `created`** (bulk archival) — [`recipes/scaling/partitioning/range-on-created/`](../../recipes/scaling/partitioning/range-on-created/README.md)
 
-## The global-`id` constraint
-
-Act's event store assigns a monotonic `id` to every event across every stream. That global order is **load-bearing** for the framework:
-
-- **Drain** reads events in `id` order to dispatch reactions deterministically.
-- **Projections** advance by `id` watermark — `(id > last_id ORDER BY id)` is the canonical fetch shape.
-- **`app.reset()`** replays projections by walking the entire events table in `id` order.
-- **Cross-stream causality** — debugging "what happened first across the system" relies on `id` being a total order.
-
-Partitioning preserves the **shared `events_id_seq`**, so the IDs themselves stay monotonic. What it does *not* preserve is **single-partition scans for global-order queries**. Any read that needs "the next N events across all streams in id order" must:
-
-1. Open every partition,
-2. Sort each partition's rows by `id`,
-3. `MergeAppend` the per-partition streams into one ordered cursor.
-
-PG's planner does this well, but the cost is linear in partition count. For an events table partitioned 16 ways, every drain query, every projection advance, every full `app.reset` does **16× the planner work and 16× the I/O setup** that an unpartitioned table would do. If your workload is dominated by these cross-stream reads — and **most event-sourced workloads are** — partitioning costs you on the hottest path.
-
-The implication: partitioning's classic upside ("parallel scan across partitions makes things faster") collides with event sourcing's "I need global id order to make sense of anything." For most queries you can't parallelize without paying MergeAppend, and the queries that *can* prune to a single partition (single-stream `claim`, `commit`, `load`) were already fast on the unpartitioned table.
-
-Carry this trade-off through every section below.
-
-## First gate: can `Act.close()` handle the growth?
-
-`Act.close(targets)` truncates a stream's events and leaves a `__tombstone__` (or `__snapshot__`) behind, reclaiming the row count for streams that are semantically complete. For the dominant Act workload — domain aggregates with a definite lifecycle (orders, tickets, sessions, payments) — close is the right tool.
-
-```ts
-await app.close([
-  { stream: "order-2024-12345", archive: async () => { /* S3 dump */ } },
-]);
-```
-
-The companion epic **act-close-the-books** (#802) lets `close()` happen automatically on a per-state policy (`.autocloses(retention(90, "days"))`, `.autocloses(terminal("OrderCompleted"))`, etc.). Once that's wired, an app's events table reaches a steady state — closed streams shed their history continuously, the table doesn't grow without bound, and no partitioning is required.
-
-**If `close()` can keep your events table in steady state, stop reading. You don't need partitioning.**
-
-You should think hard before deciding `close()` can't help. Apps frequently believe their streams are "long-lived and never end" when in fact most of them have natural terminal events that go unused (sessions that expired six months ago, tickets that nobody will ever reopen, carts that were abandoned). Adding a terminal close policy is almost always cheaper than partitioning.
-
-## Second gate: do you have an extreme workload?
-
-The narrow set of workloads where `close()` genuinely can't help:
-
-1. **Regulated / append-only audit logs.** Financial ledgers, compliance trails, blockchain-adjacent systems where deletion is forbidden by policy or law. `Act.close()` is unavailable because tombstones are still "deletion" in the strict regulatory reading. The events table grows monotonically forever; index height, VACUUM duration, and planner stats eventually dominate tail latency.
-
-2. **Single-aggregate giants.** One stream with millions of events on a single aggregate — a multi-year IoT device telemetry trail, a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might.
-
-3. **Bulk archival with retention windows.** Regulatory frameworks that require retention for N months and then mandate disposal. `Act.close()` deletes per-row, which is slow on hundreds of millions of rows; `DETACH PARTITION` + `DROP TABLE` is constant-time DDL regardless of partition size. Some regulators also accept partition-drop as "physical retention until partition retirement," which is more defensible than per-row delete.
-
-4. **Parallel projection rebuild as the bottleneck.** Operations teams running periodic full `app.reset()` on a multi-hundred-million-row events table, where the rebuild window is the operational bottleneck. *Caveat:* see the global-`id` discussion above — partitioning helps rebuild throughput only when the partitioned MergeAppend cost is dominated by per-partition parallel I/O. Benchmark before assuming this; the framework's PG benchmark (#851) reports observed vs theoretical speedup for exactly this reason.
-
-**If your workload doesn't hit one of these four cases, stop reading.** You don't need partitioning. The remaining sections are for the operators who legitimately do.
-
-## When partitioning doesn't help at all
-
-Even if you fit one of the four extreme cases, partitioning isn't always the right shape. Cases where it's specifically *not* the answer:
-
-- **Events table under ~10M rows.** Planner overhead from partition pruning + MergeAppend costs more than the table size saves.
-- **Cross-stream queries dominate.** If your projections / reactions span many streams and need global id order, partitioning slows the read path. Even the rebuild win is conditional.
-- **No HA replicas.** The migration to partitioned shape rewrites the table — WAL volume is significant and a non-replicated database means the migration window is the only window.
-- **Single-tenant SaaS with bounded customer count.** Cap the customer-stream count via the `cardinality` close policy instead; you'll get bounded storage without the partitioning operational tax.
-- **You haven't measured `close()` first.** This is the most common mistake. Operators reach for partitioning before they've actually quantified what `close()` would save them.
-
-## If partitioning is still the answer: strategy menu
-
-Three strategies, each with different trade-offs. None of them is "better partitioning" — they buy different properties for different problems.
-
-| Strategy | Migration | Ongoing cost | Solves |
-|---|---|---|---|
-| **HASH on `stream`** | Full table copy (offline or `pg_repack`-online). Set-and-forget after. | Cross-stream queries pay MergeAppend across N partitions. Single-stream queries unaffected. | Regulated append-only audit; parallel rebuild *if* the benchmark supports it |
-| **RANGE on `id`** | Full table copy. Ongoing: provision new partitions as the id sequence grows. | `ORDER BY id` queries can prune to one partition (the hot one). Older partitions go cold and can be moved to slower storage. | Single-aggregate giants; bounded planner cost as the table grows |
-| **RANGE on `created`** | Full table copy. Ongoing: `pg_partman` (or manual cron) provisions monthly/yearly partitions. | `DETACH` + `DROP` is constant-time bulk archival. Cross-stream queries pay MergeAppend. | Retention-window bulk archival in regulated domains |
-
-Notes on each:
-
-- **HASH on `stream`** is the workhorse if you must partition for general storage growth. A stream's events colocate in one partition, so `claim()` and single-stream reads prune cleanly. Cross-stream operations pay the MergeAppend cost — be sure you measured this on your workload before committing.
-
-- **RANGE on `id`** is the only strategy that helps "single-aggregate giant" scenarios. It deliberately splits one stream across partitions, ordered by the global id. Recent partitions stay hot, older partitions go cold. Document-light: range partitioning is a per-app schema design (event volume, retention window, archival policy), not a turn-key recipe. The framework documents the *strategy*; the schema is yours to design.
-
-- **RANGE on `created`** is the strategy for bulk archival by retention window. Pair with `pg_partman` for partition creation and the framework's `drop-partition.ts` runner (#853, when shipped) for the archival half of the loop. Don't use this strategy if you don't have a clean retention boundary — picking a wrong cutoff means re-partitioning later, which is the same migration cost twice.
-
-## Costs you'll see no matter which strategy you pick
-
-- **PK becomes composite.** Partitioning by anything other than `id` requires the partition key to be in every unique constraint. The events PK becomes `(id, partition_key)` instead of `id`. This is mechanically fine but breaks any external tooling that assumed `id` alone uniquely identifies a row.
-- **Index storage.** Each index is recreated per partition. For N partitions and K indexes, you have N×K index trees instead of K. Disk overhead is small per index but non-zero.
-- **`events_id_seq` is shared.** The sequence stays global so `id` monotonicity holds across partitions. This is a feature, not a cost — without it, the framework's global-order assumptions break entirely.
-- **Planner overhead.** Every query consults more relations. PG ≥ 14 with `enable_partition_pruning = on` (default) caches pruned plans, so prepared statements amortize. Ad-hoc queries pay a small constant overhead per partition checked.
-- **Rebuild semantics.** `app.reset(targets)` still works post-migration; the cost depends on whether your workload's hot path is single-stream (cheap) or cross-stream (MergeAppend). Run the partitioning benchmark (#851) on your data shape before committing — the theoretical N× parallel speedup is rarely the observed speedup, and may not exist at all on cross-stream-dominated workloads.
-
-## Recipes
-
-The framework ships recipes for the strategies that have a clean turn-key implementation. Range-based schema design is yours to own.
-
-- **HASH partitioning** — migration script + `--confirm` runner: see *(linked from #850 once shipped — `libs/act-pg/migrations/partitioned/001_hash_partition_events.sql`)*.
-- **Partition-drop archival (RANGE on `created`)** — migration + drop runner: see *(linked from #853 once shipped)*.
-- **Range partitioning for single-aggregate giants** — documentation-only guidance: see *(linked from #852 once shipped)*.
-- **Parallel rebuild benchmark** — observed-vs-theoretical numbers on partitioned vs unpartitioned `app.reset`: see *(linked from #851 once shipped → `libs/act-pg/PERFORMANCE.md`)*.
-
-## If you remember one thing
-
-Partitioning is the answer to a problem most Act apps don't have. It is operationally heavy, fights against event sourcing's global-`id` ordering on the cross-stream read path, and almost always costs more than it saves unless the workload genuinely belongs to one of the four extreme cases above.
-
-`Act.close()` — manual or via the `.autocloses(...)` policy from epic #802 — is the right answer for the dominant workload. Reach for partitioning only after you've ruled close out, measured the cost, and confirmed that your workload is the narrow exception that justifies the operational tax.
+Read the gating page first. Most Act applications don't need any of these — `.autocloses({...})` is the right answer for the dominant workload.

--- a/libs/act-pg/README.md
+++ b/libs/act-pg/README.md
@@ -142,7 +142,7 @@ Created by `seed()`:
 
 The unpartitioned default schema is the right shape for almost every Act application. If you find yourself wondering whether your `events` table needs partitioning, the first answer is almost always `Act.close()` — see the [Production checklist](https://rotorsoft.github.io/act-root/docs/guides/production-checklist) and the [auto-close epic (#802)](https://github.com/Rotorsoft/act-root/issues/802) for the policies that keep a steady-state events table without partitioning.
 
-For the narrow set of workloads where `close()` genuinely can't help (regulated append-only audit logs, single-aggregate giants, retention-window bulk archival, parallel-rebuild bottlenecks), see [PARTITIONING.md](./PARTITIONING.md). The page leads with "don't" — read it before reaching for the SQL.
+For the narrow set of workloads where `close()` genuinely can't help (regulated append-only audit logs, single-aggregate giants, retention-window bulk archival, parallel-rebuild bottlenecks), the operator playbook lives at [`recipes/scaling/`](../../recipes/scaling/README.md) — the page leads with "don't" and walks through the gates before reaching any SQL.
 
 ## When to use this vs `act-sqlite`
 
@@ -181,7 +181,7 @@ Public API governed by the [Act Stability Charter](../../STABILITY.md). `Postgre
 - **[Concurrency model](https://rotorsoft.github.io/act-root/docs/architecture/concurrency-model)** — lease lifecycle, `claim`/`ack`/`block`/timeout, optimistic concurrency.
 - **[Writing a custom Store adapter](https://rotorsoft.github.io/act-root/docs/guides/writing-a-store)** — the recipe `PostgresStore` itself follows, for authors building against other databases.
 - **[PERFORMANCE.md](./PERFORMANCE.md)** — measured throughput numbers, including the `notify` latency benchmark.
-- **[PARTITIONING.md](./PARTITIONING.md)** — extreme-case escape valve when `close()` isn't enough. The page leads with reasons not to partition.
+- **[Scaling recipes](../../recipes/scaling/README.md)** — operator playbook for the symptoms `act-pg` apps hit at the edges (close-the-books, archival, partitioning). Read this before reaching for any DDL.
 
 ## License
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,69 @@
+# Act recipes
+
+Operator-facing playbook for running an Act application in production. This folder is for the moments where you've stopped writing domain code and started thinking about indexes, maintenance windows, and weekly cron jobs. Framework reference lives in `docs/docs/` and the design history is in `book/`; this tree is the operations handbook.
+
+The framing the rest of this folder is built around: **default Act plus Postgres plus close-the-books handles almost every real workload.** This folder documents what "almost" actually means — the symptoms of the walls you might hit, and the recipes for getting past them.
+
+## What "default Act handles" looks like
+
+Concrete envelope of safe operation, all numbers traced back to the bench scripts in [`libs/act/PERFORMANCE.md`](../libs/act/PERFORMANCE.md) and [`libs/act-pg/PERFORMANCE.md`](../libs/act-pg/PERFORMANCE.md). Run the same scripts on your hardware before quoting them in capacity planning.
+
+| Dimension                                  | Where you stop being CPU-bound                                                                         | Source                                                                            |
+|--------------------------------------------|--------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| Cross-stream commits, InMemoryStore        | ~13,900 commits/sec at 50-way parallelism (synthetic upper bound)                                       | `libs/act/PERFORMANCE.md` § Current scenarios                                     |
+| Same-stream contention, InMemoryStore      | ~8,000 commits/sec with retries, no invariants                                                          | `libs/act/PERFORMANCE.md` § Current scenarios                                     |
+| Realistic ticket workflow (3 actions, 2 invariants) | ~414 commits/sec — the synthetic-to-realistic gap is roughly 50%                                 | `libs/act/PERFORMANCE.md` § Realistic workloads                                   |
+| Realistic same-stream contention with invariant | ~3,940 commits/sec — about half the synthetic ceiling                                              | `libs/act/PERFORMANCE.md` § Realistic workloads                                   |
+| Single-process reaction latency floor (PG) | p50 ~4 ms idle / ~10 ms at 100 commits/sec, saturates around 200 commits/sec sustained                  | `libs/act/PERFORMANCE.md` § Reaction latency                                      |
+| Cross-process commit→reaction latency (PG) | p50 11 ms via LISTEN/NOTIFY; polling at 50 ms is roughly 3× slower; default 10 s polling is ~1000× off  | `libs/act-pg/PERFORMANCE.md` § ACT-101                                            |
+
+Numbers above are macOS 25.4 (Apple Silicon) against the docker PG used by the adapter's own tests (`postgres:17-alpine` on port 5431). Production PG running on commodity Linux with persistent disks lands in the same order of magnitude — expect tail latency to be jumpier under autovacuum and replication, and re-run the scripts before quoting anything in a runbook.
+
+**On the storage shape itself:** events table growth is linear, and PG's btree indexes serve billions of rows without any algorithmic surprise. The walls you hit first are operational — VACUUM duration, replication lag, the size of the table dump you have to take during a schema migration window — not query planner failure. If your events table is under 10M rows and your maintenance windows fit, you have no engineering problem; you have an organic accumulation that the next section addresses.
+
+## Reach for close-the-books before anything else
+
+Almost every "my events table is growing" symptom is solved by retiring streams that have finished their business lifecycle. Resolved tickets, completed orders, expired sessions, abandoned carts — the events stay correct and the stream stays auditable, but the row count comes back to the framework for the next live stream. The mechanism is `Act.close()` plus the declarative `.autocloses({...})` policy that runs the same primitive on a background cycle.
+
+```ts
+const Ticket = state({ Ticket: ticketSchema })
+  .init(() => defaults)
+  .emits({ TicketOpened, TicketResolved })
+  // …
+  .autocloses({ is: "TicketResolved", after: { days: 90 } })
+  .archives(async (stream, head) => {
+    await s3.upload(`tickets/${stream}.jsonl`, await loadHistory(stream));
+  })
+  .build();
+```
+
+Full syntax (verb-shaped declarative form, `or: {...}` backstops, archive contract, cycle knobs) lives in [`docs/docs/guides/close-policies.md`](../docs/docs/guides/close-policies.md). The recipe at [`recipes/scaling/close-the-books/README.md`](scaling/close-the-books/README.md) is the operator-side companion: when to declare which predicate, what to monitor on the cycle, how to handle predicates that throw, and the cost model for the per-cycle scan.
+
+If `close()` can keep your events table in steady state — and for the dominant Act workload it can — none of the heavier recipes in this folder apply to you. Stop there.
+
+## Recipe index
+
+| Recipe                                                                              | Use when                                                                                               | Operational tax            |
+|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|----------------------------|
+| [scaling/README.md](scaling/README.md)                                              | You're not sure which recipe applies. Decision tree maps symptoms to recipes.                          | Reading time only          |
+| [scaling/close-the-books/README.md](scaling/close-the-books/README.md)              | Events table growing because finished streams aren't shedding history. Solves 90% of growth concerns.  | Per-cycle scan + tombstones |
+| [scaling/archival/README.md](scaling/archival/README.md)                            | You want to persist a stream's events to a cold tier (S3, warehouse) before `close()` truncates them.  | `.archives` handler latency on the close-cycle guard window |
+| [scaling/partitioning/README.md](scaling/partitioning/README.md)                    | You're in one of the four extreme cases where `close()` genuinely can't help. Gating page leads with "don't." | Migration window + ongoing planner overhead + range maintenance |
+
+Partitioning itself splits into three subrecipes that buy different properties:
+
+| Subrecipe                                                                                                           | Solves                                                                                |
+|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| [scaling/partitioning/hash-on-stream/README.md](scaling/partitioning/hash-on-stream/README.md)                       | Regulated append-only audit logs where deletion is forbidden                          |
+| [scaling/partitioning/range-on-id/README.md](scaling/partitioning/range-on-id/README.md)                             | Single-aggregate giants (one stream with millions of events, can't be closed)         |
+| [scaling/partitioning/range-on-created/README.md](scaling/partitioning/range-on-created/README.md)                   | Retention-window bulk archival — `DETACH PARTITION` + `DROP TABLE` instead of per-row delete |
+
+## Conventions
+
+Each recipe is a folder with a `README.md` and optional runnable artifacts: raw SQL files, shell scripts, occasional TypeScript samples. The SQL files use `{{schema}}` and `{{table}}` placeholders matching the PG adapter's identifier shape; substitute them with `sed` or `envsubst` against your own deployment's identifiers before running anything against a live database. Shell scripts use `bash` and assume `psql` on `PATH`. TypeScript samples are runnable against the `postgres:17-alpine` docker container on port 5431 that backs the PG adapter's own test suite (`docker run -d --name pg-stress -p 5431:5432 -e POSTGRES_PASSWORD=postgres postgres:17-alpine`) so you can rehearse a recipe against an ephemeral DB before adapting it for production.
+
+Every recipe is written as something an operator runs during a maintenance window, not something the framework runs for you. Recipes that need a tickle every N hours (range partition provisioning, archival uploads with retry) get a sample cron stanza in their README; the framework itself stays out of the loop.
+
+## When the recipes don't cover your case
+
+If you've worked through the decision tree and the wall you're hitting isn't here, open an issue at [Rotorsoft/act-root](https://github.com/Rotorsoft/act-root/issues) tagged `area:ops` with the symptom (table size, query, percentile that's slipping), the bench script you used to characterize it, and the close-the-books policy you've already tried. The recipes folder grows by case; "we hit this wall and the existing recipes didn't fit" is exactly the input that adds a new one.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -2,6 +2,20 @@
 
 Operator-facing playbook for running an Act application in production. This folder is for the moments where you've stopped writing domain code and started thinking about indexes, maintenance windows, and weekly cron jobs. Framework reference lives in `docs/docs/` and the design history is in `book/`; this tree is the operations handbook.
 
+## Act is for business apps
+
+Before any of the scaling recipes apply, the framework has to be the right tool. Act is built for **business applications** — domain-driven event-sourced systems with aggregates that have lifecycles, invariants, and human-comprehensible workflows. Orders, tickets, subscriptions, accounts, ledgers, claims, applications, sessions, audit trails for regulated processes. Workloads where events represent *business facts* — somebody did something, something was approved, a contract entered a new state — and the system's job is to keep the truth and react to it.
+
+Act is **not** built for telemetry, sensor streams, real-time analytics, log ingestion, or any other high-frequency append-only firehose where events are *measurements* rather than facts. Several reasons:
+
+- The framework's hot path is opinionated around correctness (Zod validation per event, single global `id` sequence, optimistic concurrency on `(stream, version)`, reaction routing through the drain pipeline). Every commit pays that opinion. Telemetry pipelines need the opposite trade — cheap ingest, no per-event validation, batch flushes.
+- The default storage adapter is Postgres. Postgres serves business apps beautifully and serves multi-million-events-per-second telemetry workloads poorly. The recipes in this folder all assume the PG side of that boundary; nothing here translates to ClickHouse or TimescaleDB or InfluxDB.
+- The state-machine model (one stream = one aggregate, reducer produces current state from event history) is exactly what you want for a business aggregate and exactly not what you want for measurements you'll only ever read as a time series.
+
+If your workload is telemetry-shaped, you want a time-series database, a stream processor, or a purpose-built ingest pipeline. Pick the right tool and skip the rest of this folder. If your workload is business-shaped, read on.
+
+## What "almost" means
+
 The framing the rest of this folder is built around: **default Act plus Postgres plus close-the-books handles almost every real workload.** This folder documents what "almost" actually means — the symptoms of the walls you might hit, and the recipes for getting past them.
 
 ## What "default Act handles" looks like

--- a/recipes/scaling/README.md
+++ b/recipes/scaling/README.md
@@ -13,6 +13,16 @@ and the commit/reaction rates measured in
 [libs/act-pg/PERFORMANCE.md](../../libs/act-pg/PERFORMANCE.md). If you haven't
 yet hit a measured wall, you don't need this folder.
 
+> **Make sure Act is the right tool first.** This decision tree assumes you're
+> running a business application — domain aggregates with lifecycles, invariants,
+> events that represent business facts. If your workload is telemetry, sensor
+> streams, log ingestion, or any other high-frequency append-only firehose
+> where events are *measurements*, the scaling story below doesn't apply
+> because Act isn't the right tool in the first place. Time-series databases
+> and stream processors exist for those workloads. See
+> [recipes/README.md](../README.md#act-is-for-business-apps) for the longer
+> framing on what Act is and isn't shaped for.
+
 If you have, the gates below run in order. Each gate is a question you answer
 before moving down. Most operators stop at Gate 1.
 
@@ -181,12 +191,12 @@ verbatim from [libs/act-pg/PARTITIONING.md](../../libs/act-pg/PARTITIONING.md):
 >    eventually dominate tail latency.
 >
 > 2. **Single-aggregate giants.** One stream with millions of events on a
->    single aggregate — a multi-year IoT device telemetry trail, a long-running
->    ledger for one regulated entity, an audit trail for a critical workflow
->    that runs for a decade. The aggregate can't be closed because the business
->    still treats it as alive. HASH partitioning by `stream` does not help here
->    (all the events for one stream land in one partition); range partitioning
->    by `id` might.
+>    single business-domain aggregate — a long-running ledger for one
+>    regulated entity, an audit trail for a critical workflow that runs for a
+>    decade, a compliance event log for a single legal entity. The aggregate
+>    can't be closed because the business still treats it as alive. HASH
+>    partitioning by `stream` does not help here (all the events for one
+>    stream land in one partition); range partitioning by `id` might.
 >
 > 3. **Bulk archival with retention windows.** Regulatory frameworks that
 >    require retention for N months and then mandate disposal. `Act.close()`

--- a/recipes/scaling/README.md
+++ b/recipes/scaling/README.md
@@ -1,0 +1,283 @@
+# Scaling Act in production
+
+This is the operator's decision tree for "my Act application is under storage or
+throughput pressure." It starts where your pager woke you up (a symptom) and ends
+at one of four places: a close-the-books recipe, an archival recipe, a partitioning
+recipe, or an honest "you've outgrown the framework's shipped assumptions" door.
+
+Default Act is fine for most apps. The framework's defaults — global `id`
+ordering, single Postgres instance, drain-driven reactions, optimistic concurrency
+on commit — comfortably handle hundreds of streams, tens of millions of events,
+and the commit/reaction rates measured in
+[libs/act/PERFORMANCE.md](../../libs/act/PERFORMANCE.md) and
+[libs/act-pg/PERFORMANCE.md](../../libs/act-pg/PERFORMANCE.md). If you haven't
+yet hit a measured wall, you don't need this folder.
+
+If you have, the gates below run in order. Each gate is a question you answer
+before moving down. Most operators stop at Gate 1.
+
+## Symptoms cheat-sheet
+
+Use this to jump straight to the gate that owns your problem. Detailed reasoning
+follows below.
+
+```
+| If you see ...                                  | Read ...                |
+| ----------------------------------------------- | ----------------------- |
+| events table growing without bound              | Gate 1                  |
+| slow query_stats / app.load on busy aggregates  | Gate 1                  |
+| reducer cost rising as streams accumulate       | Gate 1                  |
+| auditors want history, business wants it gone   | Gate 2                  |
+| GDPR / retention window + cold-tier requirement | Gate 2                  |
+| VACUUM windows dominating maintenance budget    | Gate 3 (case 1)         |
+| append-only audit ledger, deletion forbidden    | Gate 3 (case 1)         |
+| one stream with millions of events, no close    | Gate 3 (case 2)         |
+| regulatory retention windows + bulk drop        | Gate 3 (case 3)         |
+| app.reset() takes too long                      | Gate 3 (case 4, caveat) |
+| claim() / SKIP LOCKED contention                | not partitioning;       |
+|                                                 | check reaction backoff  |
+|                                                 | + lane sizing in        |
+|                                                 | production-checklist    |
+| drain throughput plateau                        | not partitioning;       |
+|                                                 | check lanes (LaneConfig)|
+|                                                 | + streamLimit           |
+| LISTEN/NOTIFY wakeup misses                     | not scaling; see        |
+|                                                 | libs/act-pg/PERFORMANCE |
+| close-cycle CPU climbing every release          | tune autocloseCycleMs / |
+|                                                 | closeBatchSize, then 1  |
+| even after Gates 1-3, the wall doesn't move     | Gate 4                  |
+```
+
+The right-hand column points into a gate, not a fix. The gate's prose explains
+which recipe to run.
+
+## Gate 1: Can close-the-books handle it?
+
+This is the gate you should read first and longest, because it is the answer for
+roughly 90% of "my events table is growing" tickets.
+
+The most common storage-growth pattern in event-sourced apps is not "every
+stream is busy forever." It is "old streams keep their history forever even
+though nothing reads them anymore." Resolved tickets nobody will reopen.
+Sessions that ended six months ago. Carts abandoned in 2024. Each one keeps
+paying index space, replay time, and `query_stats` latency for a workflow that
+ended long ago.
+
+`Act.close()` is the right tool. It writes a tombstone at the head of the stream
+and atomically truncates the events, leaving the stream inaccessible for new
+commits (`StreamClosedError`) and old reads (`StreamClosedError` on `app.load`).
+The events table reaches a steady state: as new streams open, old streams shed
+their history, and the high-water mark stops climbing.
+
+Two ways to wire this. **Explicit close**, called from the action handler that
+recognizes the terminal event:
+
+```ts
+await app.close([
+  { stream: "order-2024-12345", archive: async () => { /* see Gate 2 */ } },
+]);
+```
+
+**Declarative auto-close**, a per-state policy declared on the builder:
+
+```ts
+const Ticket = state({ Ticket: ticketSchema })
+  .emits({ TicketOpened, TicketResolved })
+  // ...
+  .autocloses({
+    is: "TicketResolved",      // domain lifecycle
+    after: { days: 90 },       // AND cooldown
+  })
+  .build();
+```
+
+The `.autocloses({...})` form covers ~90% of real policies in a line. See
+[docs/docs/guides/close-policies.md](../../docs/docs/guides/close-policies.md)
+for the full API: terminal-event matching, time windows, cardinality thresholds,
+`or:` backstops, and the per-cycle cost knobs (`autocloseCycleMs`,
+`closeBatchSize`, `closeYieldMs`).
+
+The recipe at [recipes/scaling/close-the-books/](./close-the-books/) is the
+operator-side companion: how to identify which streams should close, how to
+roll out an `.autocloses` policy to a running fleet without surprising users,
+how to size the cycle knobs, what `query_stats` to monitor as you cut over.
+
+### How to know you're done with Gate 1
+
+You're done when one of two things is true:
+
+1. The events table reaches steady state. Total row count plateaus over a few
+   close cycles. `app.query_stats({})` shows a stable distribution of live
+   streams instead of monotonic growth. Move on with your life.
+
+2. You can show, with numbers, that even aggressive close policies can't keep
+   pace with the workload. A single-aggregate giant whose stream never reaches
+   a terminal event. An append-only audit log whose business rules forbid
+   deletion. A retention regime where the volume between "close-eligible" and
+   "drop-eligible" is itself larger than the database can comfortably hold.
+
+If you're in case 2, continue to Gate 2 or Gate 3. If you haven't measured —
+if you're guessing close won't work — go measure first. Operators routinely
+believe their streams are "long-lived and never end" when in fact most of them
+have natural terminal events that go unused.
+
+## Gate 2: Do you need history off the hot path but not deleted?
+
+Some workloads want close-the-books' benefits — bounded hot-table size,
+predictable replay windows, fast `query_stats` — and also want the events
+to remain readable later. Auditors investigating a six-month-old incident.
+Analysts running quarterly retro queries. Regulators asking for
+proof-of-history. Customer-support reading the full timeline of a closed
+ticket.
+
+The pattern is `.autocloses` paired with `.archives`. The framework runs the
+archiver inside the close-cycle's guard window — tombstone first, archiver
+second, `Store.truncate` last — so the archived snapshot and the deleted
+events are consistent. If the archiver throws, the truncate is skipped and the
+stream is retried next tick. No events are lost.
+
+```ts
+.autocloses({ is: "TicketResolved", after: { days: 90 } })
+.archives(async (stream, head) => {
+  const events = await loadHistory(stream);
+  await s3.upload(`tickets/${stream}.jsonl`, events);
+})
+```
+
+Three contracts the framework expects from your archiver, all spelled out in
+the [close-policies guide](../../docs/docs/guides/close-policies.md#the-archive-contract):
+idempotency (re-running on a retry must not double-write), speed (the
+archiver holds the stream's guard; stage heavy work elsewhere), and durable
+acknowledgment (the framework only knows the archiver resolved; don't ack
+before the data is actually durable).
+
+The recipe at [recipes/scaling/archival/](./archival/) walks through the three
+common sinks — S3-as-JSONL, a cold Postgres tier, an analytics warehouse —
+including the SQL snippets that read the archived data back later. It also
+covers the operational checklist: what to monitor on the archive bucket, how
+to verify a sampling of archives match their original streams, and how to
+restore a single archived stream if the business asks.
+
+Stay at Gate 2 if archival is the heaviest tool your workload needs. Reach
+for Gate 3 only when the hot table itself — even with `.autocloses` running —
+can't sustain the read or maintenance shape your operations team needs.
+
+## Gate 3: Is your workload one of the four genuine extremes?
+
+Partitioning is operationally heavy. It rewrites the events table, makes the
+primary key composite, adds N×K index trees instead of K, and pays MergeAppend
+cost on every cross-stream read. Most apps that reach for partitioning end up
+paying the cost without the benefit, because their workload was actually a
+Gate 1 problem in disguise.
+
+The four workloads where close + archival genuinely can't help are quoted
+verbatim from [libs/act-pg/PARTITIONING.md](../../libs/act-pg/PARTITIONING.md):
+
+> 1. **Regulated / append-only audit logs.** Financial ledgers, compliance
+>    trails, blockchain-adjacent systems where deletion is forbidden by policy
+>    or law. `Act.close()` is unavailable because tombstones are still
+>    "deletion" in the strict regulatory reading. The events table grows
+>    monotonically forever; index height, VACUUM duration, and planner stats
+>    eventually dominate tail latency.
+>
+> 2. **Single-aggregate giants.** One stream with millions of events on a
+>    single aggregate — a multi-year IoT device telemetry trail, a long-running
+>    ledger for one regulated entity, an audit trail for a critical workflow
+>    that runs for a decade. The aggregate can't be closed because the business
+>    still treats it as alive. HASH partitioning by `stream` does not help here
+>    (all the events for one stream land in one partition); range partitioning
+>    by `id` might.
+>
+> 3. **Bulk archival with retention windows.** Regulatory frameworks that
+>    require retention for N months and then mandate disposal. `Act.close()`
+>    deletes per-row, which is slow on hundreds of millions of rows;
+>    `DETACH PARTITION` + `DROP TABLE` is constant-time DDL regardless of
+>    partition size. Some regulators also accept partition-drop as "physical
+>    retention until partition retirement," which is more defensible than
+>    per-row delete.
+>
+> 4. **Parallel projection rebuild as the bottleneck.** Operations teams
+>    running periodic full `app.reset()` on a multi-hundred-million-row events
+>    table, where the rebuild window is the operational bottleneck. *Caveat:*
+>    see the global-`id` discussion above — partitioning helps rebuild
+>    throughput only when the partitioned MergeAppend cost is dominated by
+>    per-partition parallel I/O. Benchmark before assuming this; the
+>    framework's PG benchmark (#851) reports observed vs theoretical speedup
+>    for exactly this reason.
+
+Be honest about which of these you have. Only case 1 maps cleanly to HASH
+partitioning. Case 2 needs range-on-`id` and is more documentation than
+turn-key recipe. Case 3 needs range-on-`created` and pairs with the
+partition-drop runner. Case 4 is conditional — partitioning may help your
+rebuild, may hurt it, and the only way to know is to benchmark on your data
+shape.
+
+The partitioning gating page at
+[recipes/scaling/partitioning/](./partitioning/) is the next required read
+before any of the strategy-specific recipes. It restates the global-`id`
+constraint, the MergeAppend tax on cross-stream reads, and the migration cost
+you'll pay regardless of strategy. Once you've cleared that gate, the
+strategy recipes are:
+
+- [recipes/scaling/partitioning/hash-on-stream/](./partitioning/hash-on-stream/)
+  for case 1 (regulated append-only).
+- [recipes/scaling/partitioning/range-on-id/](./partitioning/range-on-id/)
+  for case 2 (single-aggregate giants).
+- [recipes/scaling/partitioning/range-on-created/](./partitioning/range-on-created/)
+  for case 3 (retention-window bulk drop).
+
+Case 4 doesn't have a dedicated recipe because the answer is "run #851's
+parallel-rebuild benchmark on your data shape and decide from the numbers."
+The bench is the recipe.
+
+## Gate 4: You've reached the framework's limit
+
+Some workloads outgrow the assumptions the framework ships with. The events
+table cannot fit on a single Postgres instance even with HASH partitioning.
+The global `id` order is itself the bottleneck — drain throughput plateaus
+because the lagging-frontier claim ordering is serialized through one
+sequence. The business needs strict per-tenant isolation that
+`ActOptions.scoped` doesn't deliver at the storage layer. Multi-region
+write-anywhere semantics that conflict with optimistic concurrency on a
+shared sequence.
+
+The framework intentionally does not ship sharding, multi-master, or
+cross-region strategies. They are not "missing features"; they are bespoke
+trade-offs that depend on which invariants you're willing to give up
+(global ordering, single-writer simplicity, exact-once drain) for what gain.
+Shipping a one-size-fits-all answer would be wrong.
+
+If you're at Gate 4, the path forward is:
+
+1. Confirm with numbers that Gates 1-3 don't move your wall. Specifically:
+   show the close-cycle is doing what it can, archival is keeping the hot
+   table bounded, partitioning has been measured (not assumed) for your read
+   shape, and the wall is still there.
+
+2. Open an issue at https://github.com/Rotorsoft/act-root/issues with the
+   `area:ops` label, attach your numbers, and describe which framework
+   assumption is the binding constraint. "Drain at X commits/sec across Y
+   workers but `claim()` serializes through one sequence." Concrete.
+
+3. Expect the conversation to be bespoke. We may sketch a sharded variant,
+   suggest moving the bottleneck workload onto its own `ActOptions.scoped`
+   instance with a separate store, or conclude that your case is genuinely
+   the kind of scale where you outgrow the framework. All three are
+   legitimate outcomes; "Act is wrong for this" is sometimes the right
+   answer.
+
+This gate isn't a recipe because there isn't a generic one. It is a door
+into a focused conversation grounded in measurements.
+
+## A closing note on order
+
+The gates are ordered by how often they apply, not by how interesting they
+sound. Gate 1 is boring and answers most tickets. Gate 3 is exciting and
+answers very few. The temptation, especially under pressure, is to skip
+straight to partitioning because it sounds like the heavyweight answer.
+Resist it. The cost of running Gate 1 first is at most a day of measurement;
+the cost of partitioning a table that didn't need it is months of
+operational tax that can't be undone without another full migration.
+
+Most "we need to scale Act" tickets are Gate 1 tickets in disguise. Start
+there.

--- a/recipes/scaling/archival/README.md
+++ b/recipes/scaling/archival/README.md
@@ -1,0 +1,87 @@
+# Archiving streams before truncate
+
+Pair `.autocloses({...})` with `.archives(fn)` so the events of a closing stream land in cold storage — S3, an analytics warehouse, JSONL on a mounted disk — *before* the framework truncates them. The archiver runs inside the close cycle's guard window; if it throws, the stream stays guarded and un-truncated, and the cycle retries on the next tick. No partial state, no half-archived rows.
+
+Default Act doesn't need this recipe. Most apps with a clean terminal event (`Resolved`, `Delivered`, `Cancelled`) can close streams cold and never look back — `app.load` on a closed stream throws `StreamClosedError`, and that's the right answer for the dominant workload. Reach for archival only when the operator answer to "what happens if someone asks for the closed events six months from now?" is not "they don't get them."
+
+## When this recipe earns its keep
+
+Three operator concerns drive the decision to archive before truncate:
+
+- **Auditors want the events later.** A regulator, an internal audit team, or a future SOC 2 review needs to walk the original event log of a customer interaction the business has long since marked closed. The hot store doesn't need to serve that read; cold storage does.
+- **Users might re-query closed streams.** A "view past tickets" screen that occasionally hits old streams is fine — the archive is the source of truth for the cold read, the hot store handles the live one.
+- **Regulatory retention requires the bytes to exist somewhere.** Frameworks like GDPR, HIPAA, or sector-specific rules sometimes mandate retention for N months even after the operational lifecycle is over. The events must survive; the hot table doesn't have to.
+
+If none of these apply, drop `.archives(...)` and let `.autocloses({...})` truncate clean. The framework charges nothing for the absent declarator.
+
+## The contract
+
+The `.archives(fn)` declarator is documented in [docs/docs/guides/close-policies.md § The archive contract](../../../docs/docs/guides/close-policies.md). The four invariants the cycle gives you, restated for operators:
+
+1. **The archiver runs inside the guard window.** A tombstone marker has already been committed with `expectedVersion`, so no new writes can land on the stream while the archiver is running. The events you read are the final ones.
+2. **A thrown archiver leaves the stream un-truncated.** The error propagates to the cycle's `closed`-emission path; no events are deleted, the stream stays guarded, and the cycle retries the candidate on the next tick. A network blip on the S3 PUT doesn't lose data — it pushes the close out by one cycle.
+3. **The host owns idempotency.** A retry can call the archiver a second time on the same stream. Most archivers achieve idempotency by using the stream name as the destination key: `tickets/${stream}.jsonl` is the same key every retry, so the second PUT overwrites the first cleanly. If your destination is append-only (an analytics warehouse, a Kafka topic), put a dedup key in the payload.
+4. **Resolve only when the data is durable.** The framework doesn't check whether S3 actually accepted the bytes. It only knows the archiver resolved. Don't ack from a queue ("I queued the write, the broker will handle it") and then return — the truncate will fire while the broker is still flushing. Wait for the storage backend to confirm, then resolve.
+
+The archiver also holds the guard. A 10-second archiver delays the truncate by 10 seconds and adds 10 seconds to the cycle's flush. Keep it under a few hundred milliseconds where you can; stage the heavy work to a queue if it can't.
+
+## The S3 + JSONL pattern
+
+The shape that fits 80% of cases: dump each stream as one JSONL object per event, upload to S3 under a key derived from the stream name. The recipe walks four steps.
+
+**Read stream history via `store().query`.** The store's `query(callback, filter)` method paginates events for the operator. Pass `{ stream }` to scope the read; the callback fires per event in version order. The archiver collects them into an array for serialization.
+
+**Serialize to JSONL.** One JSON object per line, no wrapping array. JSONL is friendly to streaming readers, append-only consumers, and `jq -c` debugging. Keep the full `Committed` shape — `id`, `name`, `data`, `stream`, `version`, `created`, `meta` — so a future rehydrator has everything it needs.
+
+**Upload with stable key naming.** `tickets/${stream}.jsonl` (or `audit/${stream}.jsonl`, etc.) — one key per stream. Retries on the same stream overwrite the same key, which is the cheap way to get idempotency. Don't include a timestamp in the key; that turns retries into duplicate uploads.
+
+**Throw on AWS errors.** Catch nothing. If `s3.send(...)` rejects, let it bubble — the framework's safety property turns a thrown archiver into "leave the stream alone, retry next tick." Swallowing the error and resolving would silently truncate the stream with no archive in cold storage.
+
+The sample at [examples/s3-jsonl-archiver.ts](examples/s3-jsonl-archiver.ts) is a working file an operator can copy into their service and adapt.
+
+## Pair with `.autocloses({...})`
+
+The two declarators live on the same state and run on the same cycle. Concrete shape:
+
+```ts
+import { state } from "@rotorsoft/act";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({ region: process.env.AWS_REGION });
+const BUCKET = process.env.ARCHIVE_BUCKET!;
+
+const Ticket = state({ Ticket: ticketSchema })
+  .init(() => defaults)
+  .emits({ TicketOpened, TicketResolved })
+  // ... actions, patches, invariants
+  .autocloses({
+    is: "TicketResolved",
+    after: { days: 90 },
+  })
+  .archives(async (stream) => {
+    const events: unknown[] = [];
+    await store().query((e) => { events.push(e); }, { stream });
+    const body = events.map((e) => JSON.stringify(e)).join("\n");
+    await s3.send(new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: `tickets/${stream}.jsonl`,
+      Body: body,
+    }));
+  })
+  .build();
+```
+
+Reads: *"autocloses is Resolved after 90 days; archives to `tickets/${stream}.jsonl` first."* The cycle does the rest — predicate matches, archiver runs, truncate fires. See the full file at [examples/s3-jsonl-archiver.ts](examples/s3-jsonl-archiver.ts) for the wired state with action handlers and event schemas.
+
+## What this recipe is NOT
+
+- **A full-system backup.** Archiving individual streams on close gives you the events of *closed* streams in cold storage. It doesn't give you a snapshot of the live database, the streams table, lease state, projection rows, or anything else. Use `pg_dump` (or your provider's managed backup) for full disaster recovery. Use WAL archiving for point-in-time recovery.
+- **Real-time replication.** The archive cycle runs on `autocloseCycleMs` cadence (default 60 s) and only on streams that are being closed. If you need every event mirrored to a downstream consumer in flight, that's a reaction problem — forward via [@rotorsoft/act-http/webhook](../../../libs/act-http/README.md) or a message bus.
+- **A query interface over the archived data.** S3 holds the JSONL; nothing in the framework reads it back. Rehydrating a projection from archived JSONL is possible (parse the file, replay through your `.patch` handlers) but it's host code, not a framework primitive. For *in-store* projection rebuild, use [`app.reset(targets)`](../../../docs/docs/concepts/event-sourcing.md) — that walks the live events table, not the archive.
+
+## Cross-references
+
+- [.autocloses + .archives full reference](../../../docs/docs/guides/close-policies.md)
+- [Production checklist § 10 (closing the books)](../../../docs/docs/guides/production-checklist.md)
+- [Scaling decision tree](../README.md)
+- [Partitioning gating page](../partitioning/README.md) — for the workloads where close + archive isn't enough

--- a/recipes/scaling/archival/examples/s3-jsonl-archiver.ts
+++ b/recipes/scaling/archival/examples/s3-jsonl-archiver.ts
@@ -1,0 +1,100 @@
+// Sample: archive Ticket streams to S3 as JSONL before the online close cycle
+// truncates them.
+//
+// This file is illustrative, not a runtime dependency of @rotorsoft/act. The
+// `@aws-sdk/client-s3` import below is NOT declared in any package.json in this
+// repo — copy this file into your own service and add the dep yourself:
+//
+//   pnpm add @aws-sdk/client-s3
+//
+// How the cycle calls .archives():
+//   1. The .autocloses({...}) predicate matches a stream (head event is
+//      TicketResolved and at least 90 days old).
+//   2. The framework commits a tombstone marker on the stream — guard window
+//      opens, no new writes can land.
+//   3. The framework awaits this archiver function. We read history and ship
+//      it to S3.
+//   4. On resolve: framework calls Store.truncate() — events are gone from
+//      the hot table, S3 has the cold copy.
+//   5. On throw: framework leaves the stream guarded and un-truncated; the
+//      cycle retries the candidate on the next tick.
+//
+// Idempotency: the S3 key is derived from the stream name with no timestamp,
+// so a retry overwrites the previous (incomplete) upload.
+
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { state, store } from "@rotorsoft/act";
+import { z } from "zod";
+
+const s3 = new S3Client({ region: process.env.AWS_REGION ?? "us-east-1" });
+const ARCHIVE_BUCKET = process.env.ARCHIVE_BUCKET ?? "act-archive";
+
+// Domain shape — a minimal Ticket state.
+
+const TicketSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  status: z.enum(["open", "resolved"]),
+});
+
+const TicketOpened = z.object({
+  id: z.string(),
+  title: z.string(),
+});
+
+const TicketResolved = z.object({
+  id: z.string(),
+  resolution: z.string(),
+});
+
+export const Ticket = state({ Ticket: TicketSchema })
+  .init(() => ({ id: "", title: "", status: "open" as const }))
+  .emits({ TicketOpened, TicketResolved })
+  .patch({
+    TicketOpened: ({ data }) => ({
+      id: data.id,
+      title: data.title,
+      status: "open",
+    }),
+    TicketResolved: (_e, state) => ({ ...state, status: "resolved" }),
+  })
+  .on({ openTicket: z.object({ id: z.string(), title: z.string() }) })
+  .emit((action) => ["TicketOpened", action])
+  .on({
+    resolveTicket: z.object({ id: z.string(), resolution: z.string() }),
+  })
+  .emit((action) => ["TicketResolved", action])
+  // Close 90 days after the ticket is resolved.
+  .autocloses({
+    is: "TicketResolved",
+    after: { days: 90 },
+  })
+  // Archive the stream's events to S3 before truncate.
+  .archives(async (stream) => {
+    // Walk the stream history in version order.
+    const events: unknown[] = [];
+    await store().query(
+      (event) => {
+        events.push(event);
+      },
+      { stream }
+    );
+
+    // Serialize as JSONL — one event per line.
+    const body = events.map((e) => JSON.stringify(e)).join("\n");
+
+    // Upload. The key is stable across retries; a re-run after a previous
+    // tick's failure overwrites the same object cleanly. Throwing from
+    // s3.send() bubbles to the cycle, which leaves the stream un-truncated
+    // and re-queues it for the next tick — no data loss on a transient
+    // S3 error.
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: ARCHIVE_BUCKET,
+        Key: `tickets/${stream}.jsonl`,
+        Body: body,
+        ContentType: "application/x-ndjson",
+      })
+    );
+  })
+  .build();

--- a/recipes/scaling/close-the-books/README.md
+++ b/recipes/scaling/close-the-books/README.md
@@ -1,0 +1,182 @@
+# Close the books
+
+The 90% answer to "my events table is growing." You declare a per-state
+close policy on the state builder, the framework's autoclose cycle finds
+streams whose head event matches, and the events get tombstoned and
+truncated in the background. No partitioning, no archival pipeline,
+no maintenance window — just a one-line declarator at the call site
+of every state whose streams have a definable end of life.
+
+## When to reach for it
+
+Almost always. The symptoms `recipes/scaling/README.md` Gate 1 calls
+out — `events` rowcount growing monotonically, projection rebuild
+windows growing in lock-step, autovacuum starting to surprise you,
+`query_stats` getting slower — all share the same underlying cause.
+The events table is full of streams that were semantically complete
+months ago but were never told to retire. Close-the-books retires them.
+
+The decision is rarely "should I close" and almost always "what's
+my close predicate." Sessions end. Tickets resolve. Orders ship.
+GDPR deletion requests have statutory windows. Even apps that
+"feel like" they have long-lived streams usually have a terminal
+event somewhere — it's just unused. Adding a close policy after
+the fact is one of the cheapest operational wins in the framework.
+
+Default Act with no `.autocloses(...)` is also fine. The cycle is
+opt-in; absent the declarator the controller doesn't even allocate,
+and a happily-bounded fleet pays nothing for the feature. This
+recipe is for the workloads that have outgrown default storage.
+
+## The two field shapes
+
+The declarator accepts either a predicate function or a declarative
+options object. The function form is the long-tail escape hatch.
+The object form covers ~90% of real policies in one line, with
+verb-shaped fields (`is`, `after`, `reaches`) that compose at the
+call site like a sentence. Full reference lives at
+[docs/docs/guides/close-policies.md](../../../docs/docs/guides/close-policies.md);
+this page covers the two shapes that show up most.
+
+### Cooldown after terminal (the AND case)
+
+The cooldown-after-terminal pattern runs through almost every
+business app: close N days after the terminal event. Top-level
+fields combine with AND, so the cycle truncates only when every
+condition holds.
+
+```ts
+.autocloses({
+  is: "TicketResolved",
+  after: { days: 90 },
+})
+```
+
+Reads: *"autocloses is Resolved after 90 days."* The stream stays
+queryable for a 90-day return / dispute / customer-success window
+after the ticket resolves, then retires itself. Same shape works
+for `Delivered` + 14 days on an order workflow, `Cancelled` +
+30 days on a subscription, `Paid` + 7 days on an invoice. The
+runnable example lives at
+[examples/ticket-cooldown.ts](examples/ticket-cooldown.ts).
+
+### Pure-OR backstops (the or-block)
+
+Some streams have multiple independent close triggers and you
+want any of them to fire. The terminal event might never arrive
+(an abandoned session, a forgotten draft), so a retention floor
+needs to apply regardless. Or the stream is cardinality-bounded
+(a rotating audit log) and a row-count threshold should retire
+it independent of any domain event.
+
+```ts
+.autocloses({
+  is: "SessionEnded",
+  or: { after: { days: 365 } },
+})
+```
+
+Reads: *"autocloses is Ended, or after 365 days."* Sessions that
+ended close on the terminal event; sessions that never ended
+retire on the retention floor. Mix and match: a pure-OR policy
+with no top-level fields (`{ or: { is, after, reaches } }`) closes
+on any of the three triggers independently. The runnable example
+lives at [examples/retention-floor.ts](examples/retention-floor.ts).
+
+The full set of fields (`after: { days }`, `is: "EventName"` or
+`is: string[]`, `reaches: N`), AND/OR composition rules, and the
+function-form escape hatch are documented at
+[docs/docs/guides/close-policies.md](../../../docs/docs/guides/close-policies.md).
+
+## What this buys you
+
+Steady state. An events table with a close policy reaches a size
+that's roughly active streams × average events per active stream.
+Closed streams shed their history continuously, the table doesn't
+grow without bound, and the operational properties that scale with
+table size stop being scary.
+
+The exact savings depend on your workload's terminal rate and
+cooldown window, so measure for yourself. Order-of-magnitude
+guidance from the workloads we've watched closely:
+
+- For a tickets-style app closing 90 days after `Resolved`, steady
+  state typically lands at 1–5% of what the unbounded table would
+  have grown to after 18–24 months. The bulk of historical rows
+  are tickets that resolved more than 90 days ago and have no
+  reason to still be in primary storage.
+
+- VACUUM windows shrink in proportion to the table. The
+  long-tail autovacuum surprises that show up when a table crosses
+  a hundred million rows mostly stop appearing because the table
+  no longer crosses that threshold.
+
+- `app.reset()` time scales linearly with events processed.
+  Bounded events table → bounded rebuild window. This is the
+  cheapest way to bound rebuild — orders of magnitude cheaper
+  than partitioning, which is documented at
+  [recipes/scaling/partitioning/README.md](../partitioning/README.md)
+  as a last resort when close-the-books genuinely can't apply.
+
+For PG-specific perf evidence on the cycle itself (claim latency,
+notify→reaction latency, batched truncate cost), see
+[libs/act-pg/PERFORMANCE.md](../../../libs/act-pg/PERFORMANCE.md).
+Core-level numbers (cache-on-commit, watermark-aware claim,
+batched projection replay) are at
+[libs/act/PERFORMANCE.md](../../../libs/act/PERFORMANCE.md).
+
+## Pair with `.archives()` if you need history later
+
+The close cycle truncates events out of primary storage. If you
+need them in cold storage afterwards — for compliance, analytics,
+or just "we might want to look at this in two years" — pair the
+declarator with a `.archives(fn)` declarator on the same state.
+The archiver runs inside the cycle's guard window: tombstone
+committed, archiver awaited, truncate. A throw leaves the stream
+guarded but un-truncated, and the cycle retries the candidate
+next tick, so a transient S3 outage doesn't lose data.
+
+The host owns idempotency, speed (don't hold the guard with
+slow I/O), and storage durability. The framework only knows the
+archiver resolved. See
+[recipes/scaling/archival/README.md](../archival/README.md) for
+the recipe; the architectural contract is at
+[docs/docs/guides/close-policies.md § The archive contract](../../../docs/docs/guides/close-policies.md).
+
+## What this recipe is NOT for
+
+**Hard real-time close.** The autoclose cycle defaults to a 60-second
+tick. A terminal event lingers up to a cycle's worth before truncate.
+If the close has to happen in the same request that emitted the
+terminal event — regulatory cutoffs measured in seconds, "user
+deleted my account, the data must be gone now" workflows — call
+`app.close([{ stream }])` directly from the action handler. The
+[production checklist](../../../docs/docs/guides/production-checklist.md)
+covers cycle tuning (`autocloseCycleMs`, `closeBatchSize`,
+`closeYieldMs`) for the in-between case where 60 s is too long
+but a per-request close is overkill.
+
+**Stream rotation while keeping the entity alive.** Close always
+tombstones. For a long-running entity that needs its history
+rotated but stays live (a chat thread that's been going for two
+years and you want to flush the first year), use
+`app.close({ stream, restart: true })` — same primitive, different
+post-condition. The recipe page above covers when to reach for it.
+
+**Cross-state coordination.** Each state's predicate sees only
+its own candidates. "Close stream A only after B is closed"
+patterns belong in the host scheduler, not in `.autocloses(...)`.
+
+## Examples in this folder
+
+- [examples/ticket-cooldown.ts](examples/ticket-cooldown.ts) —
+  Ticket state with `TicketOpened` / `TicketResolved`, closes
+  90 days after resolution. The primary cooldown pattern.
+- [examples/retention-floor.ts](examples/retention-floor.ts) —
+  Session state with `SessionStarted` / `SessionEnded`, closes
+  on the terminal event OR after 365 days. The terminal-with-
+  backstop pattern.
+
+Both compile against `@rotorsoft/act` as published and run with
+`tsx` against the default in-memory store — no database needed
+to verify the declarator wires up.

--- a/recipes/scaling/close-the-books/README.md
+++ b/recipes/scaling/close-the-books/README.md
@@ -157,11 +157,12 @@ covers cycle tuning (`autocloseCycleMs`, `closeBatchSize`,
 but a per-request close is overkill.
 
 **Stream rotation while keeping the entity alive.** Close always
-tombstones. For a long-running entity that needs its history
-rotated but stays live (a chat thread that's been going for two
-years and you want to flush the first year), use
-`app.close({ stream, restart: true })` — same primitive, different
-post-condition. The recipe page above covers when to reach for it.
+tombstones. For a long-running business entity that needs its
+history rotated but stays live (a multi-year customer relationship
+where the last year of activity is what's hot and the older history
+is reference-only), use `app.close({ stream, restart: true })` —
+same primitive, different post-condition. The recipe page above
+covers when to reach for it.
 
 **Cross-state coordination.** Each state's predicate sees only
 its own candidates. "Close stream A only after B is closed"

--- a/recipes/scaling/close-the-books/examples/retention-floor.ts
+++ b/recipes/scaling/close-the-books/examples/retention-floor.ts
@@ -1,0 +1,74 @@
+/**
+ * Terminal-with-retention-floor close policy — the OR-backstop pattern.
+ *
+ * Sessions usually close on `SessionEnded`. Some don't (the user closed
+ * the tab, the device dropped off the network, the worker that would
+ * have emitted the terminal event crashed). The retention floor — 365
+ * days since the head event — catches the long tail so abandoned
+ * streams don't accumulate forever.
+ *
+ * Run:  pnpm tsx recipes/scaling/close-the-books/examples/retention-floor.ts
+ */
+
+import { act, state, ZodEmpty } from "@rotorsoft/act";
+import { z } from "zod";
+
+const Session = state({
+  Session: z.object({ user: z.string(), active: z.boolean() }),
+})
+  .init(() => ({ user: "", active: false }))
+  .emits({
+    SessionStarted: z.object({ user: z.string() }),
+    SessionEnded: ZodEmpty,
+  })
+  .patch({
+    SessionStarted: ({ data }) => ({ user: data.user, active: true }),
+    SessionEnded: (_e, state) => ({ ...state, active: false }),
+  })
+  .on({ StartSession: z.object({ user: z.string() }) })
+  .emit((a) => ["SessionStarted", { user: a.user }])
+  .on({ EndSession: ZodEmpty })
+  .emit(() => ["SessionEnded", {}])
+  // The recipe — terminal event with a retention-floor backstop.
+  // "autocloses is Ended, or after 365 days."
+  // The two paths fire independently: a session that ends closes
+  // promptly; a session that never ends closes a year later.
+  .autocloses({
+    is: "SessionEnded",
+    or: { after: { days: 365 } },
+  })
+  .build();
+
+async function main() {
+  const app = act().withState(Session).build({
+    autocloseCycleMs: 60_000,
+    closeBatchSize: 64,
+  });
+
+  const predicate = app.registry.autoclose_policy("Session");
+  console.log("Session.autoclose registered:", typeof predicate === "function");
+
+  const actor = { id: "demo", name: "demo" };
+  await app.do(
+    "StartSession",
+    { stream: "session-1", actor },
+    { user: "alice" }
+  );
+  await app.do("EndSession", { stream: "session-1", actor }, {});
+
+  // Second session, deliberately left unterminated. The retention
+  // floor would catch it 365 days from now in a long-running process.
+  await app.do(
+    "StartSession",
+    { stream: "session-orphan", actor },
+    { user: "bob" }
+  );
+
+  app.start_correlations();
+  await app.shutdown();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/recipes/scaling/close-the-books/examples/ticket-cooldown.ts
+++ b/recipes/scaling/close-the-books/examples/ticket-cooldown.ts
@@ -1,0 +1,73 @@
+/**
+ * Cooldown-after-terminal close policy — the primary pattern.
+ *
+ * Tickets resolve, then sit in primary storage for a 90-day return /
+ * dispute / customer-success window, then retire themselves on the
+ * next autoclose cycle. The `.autocloses({...})` declarator does
+ * the work; the rest of the file is a minimal harness so this can
+ * be run end-to-end with `tsx` to confirm the API wiring.
+ *
+ * Run:  pnpm tsx recipes/scaling/close-the-books/examples/ticket-cooldown.ts
+ */
+
+import { act, state, ZodEmpty } from "@rotorsoft/act";
+import { z } from "zod";
+
+const Ticket = state({
+  Ticket: z.object({ title: z.string(), open: z.boolean() }),
+})
+  .init(() => ({ title: "", open: false }))
+  .emits({
+    TicketOpened: z.object({ title: z.string() }),
+    TicketResolved: ZodEmpty,
+  })
+  .patch({
+    TicketOpened: ({ data }) => ({ title: data.title, open: true }),
+    TicketResolved: (_e, state) => ({ ...state, open: false }),
+  })
+  .on({ OpenTicket: z.object({ title: z.string() }) })
+  .emit((a) => ["TicketOpened", { title: a.title }])
+  .on({ ResolveTicket: ZodEmpty })
+  .emit(() => ["TicketResolved", {}])
+  // The recipe — declarative form, top-level AND.
+  // "autocloses is Resolved after 90 days."
+  .autocloses({
+    is: "TicketResolved",
+    after: { days: 90 },
+  })
+  .build();
+
+async function main() {
+  const app = act().withState(Ticket).build({
+    // 60 s is the default cycle cadence; spelled out here so the
+    // example doubles as a knobs reference.
+    autocloseCycleMs: 60_000,
+    closeBatchSize: 64,
+  });
+
+  // The registry exposes the compiled predicate. Useful in tests
+  // to assert the policy survived `act().build()` validation.
+  const predicate = app.registry.autoclose_policy("Ticket");
+  console.log("Ticket.autoclose registered:", typeof predicate === "function");
+
+  // Commit a ticket so the cycle has something to look at the first
+  // time it ticks. Default storage is in-memory, so no DB connection
+  // is needed to verify the wiring.
+  const actor = { id: "demo", name: "demo" };
+  await app.do("OpenTicket", { stream: "ticket-1", actor }, { title: "demo" });
+  await app.do("ResolveTicket", { stream: "ticket-1", actor }, {});
+
+  // `start_correlations()` also starts the autoclose ticker.
+  // A predicate keyed on `after: { days: 90 }` will not fire on a
+  // ticket that resolved seconds ago — the example proves the wiring
+  // up, not the eviction.
+  app.start_correlations();
+
+  // Tear down cleanly so the script exits.
+  await app.shutdown();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/recipes/scaling/partitioning/README.md
+++ b/recipes/scaling/partitioning/README.md
@@ -63,7 +63,7 @@ The narrow set of workloads where `close()` genuinely can't help:
 
 1. **Regulated / append-only audit logs.** Financial ledgers, compliance trails, blockchain-adjacent systems where deletion is forbidden by policy or law. `Act.close()` is unavailable because tombstones are still "deletion" in the strict regulatory reading. The events table grows monotonically forever; index height, VACUUM duration, and planner stats eventually dominate tail latency. The recipe for this case is `recipes/scaling/partitioning/hash-on-stream/README.md` — HASH-on-stream colocates each aggregate's events in one partition, keeps single-stream reads cheap, and caps per-partition index height.
 
-2. **Single-aggregate giants.** One stream with millions of events on a single aggregate — a multi-year IoT device telemetry trail, a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might. See `recipes/scaling/partitioning/range-on-id/README.md` — that recipe is documentation-only by design because the cut points are app-specific.
+2. **Single-aggregate giants.** One stream with millions of events on a single business-domain aggregate — a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade, a compliance event log for a single legal entity. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might. See `recipes/scaling/partitioning/range-on-id/README.md` — that recipe is documentation-only by design because the cut points are app-specific.
 
 3. **Bulk archival with retention windows.** Regulatory frameworks that require retention for N months and then mandate disposal. `Act.close()` deletes per-row, which is slow on hundreds of millions of rows; `DETACH PARTITION` + `DROP TABLE` is constant-time DDL regardless of partition size. Some regulators also accept partition-drop as "physical retention until partition retirement," which is more defensible than per-row delete. Recipe: `recipes/scaling/partitioning/range-on-created/README.md`. If you're chasing retention with non-regulatory motivations, check `recipes/scaling/archival/README.md` first — the `close()`-plus-archiver path is usually enough.
 
@@ -98,6 +98,23 @@ Notes on each:
 - **RANGE on `id`** is the only strategy that helps "single-aggregate giant" scenarios. It deliberately splits one stream across partitions, ordered by the global id. Recent partitions stay hot, older partitions go cold. Documentation-only: range partitioning is a per-app schema design (event volume, retention window, archival policy), not a turn-key recipe. The framework documents the *strategy*; the schema is yours to design.
 
 - **RANGE on `created`** is the strategy for bulk archival by retention window. Pair with `pg_partman` for partition creation and the drop-partition runner in the recipe for the archival half of the loop. Don't use this strategy if you don't have a clean retention boundary — picking a wrong cutoff means re-partitioning later, which is the same migration cost twice.
+
+## Consistency cost when a strategy involves `DROP PARTITION`
+
+Any strategy that drops partitions (most often `RANGE on created` for retention archival, occasionally `RANGE on id` for cold-storage tiering) deletes events from the events table. Act reconstructs aggregate state by replaying every event for a stream from version 1 forward, so if you drop a partition containing events for a stream that's still alive — no `__tombstone__` from `app.close()` / `.autocloses({...})`, no `__snapshot__` from `app.snap()` / a `.snap` predicate — the next `app.load(stream)` returns **silently wrong state**. The reducer runs over the surviving events as if the dropped ones never existed.
+
+There is no error. No integrity check. No warning. Just a corrupted aggregate.
+
+The recipes that involve `DROP PARTITION` (`range-on-created/drop-partition.sql`) ship with a pre-flight guard that runs as the first SQL statement: it lists every stream with events older than the cutoff that lacks a tombstone or snapshot at or after the cutoff. The guard raises and rolls back the transaction if any unsafe streams exist; the operator must retire them (`app.close()`) or snapshot them (`app.snap()`) before re-running.
+
+The two-tool composition that scales:
+
+- **Per-stream retirement** via `.autocloses({...})` so streams earn their tombstone in the partition where they go terminal. By the time that partition ages out of the retention window, the tombstones are safely in a future partition.
+- **Table-wide retention floor** via the drop runner, which checks the guard before touching DDL.
+
+For states that lack a natural terminal event, schedule explicit `app.snap()` calls in lock-step with the partition cadence — the snapshot writes to the always-current partition and survives the next drop. The recipe pages for `range-on-created` and `range-on-id` carry this guidance per-strategy; this section exists because the constraint cuts across every partitioning approach that can lose events.
+
+HASH-on-stream is the only strategy in this folder that's safe by construction — it never drops events, only relocates them across partitions.
 
 ## Costs you'll see no matter which strategy you pick
 

--- a/recipes/scaling/partitioning/README.md
+++ b/recipes/scaling/partitioning/README.md
@@ -1,0 +1,114 @@
+# Partitioning the events table
+
+> **TL;DR — don't.** For almost every Act application, the right answer to "my events table is growing" is `Act.close()`, not partitioning. Partitioning is an **extreme-case escape valve** for the narrow set of workloads where the default storage adapter genuinely can't serve the business. Read this page if and only if you've already ruled out close-the-books as a solution.
+
+This page replaces the old `libs/act-pg/PARTITIONING.md`. It lives under `recipes/` because partitioning is an operator concern, not a framework-internals concern: the framework's job is to keep the global event order correct on top of whatever schema you give it, and the operator's job is to decide whether the schema needs to change.
+
+## Why this page leads with "don't"
+
+Partitioning is operationally heavy. It adds migration downtime, ongoing planner overhead, a more complex query plan for every cross-stream read, and (for range strategies) ongoing partition-maintenance toil. It also fights against event sourcing's central invariant — global `id` ordering — in ways that are easy to under-appreciate until you measure them.
+
+Most teams that reach for partitioning do it before they have a workload that genuinely needs it, and end up paying the operational cost without the operational win. So this page is structured as a series of gates: each section is a chance to stop, conclude "partitioning isn't the answer for me," and close the tab.
+
+The default Act setup — the schema in `libs/act-pg/src/postgres-store.ts`, the indexes it creates, the close-the-books machinery from epic #802 — is the right shape for the dominant workload. If you can stay on it, stay on it.
+
+## The global-`id` constraint
+
+Act's event store assigns a monotonic `id` to every event across every stream. That global order is **load-bearing** for the framework:
+
+- **Drain** reads events in `id` order to dispatch reactions deterministically.
+- **Projections** advance by `id` watermark — `(id > last_id ORDER BY id)` is the canonical fetch shape.
+- **`app.reset()`** replays projections by walking the entire events table in `id` order.
+- **Cross-stream causality** — debugging "what happened first across the system" relies on `id` being a total order.
+
+Partitioning preserves the **shared `events_id_seq`**, so the IDs themselves stay monotonic. What it does *not* preserve is **single-partition scans for global-order queries**. Any read that needs "the next N events across all streams in id order" must:
+
+1. Open every partition,
+2. Sort each partition's rows by `id`,
+3. `MergeAppend` the per-partition streams into one ordered cursor.
+
+PG's planner does this well, but the cost is linear in partition count. For an events table partitioned 16 ways, every drain query, every projection advance, every full `app.reset` does **16× the planner work and 16× the I/O setup** that an unpartitioned table would do. If your workload is dominated by these cross-stream reads — and **most event-sourced workloads are** — partitioning costs you on the hottest path.
+
+The implication: partitioning's classic upside ("parallel scan across partitions makes things faster") collides with event sourcing's "I need global id order to make sense of anything." For most queries you can't parallelize without paying MergeAppend, and the queries that *can* prune to a single partition (single-stream `claim`, `commit`, `load`) were already fast on the unpartitioned table. The current PG adapter benchmarks in `libs/act-pg/PERFORMANCE.md` were all measured on the unpartitioned schema for exactly this reason — that's the shape almost every Act deployment runs.
+
+Carry this trade-off through every section below.
+
+## First gate: can `Act.close()` handle the growth?
+
+`Act.close(targets)` truncates a stream's events and leaves a `__tombstone__` (or `__snapshot__`) behind, reclaiming the row count for streams that are semantically complete. For the dominant Act workload — domain aggregates with a definite lifecycle (orders, tickets, sessions, payments) — close is the right tool. Combined with the cache-on-commit path described in `docs/docs/architecture/cache-and-snapshots.md`, closed streams shed their events without losing the ability to reconstruct state on demand.
+
+```ts
+await app.close([
+  { stream: "order-2024-12345", archive: async () => { /* S3 dump */ } },
+]);
+```
+
+The `.autocloses({...})` policy from epic #802 (full syntax in `docs/docs/guides/close-policies.md`) lets `close()` happen automatically on a per-state policy:
+
+```ts
+state("Order", OrderSchema)
+  .autocloses({ is: "OrderCompleted", after: { days: 30 } })
+  .archives(async (stream, events) => { /* S3 dump */ });
+```
+
+Once that's wired, an app's events table reaches a steady state — closed streams shed their history continuously, the table doesn't grow without bound, and no partitioning is required. The full recipe lives at `recipes/scaling/close-the-books/README.md`.
+
+**If `close()` can keep your events table in steady state, stop reading. You don't need partitioning.**
+
+You should think hard before deciding `close()` can't help. Apps frequently believe their streams are "long-lived and never end" when in fact most of them have natural terminal events that go unused (sessions that expired six months ago, tickets that nobody will ever reopen, carts that were abandoned). Adding a terminal close policy is almost always cheaper than partitioning. The decision tree at `recipes/scaling/README.md` walks through the heuristics in order — close first, archival second, partitioning only after both.
+
+## Second gate: do you have an extreme workload?
+
+The narrow set of workloads where `close()` genuinely can't help:
+
+1. **Regulated / append-only audit logs.** Financial ledgers, compliance trails, blockchain-adjacent systems where deletion is forbidden by policy or law. `Act.close()` is unavailable because tombstones are still "deletion" in the strict regulatory reading. The events table grows monotonically forever; index height, VACUUM duration, and planner stats eventually dominate tail latency. The recipe for this case is `recipes/scaling/partitioning/hash-on-stream/README.md` — HASH-on-stream colocates each aggregate's events in one partition, keeps single-stream reads cheap, and caps per-partition index height.
+
+2. **Single-aggregate giants.** One stream with millions of events on a single aggregate — a multi-year IoT device telemetry trail, a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might. See `recipes/scaling/partitioning/range-on-id/README.md` — that recipe is documentation-only by design because the cut points are app-specific.
+
+3. **Bulk archival with retention windows.** Regulatory frameworks that require retention for N months and then mandate disposal. `Act.close()` deletes per-row, which is slow on hundreds of millions of rows; `DETACH PARTITION` + `DROP TABLE` is constant-time DDL regardless of partition size. Some regulators also accept partition-drop as "physical retention until partition retirement," which is more defensible than per-row delete. Recipe: `recipes/scaling/partitioning/range-on-created/README.md`. If you're chasing retention with non-regulatory motivations, check `recipes/scaling/archival/README.md` first — the `close()`-plus-archiver path is usually enough.
+
+4. **Parallel projection rebuild as the bottleneck.** Operations teams running periodic full `app.reset()` on a multi-hundred-million-row events table, where the rebuild window is the operational bottleneck. *Caveat:* see the global-`id` discussion above — partitioning helps rebuild throughput only when the partitioned MergeAppend cost is dominated by per-partition parallel I/O. Benchmark before assuming this; the framework's PG benchmark (#851) reports observed vs theoretical speedup for exactly this reason, and `libs/act-pg/PERFORMANCE.md` records both numbers so you can compare against your own workload.
+
+**If your workload doesn't hit one of these four cases, stop reading.** You don't need partitioning. The remaining sections are for the operators who legitimately do.
+
+## When partitioning doesn't help at all
+
+Even if you fit one of the four extreme cases, partitioning isn't always the right shape. Cases where it's specifically *not* the answer:
+
+- **Events table under ~10M rows.** Planner overhead from partition pruning + MergeAppend costs more than the table size saves. PG documentation gives this as the rough lower bound, and our PG 17 microbenchmarks in `libs/act-pg/PERFORMANCE.md` were all run well below this threshold for the same reason — there isn't a real win to measure.
+- **Cross-stream queries dominate.** If your projections / reactions span many streams and need global id order, partitioning slows the read path. Even the rebuild win is conditional.
+- **No HA replicas.** The migration to partitioned shape rewrites the table — WAL volume is significant and a non-replicated database means the migration window is the only window. Plan downtime accordingly, or stand up a logical replica first.
+- **Single-tenant SaaS with bounded customer count.** Cap the customer-stream count via the `.autocloses({ reaches: N })` cardinality form instead; you'll get bounded storage without the partitioning operational tax.
+- **You haven't measured `close()` first.** This is the most common mistake. Operators reach for partitioning before they've actually quantified what `close()` would save them. Run a one-week `.autocloses({...})` policy in staging, measure the row-count delta, then decide.
+
+## If partitioning is still the answer: strategy menu
+
+Three strategies, each with different trade-offs. None of them is "better partitioning" — they buy different properties for different problems.
+
+| Strategy | Migration | Ongoing cost | Solves | Recipe |
+|---|---|---|---|---|
+| HASH on `stream` | Full table copy (offline or `pg_repack`-online). Set-and-forget after. | Cross-stream queries pay MergeAppend across N partitions. Single-stream queries unaffected. | Regulated append-only audit; parallel rebuild *if* the benchmark supports it | `recipes/scaling/partitioning/hash-on-stream/README.md` |
+| RANGE on `id` | Full table copy. Ongoing: provision new partitions as the id sequence grows. | `ORDER BY id` queries can prune to one partition (the hot one). Older partitions go cold and can be moved to slower storage. | Single-aggregate giants; bounded planner cost as the table grows | `recipes/scaling/partitioning/range-on-id/README.md` |
+| RANGE on `created` | Full table copy. Ongoing: `pg_partman` (or manual cron) provisions monthly/yearly partitions. | `DETACH` + `DROP` is constant-time bulk archival. Cross-stream queries pay MergeAppend. | Retention-window bulk archival in regulated domains | `recipes/scaling/partitioning/range-on-created/README.md` |
+
+Notes on each:
+
+- **HASH on `stream`** is the workhorse if you must partition for general storage growth. A stream's events colocate in one partition, so `claim()` and single-stream reads prune cleanly. Cross-stream operations pay the MergeAppend cost — be sure you measured this on your workload before committing. The recipe ships SQL and a sample migration script that operators can adapt during a maintenance window.
+
+- **RANGE on `id`** is the only strategy that helps "single-aggregate giant" scenarios. It deliberately splits one stream across partitions, ordered by the global id. Recent partitions stay hot, older partitions go cold. Documentation-only: range partitioning is a per-app schema design (event volume, retention window, archival policy), not a turn-key recipe. The framework documents the *strategy*; the schema is yours to design.
+
+- **RANGE on `created`** is the strategy for bulk archival by retention window. Pair with `pg_partman` for partition creation and the drop-partition runner in the recipe for the archival half of the loop. Don't use this strategy if you don't have a clean retention boundary — picking a wrong cutoff means re-partitioning later, which is the same migration cost twice.
+
+## Costs you'll see no matter which strategy you pick
+
+- **PK becomes composite.** Partitioning by anything other than `id` requires the partition key to be in every unique constraint. The events PK becomes `(id, partition_key)` instead of `id`. This is mechanically fine but breaks any external tooling that assumed `id` alone uniquely identifies a row. The unique `(stream, version)` constraint that backs optimistic concurrency stays correct under all three strategies, because `stream` is either the partition key (HASH) or a column already present in the constraint (RANGE).
+- **Index storage.** Each index is recreated per partition. For N partitions and K indexes, you have N×K index trees instead of K. Disk overhead is small per index but non-zero. The default schema ships four indexes on the events table (`{{table}}_stream_ix`, `{{table}}_name_ix`, `{{table}}_created_id_ix`, `{{table}}_correlation_ix`); multiply by N to budget storage.
+- **`events_id_seq` is shared.** The sequence stays global so `id` monotonicity holds across partitions. This is a feature, not a cost — without it, the framework's global-order assumptions break entirely.
+- **Planner overhead.** Every query consults more relations. PG ≥ 14 with `enable_partition_pruning = on` (default) caches pruned plans, so prepared statements amortize. Ad-hoc queries pay a small constant overhead per partition checked.
+- **Rebuild semantics.** `app.reset(targets)` still works post-migration; the cost depends on whether your workload's hot path is single-stream (cheap) or cross-stream (MergeAppend). Run the partitioning benchmark (#851) on your data shape before committing — the theoretical N× parallel speedup is rarely the observed speedup, and may not exist at all on cross-stream-dominated workloads.
+
+## If you remember one thing
+
+Partitioning is the answer to a problem most Act apps don't have. It is operationally heavy, fights against event sourcing's global-`id` ordering on the cross-stream read path, and almost always costs more than it saves unless the workload genuinely belongs to one of the four extreme cases above.
+
+`Act.close()` — manual or via the `.autocloses({...})` policy from epic #802 — is the right answer for the dominant workload. Reach for partitioning only after you've ruled close out, measured the cost, and confirmed that your workload is the narrow exception that justifies the operational tax. The close-the-books recipe at `recipes/scaling/close-the-books/README.md` is where almost every "my events table is growing" conversation should start; the production checklist at `docs/docs/guides/production-checklist.md` has the operator-side wiring.

--- a/recipes/scaling/partitioning/hash-on-stream/README.md
+++ b/recipes/scaling/partitioning/hash-on-stream/README.md
@@ -1,0 +1,318 @@
+# HASH-on-stream partitioning
+
+This recipe converts an unpartitioned `events` table into one that lives behind
+`PARTITION BY HASH (stream)`. The events stay logically one table, the global
+`id` sequence stays shared, and `claim()` / single-stream reads still prune to
+one partition. What changes is how the storage is laid out underneath: instead
+of one giant heap and one giant set of B-trees, you get N smaller heaps and N
+smaller B-trees, one per hash bucket.
+
+Default Act is fine for most apps. You shouldn't be here unless the gating
+page at [recipes/scaling/partitioning/README.md](../README.md) has already
+walked you through the four extreme cases and you've concluded yours is case #1
+(regulated / append-only audit logs where `.autocloses(...)` isn't an option).
+If your events table can be kept in steady state by `Act.close()` — explicit or
+via [.autocloses(...)](../../../../docs/docs/guides/close-policies.md) — close
+the tab and reach for that instead. This recipe will cost you more than it
+saves.
+
+## When to reach for it
+
+Case #1 from the gating page is the canonical fit: a regulated or append-only
+audit log where deletion (even tombstone-shaped deletion) isn't acceptable to
+your auditors, and the events table is consequently going to grow monotonically
+forever. The operational wins HASH partitioning buys you in that scenario:
+
+- **VACUUM concurrency.** Autovacuum runs per-relation. One unpartitioned table
+  means one autovacuum worker walks the whole heap; N partitions means up to N
+  workers walking N smaller heaps in parallel, and a long-running VACUUM on one
+  bucket doesn't block the others.
+- **Smaller B-tree depth.** A B-tree on K rows has height roughly
+  `log_fanout(K)`. Splitting K across N partitions reduces the per-tree height
+  by approximately `log_fanout(N)` — on commodity workloads this is in the
+  ballpark of one level (around 20% shorter trees on 16 partitions for
+  realistic fanouts). Each lookup does one fewer page hop.
+- **Fresher planner stats.** ANALYZE costs scale with table size. Smaller
+  partitions get re-sampled more often within the same autovacuum budget, so
+  cardinality estimates stay closer to reality on the hot single-stream path.
+
+These are operational wins, not algorithmic wins. The framework's hot read
+paths (`claim()`, single-stream `load`, single-stream `commit`) were already
+fast on the unpartitioned table. What you're buying here is **better tail
+latency under sustained growth**, not lower median latency. If your audit log
+isn't growing fast enough to make VACUUM and index height into operational
+problems, HASH partitioning will make your life worse, not better.
+
+There are no measured framework benchmarks for HASH-on-stream on a real
+audit-log workload yet; the parallel-rebuild benchmark in
+[libs/act-pg/PERFORMANCE.md](../../../../libs/act-pg/PERFORMANCE.md) covers the
+rebuild-throughput question, not the steady-state-VACUUM question. Measure on
+your own data shape before committing.
+
+## What it does NOT solve
+
+Quoting the gating page so you don't have to switch tabs:
+
+- **Single-aggregate giants** (case #2). "One stream with millions of events on
+  a single aggregate — a multi-year IoT device telemetry trail, a long-running
+  ledger for one regulated entity, an audit trail for a critical workflow that
+  runs for a decade." HASH partitioning by `stream` does not help here: all the
+  events for one stream hash to the same bucket and land in one partition.
+  You'd be growing one partition without bound while the others sit empty. See
+  [recipes/scaling/partitioning/range-on-id/README.md](../range-on-id/README.md)
+  if this is your problem.
+- **Bulk archival with retention windows** (case #3). HASH partitions can't be
+  dropped — every bucket holds events from every retention period mixed
+  together. If your problem is "delete everything older than 18 months in
+  constant-time DDL," you need RANGE on `created`, not HASH on `stream`. See
+  [recipes/scaling/partitioning/range-on-created/README.md](../range-on-created/README.md).
+- **Cross-stream read latency.** HASH partitioning makes every cross-stream
+  query pay MergeAppend across N partitions. The drain pipeline, projection
+  advance, and `app.reset()` all read in global `id` order across many streams.
+  HASH won't make these faster; it makes them measurably slower in exchange for
+  the VACUUM and B-tree wins above. The trade is worth it for an audit-log
+  workload that's dominated by single-stream commit traffic. It is **not** worth
+  it for a workload dominated by projection rebuilds or cross-stream reads.
+
+## Schema changes
+
+The post-migration shape matches the unpartitioned schema in
+`libs/act-pg/src/postgres-store.ts` (lines 365–455) on every observable column,
+with three structural differences forced by PG's partitioning rules:
+
+1. **Primary key becomes `(id, stream)`.** PG requires the partition key to be
+   in every unique constraint. The partition key here is `stream`, so the PK is
+   composite. External tooling that assumed `id` alone uniquely identifies a
+   row needs updating — within Act itself this is fine because the framework
+   never asserts row-identity by `id` alone.
+2. **Indexes are partitioned.** The four existing indexes — unique
+   `(stream, version)`, `(name)`, `(created, id)`, and
+   `((meta ->> 'correlation'))` — are recreated as partitioned indexes that the
+   planner propagates to every child partition. Each child gets its own
+   physical B-tree.
+3. **The `events_id_seq` sequence is preserved verbatim.** Never recreate it.
+   The migration ends with a `setval(...)` to advance the sequence past the
+   highest copied `id`. Recreating the sequence would silently break global
+   `id` monotonicity, which is load-bearing for drain, projections, and
+   `app.reset()`. See [docs/docs/architecture/cache-and-snapshots.md](../../../../docs/docs/architecture/cache-and-snapshots.md)
+   for why monotonicity matters.
+
+The `streams` table is **not partitioned** by this recipe. It's small, the
+`claim()` index pattern (`blocked, priority DESC, at`) doesn't benefit from
+hashing, and partitioning it would force every claim query to MergeAppend
+across buckets. Leave it alone.
+
+## The workflow
+
+This is the operational workflow. Run it during a maintenance window with a
+recent backup at hand. The forward migration is split across two phases: a
+concurrent online phase that copies bulk data with reads and writes flowing
+normally, and a brief atomic swap that takes an `ACCESS EXCLUSIVE` lock to
+drain the last few rows and rename the tables.
+
+### Phase 0: Pre-flight
+
+Cheap checks before any DDL. The goal is to fail fast and loudly if the
+environment doesn't match the recipe's assumptions. Verify in order:
+
+- **PostgreSQL version ≥ 14.** Earlier versions lack `enable_partition_pruning`
+  on by default and have weaker MergeAppend behavior. The migration may still
+  succeed on 12/13 but you'll lose the planner improvements that motivate the
+  trade.
+- **Free disk space ≥ 2× the current `events` table.** The bulk copy holds
+  both the source and the partitioned target on disk until the swap completes.
+  Run `SELECT pg_size_pretty(pg_total_relation_size('{{schema}}.{{table}}'))`
+  and confirm you have headroom.
+- **`{{table}}_id_seq` exists and is owned by `{{schema}}.{{table}}.id`.** The
+  swap relies on this sequence surviving the rename intact. Run
+  `\d {{schema}}.{{table}}` and confirm the default for `id` is
+  `nextval('{{schema}}.{{table}}_id_seq'::regclass)`.
+- **No concurrent migration-shaped locks.** Run `SELECT * FROM pg_locks WHERE
+  relation = '{{schema}}.{{table}}'::regclass` and confirm only short-lived
+  row locks are held. A long-running `CREATE INDEX` or `CLUSTER` will fight
+  the migration.
+- **The application can tolerate a brief write pause** during Phase 2's swap.
+  The swap holds `ACCESS EXCLUSIVE` for the time it takes to drain late rows
+  and rename the tables — typically seconds, not minutes, but commit traffic
+  will queue during the window. Drain `claim()` workers ahead of the swap if
+  your business can't tolerate the queue depth.
+
+If any check fails, stop. Fix the underlying condition and re-run pre-flight.
+Do not start Phase 1 until every check passes.
+
+### Phase 1: Build the partitioned shape (online)
+
+This phase runs with reads and writes flowing normally to the existing table.
+The `forward.sql` file in this directory:
+
+1. Creates the partitioned target table as `{{table}}_partitioned` with the
+   composite PK and the partition definition `PARTITION BY HASH (stream)`.
+2. Creates 16 child partitions, one per `MODULUS 16 / REMAINDER 0..15` bucket.
+   Tune the partition count below.
+3. Creates the four partitioned indexes that propagate to every child.
+4. Bulk-copies every row from the current `events` table into the partitioned
+   target with a single `INSERT INTO ... SELECT * FROM ...`. PG routes each row
+   to the correct child based on `hash(stream) % 16`.
+
+The bulk copy is the slow step. On commodity PG 17 + NVMe SSD, expect a
+sustained 10k–30k rows/sec throughput for a table with the Act events shape
+(small `jsonb` payloads, the four standard indexes). For a 100M-row events
+table, plan for **1–3 hours** of online copy. The system stays available
+throughout: writes continue to land in the source table; the new rows that
+land during the copy are picked up in Phase 2's drain step.
+
+During Phase 1 you should monitor:
+
+- **WAL pressure.** The copy generates roughly 1× the table's heap size in WAL.
+  If you have streaming replicas, watch their lag — pause the copy if a replica
+  falls behind your RPO.
+- **Autovacuum on the source.** The copy doesn't change the source's
+  modification rate, so autovacuum should be unaffected, but a long-running
+  open transaction (which `INSERT INTO ... SELECT` is) prevents VACUUM from
+  reclaiming dead tuples on the source until the copy commits.
+- **Disk usage.** This is the moment of peak disk pressure. The forward.sql
+  file is conservative — it uses a single bulk insert. If your disk budget is
+  tight, see "Tuning" below for the chunked-copy variant.
+
+### Phase 2: Atomic swap
+
+Once Phase 1's bulk copy completes, the partitioned target has every row that
+was in `events` at the moment Phase 1 started, plus zero rows that landed
+since. The swap step in `forward.sql`:
+
+1. Takes `LOCK TABLE {{schema}}.{{table}} IN ACCESS EXCLUSIVE MODE`. New writes
+   block, in-flight transactions are allowed to finish.
+2. Drains late rows — copies every row in the source with `id` greater than the
+   max `id` already in the partitioned target. This catches everything that
+   landed during the Phase 1 copy.
+3. Calls `setval('{{schema}}.{{table}}_id_seq', <max_id>, true)` to advance the
+   shared sequence past every copied `id`. The sequence is **not recreated** —
+   only advanced.
+4. Renames `{{table}}` to `{{table}}_pre_partition_backup` and renames
+   `{{table}}_partitioned` to `{{table}}`.
+5. Commits, releasing the `ACCESS EXCLUSIVE` lock.
+
+The swap holds the lock for the duration of the late-row drain plus the two
+renames. If Phase 1 finished close to "right now" the drain is a few thousand
+rows at most and the lock window is on the order of seconds. If Phase 1
+finished hours ago and traffic has been heavy, the drain may run minutes —
+plan accordingly.
+
+### Phase 3: Verify + report
+
+After the swap commits:
+
+- **Row counts match.** `SELECT count(*) FROM {{schema}}.{{table}}` against
+  `SELECT count(*) FROM {{schema}}.{{table}}_pre_partition_backup`. They should
+  be equal; differences indicate the late-row drain missed something and
+  require investigation before declaring success.
+- **Sequence advances correctly.** Issue a `SELECT nextval('{{schema}}.{{table}}_id_seq')`
+  and confirm the returned value is greater than the max `id` in the new
+  partitioned table. The next real commit should also land cleanly.
+- **Partition distribution is roughly even.** Run
+  `SELECT tableoid::regclass, count(*) FROM {{schema}}.{{table}} GROUP BY 1`
+  and confirm the counts are within ~10% of each other across partitions.
+  Severe skew indicates pathological stream-name distribution and the recipe
+  isn't buying what it promised.
+- **Backup table preserved.** `{{table}}_pre_partition_backup` is still there,
+  on disk, unmodified. Do not drop it until you've run the application for at
+  least a week against the partitioned shape with no surprises. Disk is
+  cheaper than re-running the migration.
+
+## Rollback workflow
+
+Rollback exists for the case where the partitioned shape breaks production in
+a way you can't tune around. It is **not** an online operation: it requires a
+maintenance window with paused writes. The `rollback.sql` file:
+
+1. Takes `ACCESS EXCLUSIVE` on the now-partitioned `{{table}}`.
+2. Renames the current backup `{{table}}_pre_partition_backup` → no-op if you
+   want to keep the original under that name; otherwise rename it back to a
+   new backup slot like `{{table}}_pre_rollback_backup`.
+3. Renames the partitioned `{{table}}` → `{{table}}_post_partition_backup`.
+4. Restores the pre-partition table by renaming it back to `{{table}}`, or
+   alternatively bulk-copies every row from the partitioned table into a fresh
+   unpartitioned `{{table}}` if you want to keep writes that landed
+   post-partition.
+5. Sets the sequence forward past the max `id` in the restored table.
+
+**The rollback can pull writes that landed post-partition** if you choose the
+copy-from-partitioned variant. The simpler variant (rename the original back)
+discards every event written after the original swap — only choose it if you
+caught the breakage within the first few minutes and your application can
+tolerate replaying the lost commits.
+
+You **cannot** roll back online. The schemas differ in the PK shape, the
+indexes are physically distinct, and PG has no in-place "unpartition" operation.
+Plan the rollback window the same way you planned the forward window: backup,
+maintenance announcement, paused writes.
+
+## Safety rails
+
+- **Two backups exist at the end.** After the forward migration,
+  `{{table}}_pre_partition_backup` is on disk. After a rollback,
+  `{{table}}_post_partition_backup` is on disk. Keep both until you're certain
+  you don't need to revisit.
+- **The sequence is never recreated.** Only `setval` advances it. This is the
+  single most important invariant. Recreating `{{table}}_id_seq` would silently
+  break global `id` monotonicity, which would in turn break drain ordering,
+  projection watermarks, and `app.reset()`. The `forward.sql` and `rollback.sql`
+  files never issue `CREATE SEQUENCE` or `DROP SEQUENCE` against this name.
+- **The `streams` table is untouched.** Claim semantics, lane assignments,
+  blocked flags, retry counters — all preserved verbatim. The forward
+  migration touches the events table only.
+- **Every cheap validation runs before any DDL.** Pre-flight is row-count and
+  metadata queries; nothing is written until you pass every check. If something
+  is off, you find out before you've committed any irreversible action.
+- **Pre-flight runs in its own session.** Don't reuse the pre-flight session
+  for the forward migration — a stale catalog snapshot can mask a problem that
+  appeared between checks.
+
+## Tuning: `--partitions N`
+
+The default partition count is **16**. This is the sweet spot for the
+target workload (regulated audit log, growth-dominated, single-stream traffic):
+
+- **Uniform distribution.** 16 buckets with a reasonably well-distributed
+  `stream` name space gives each bucket roughly 1/16 of the rows. The standard
+  hash function in PG is good enough that you'd need pathological stream names
+  (e.g., everyone hashing to the same bucket because they share a prefix and
+  the hash collapses) to see severe skew, and `hash_text` doesn't have that
+  failure mode.
+- **Enough parallelism for VACUUM.** Modern PG instances run at least 3
+  autovacuum workers; 16 partitions means a busy table can keep 3 workers
+  busy without one of them holding up the others.
+- **Not enough to overwhelm the planner.** Every cross-stream query consults
+  every partition (modulo pruning). At 16 partitions the MergeAppend cost is
+  noticeable but manageable; at 64+ the planner overhead starts to dominate
+  for short queries. The PG documentation's general guidance is "hundreds of
+  partitions is fine for big-table workloads, thousands is questionable" — but
+  Act's MergeAppend-heavy read path is more sensitive than that, so the
+  practical cap is lower.
+
+Acceptable bounds are **[2, 64]**. Below 2 you have one partition and you've
+done all this work for nothing; above 64 the planner overhead on cross-stream
+reads starts being visible in p95 latency and you've crossed into "measure
+yourself or regret it" territory. The `run.sh` wrapper validates the bound and
+fails fast if you pass anything outside.
+
+If you have specific tenant-shaped traffic patterns (e.g., 90% of writes go to
+3 hot streams) HASH partitioning won't fix that — the hash will distribute the
+hot streams across buckets but each hot stream's traffic still concentrates in
+one bucket. Consider whether the gating page's case #2 (single-aggregate
+giants) is closer to your problem than case #1.
+
+## Cross-references
+
+- [Gating page](../README.md) — the four cases this recipe doesn't solve.
+- [Close-the-books recipe](../../close-the-books/README.md) — the path you
+  should try first.
+- [Archival recipe](../../archival/README.md) — for retention-window cases.
+- [.autocloses(...) syntax](../../../../docs/docs/guides/close-policies.md) —
+  declarative close policies.
+- [Production checklist](../../../../docs/docs/guides/production-checklist.md)
+  — operational baseline.
+- [PG perf data](../../../../libs/act-pg/PERFORMANCE.md) — measured numbers
+  for the PG adapter.
+- [Core perf data](../../../../libs/act/PERFORMANCE.md) — measured numbers for
+  the core framework.

--- a/recipes/scaling/partitioning/hash-on-stream/README.md
+++ b/recipes/scaling/partitioning/hash-on-stream/README.md
@@ -54,10 +54,11 @@ your own data shape before committing.
 Quoting the gating page so you don't have to switch tabs:
 
 - **Single-aggregate giants** (case #2). "One stream with millions of events on
-  a single aggregate — a multi-year IoT device telemetry trail, a long-running
-  ledger for one regulated entity, an audit trail for a critical workflow that
-  runs for a decade." HASH partitioning by `stream` does not help here: all the
-  events for one stream hash to the same bucket and land in one partition.
+  a single business-domain aggregate — a long-running ledger for one regulated
+  entity, an audit trail for a critical workflow that runs for a decade, a
+  compliance event log for a single legal entity." HASH partitioning by
+  `stream` does not help here: all the events for one stream hash to the same
+  bucket and land in one partition.
   You'd be growing one partition without bound while the others sit empty. See
   [recipes/scaling/partitioning/range-on-id/README.md](../range-on-id/README.md)
   if this is your problem.

--- a/recipes/scaling/partitioning/hash-on-stream/forward.sql
+++ b/recipes/scaling/partitioning/hash-on-stream/forward.sql
@@ -1,0 +1,148 @@
+-- =============================================================================
+-- HASH-on-stream partitioning: forward migration
+-- =============================================================================
+--
+-- What this file does
+--   Converts an unpartitioned Act events table into one partitioned by
+--   HASH (stream) with 16 child partitions. Streams table is untouched.
+--   The shared events_id_seq is preserved (advanced, never recreated).
+--
+-- Placeholders to substitute (use sed / envsubst before piping to psql)
+--   {{schema}}      schema name (matches PostgresConfig.schema)
+--   {{table}}       events table name (matches PostgresConfig.table)
+--
+-- Pre-state
+--   Regular (unpartitioned) table {{schema}}.{{table}} with the standard
+--   Act events schema:
+--     id serial PRIMARY KEY,
+--     name varchar(100), data jsonb,
+--     stream varchar(100), version int,
+--     created timestamptz, meta jsonb, pii jsonb
+--   Standard indexes:
+--     UNIQUE (stream, version)        -- {{table}}_stream_ix
+--     (name)                          -- {{table}}_name_ix
+--     (created, id)                   -- {{table}}_created_id_ix
+--     ((meta ->> 'correlation'))      -- {{table}}_correlation_ix
+--   Sequence {{schema}}.{{table}}_id_seq owns the id column.
+--
+-- Post-state
+--   Partitioned table {{schema}}.{{table}} with composite PK (id, stream)
+--   and 16 hash partitions. The original table is renamed to
+--   {{schema}}.{{table}}_pre_partition_backup and left in place.
+--
+-- Tuning
+--   This file uses MODULUS 16 (16 partitions). To change the partition count
+--   N, edit the MODULUS N values in every CREATE TABLE ... PARTITION OF
+--   statement below. Acceptable range is [2, 64]; outside that you should
+--   reconsider whether HASH partitioning is the right strategy. The run.sh
+--   wrapper handles this substitution if you set PARTITIONS=N in env.
+--
+-- Expected throughput
+--   10k-30k rows/sec sustained copy on commodity PG 17 + NVMe SSD. For a
+--   100M-row events table, plan for 1-3 hours of online copy in Phase 1.
+--
+-- Lock window
+--   Phase 2's swap holds ACCESS EXCLUSIVE on {{schema}}.{{table}} for the
+--   time it takes to drain late rows and rename two tables. Expect seconds
+--   under low write load; minutes if Phase 1 ran for hours under heavy
+--   write traffic.
+--
+-- Disk peak
+--   2x the source events table during the copy window. Verify free disk
+--   before starting.
+--
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- == Phase 1 ==
+-- Build the partitioned shape and copy bulk data with reads and writes
+-- flowing normally against {{schema}}.{{table}}.
+
+-- Create the partitioned target table. Composite PK because PG requires
+-- the partition key (stream) to be part of every unique constraint.
+CREATE TABLE "{{schema}}"."{{table}}_partitioned" (
+    id integer NOT NULL DEFAULT nextval('"{{schema}}"."{{table}}_id_seq"'::regclass),
+    name varchar(100) COLLATE pg_catalog."default" NOT NULL,
+    data jsonb,
+    stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
+    version integer NOT NULL,
+    created timestamptz NOT NULL DEFAULT now(),
+    meta jsonb,
+    pii jsonb,
+    PRIMARY KEY (id, stream)
+) PARTITION BY HASH (stream);
+
+-- Create 16 child partitions. Change the MODULUS value here and on every
+-- partition below if you want a different bucket count.
+CREATE TABLE "{{schema}}"."{{table}}_p00" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 0);
+CREATE TABLE "{{schema}}"."{{table}}_p01" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 1);
+CREATE TABLE "{{schema}}"."{{table}}_p02" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 2);
+CREATE TABLE "{{schema}}"."{{table}}_p03" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 3);
+CREATE TABLE "{{schema}}"."{{table}}_p04" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 4);
+CREATE TABLE "{{schema}}"."{{table}}_p05" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 5);
+CREATE TABLE "{{schema}}"."{{table}}_p06" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 6);
+CREATE TABLE "{{schema}}"."{{table}}_p07" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 7);
+CREATE TABLE "{{schema}}"."{{table}}_p08" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 8);
+CREATE TABLE "{{schema}}"."{{table}}_p09" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 9);
+CREATE TABLE "{{schema}}"."{{table}}_p10" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 10);
+CREATE TABLE "{{schema}}"."{{table}}_p11" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 11);
+CREATE TABLE "{{schema}}"."{{table}}_p12" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 12);
+CREATE TABLE "{{schema}}"."{{table}}_p13" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 13);
+CREATE TABLE "{{schema}}"."{{table}}_p14" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 14);
+CREATE TABLE "{{schema}}"."{{table}}_p15" PARTITION OF "{{schema}}"."{{table}}_partitioned" FOR VALUES WITH (MODULUS 16, REMAINDER 15);
+
+-- Create partitioned indexes. PG propagates these to every child partition
+-- automatically; each child gets its own physical B-tree.
+CREATE UNIQUE INDEX "{{table}}_partitioned_stream_ix"
+    ON "{{schema}}"."{{table}}_partitioned" (stream COLLATE pg_catalog."default", version);
+
+CREATE INDEX "{{table}}_partitioned_name_ix"
+    ON "{{schema}}"."{{table}}_partitioned" (name COLLATE pg_catalog."default");
+
+CREATE INDEX "{{table}}_partitioned_created_id_ix"
+    ON "{{schema}}"."{{table}}_partitioned" (created, id);
+
+CREATE INDEX "{{table}}_partitioned_correlation_ix"
+    ON "{{schema}}"."{{table}}_partitioned" ((meta ->> 'correlation') COLLATE pg_catalog."default");
+
+-- Bulk copy. PG routes each row to the correct child based on hash(stream).
+-- This is the slow step. Reads and writes against the source continue normally.
+INSERT INTO "{{schema}}"."{{table}}_partitioned" (id, name, data, stream, version, created, meta, pii)
+SELECT id, name, data, stream, version, created, meta, pii
+FROM "{{schema}}"."{{table}}";
+
+-- == Phase 2 ==
+-- Atomic swap. Acquires ACCESS EXCLUSIVE for the late-row drain and rename.
+
+LOCK TABLE "{{schema}}"."{{table}}" IN ACCESS EXCLUSIVE MODE;
+
+-- Drain late rows: anything that landed during the Phase 1 copy.
+INSERT INTO "{{schema}}"."{{table}}_partitioned" (id, name, data, stream, version, created, meta, pii)
+SELECT s.id, s.name, s.data, s.stream, s.version, s.created, s.meta, s.pii
+FROM "{{schema}}"."{{table}}" s
+LEFT JOIN "{{schema}}"."{{table}}_partitioned" p ON p.id = s.id AND p.stream = s.stream
+WHERE p.id IS NULL;
+
+-- Advance the shared sequence past the highest copied id. The sequence is
+-- never recreated; only advanced. Recreating it would silently break the
+-- framework's global id monotonicity invariant.
+SELECT setval(
+    '"{{schema}}"."{{table}}_id_seq"',
+    GREATEST(
+        (SELECT COALESCE(MAX(id), 0) FROM "{{schema}}"."{{table}}_partitioned"),
+        (SELECT last_value FROM "{{schema}}"."{{table}}_id_seq")
+    ),
+    true
+);
+
+-- Rename: source becomes the backup, partitioned becomes the live table.
+-- Indexes are renamed together with their tables by PG.
+ALTER TABLE "{{schema}}"."{{table}}" RENAME TO "{{table}}_pre_partition_backup";
+ALTER TABLE "{{schema}}"."{{table}}_partitioned" RENAME TO "{{table}}";
+
+COMMIT;
+
+-- The migration is complete. Run the Phase 3 verification queries from the
+-- README before declaring success and before dropping the backup table.

--- a/recipes/scaling/partitioning/hash-on-stream/rollback.sql
+++ b/recipes/scaling/partitioning/hash-on-stream/rollback.sql
@@ -1,0 +1,103 @@
+-- =============================================================================
+-- HASH-on-stream partitioning: rollback
+-- =============================================================================
+--
+-- What this file does
+--   Reverts the events table from PARTITION BY HASH (stream) back to a
+--   regular unpartitioned table. The partitioned table is preserved as
+--   a backup. The sequence is advanced (never recreated).
+--
+-- Placeholders to substitute (use sed / envsubst before piping to psql)
+--   {{schema}}      schema name
+--   {{table}}       events table name
+--
+-- Requires a maintenance window
+--   This is NOT an online operation. Reads will block briefly; writes must
+--   be paused for the duration of the run. The schemas differ in PK shape
+--   and index layout, so PG cannot perform the swap online.
+--
+-- Pre-state (after a successful forward.sql)
+--   Partitioned table  {{schema}}.{{table}}                  (live)
+--   Original backup    {{schema}}.{{table}}_pre_partition_backup
+--   Sequence           {{schema}}.{{table}}_id_seq           (shared)
+--
+-- Post-state (after this rollback)
+--   Regular table      {{schema}}.{{table}}                  (live, repopulated)
+--   Pre-partition backup remains where forward.sql left it
+--   Post-partition backup at {{schema}}.{{table}}_post_partition_backup
+--
+-- What gets carried forward
+--   Every row that the partitioned table held at the moment this script
+--   ran. That INCLUDES writes that landed after the original swap — the
+--   INSERT step copies from the current partitioned table, not from the
+--   pre-partition backup. If you only wanted writes up to the pre-partition
+--   moment, drop {{table}}_post_partition_backup and rename
+--   {{table}}_pre_partition_backup back to {{table}} manually instead of
+--   running this script.
+--
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- Block writes for the duration of the rollback.
+LOCK TABLE "{{schema}}"."{{table}}" IN ACCESS EXCLUSIVE MODE;
+
+-- Create a fresh unpartitioned target with the standard Act events shape.
+-- PK is the simple (id) again; the partition-key requirement no longer applies.
+CREATE TABLE "{{schema}}"."{{table}}_unpartitioned" (
+    id integer NOT NULL DEFAULT nextval('"{{schema}}"."{{table}}_id_seq"'::regclass) PRIMARY KEY,
+    name varchar(100) COLLATE pg_catalog."default" NOT NULL,
+    data jsonb,
+    stream varchar(100) COLLATE pg_catalog."default" NOT NULL,
+    version integer NOT NULL,
+    created timestamptz NOT NULL DEFAULT now(),
+    meta jsonb,
+    pii jsonb
+) TABLESPACE pg_default;
+
+-- Recreate the standard four indexes. These match the indexes that
+-- postgres-store.ts's seed() would create on a fresh install.
+CREATE UNIQUE INDEX "{{table}}_unpartitioned_stream_ix"
+    ON "{{schema}}"."{{table}}_unpartitioned" (stream COLLATE pg_catalog."default", version);
+
+CREATE INDEX "{{table}}_unpartitioned_name_ix"
+    ON "{{schema}}"."{{table}}_unpartitioned" (name COLLATE pg_catalog."default");
+
+CREATE INDEX "{{table}}_unpartitioned_created_id_ix"
+    ON "{{schema}}"."{{table}}_unpartitioned" (created, id);
+
+CREATE INDEX "{{table}}_unpartitioned_correlation_ix"
+    ON "{{schema}}"."{{table}}_unpartitioned" ((meta ->> 'correlation') COLLATE pg_catalog."default");
+
+-- Copy every row from the partitioned table, preserving id values. The
+-- partitioned table's MergeAppend serves this in global id order.
+INSERT INTO "{{schema}}"."{{table}}_unpartitioned" (id, name, data, stream, version, created, meta, pii)
+SELECT id, name, data, stream, version, created, meta, pii
+FROM "{{schema}}"."{{table}}"
+ORDER BY id;
+
+-- Advance the sequence past the highest copied id. As in forward.sql,
+-- the sequence is never recreated.
+SELECT setval(
+    '"{{schema}}"."{{table}}_id_seq"',
+    GREATEST(
+        (SELECT COALESCE(MAX(id), 0) FROM "{{schema}}"."{{table}}_unpartitioned"),
+        (SELECT last_value FROM "{{schema}}"."{{table}}_id_seq")
+    ),
+    true
+);
+
+-- Rename: partitioned table becomes the rollback backup, the new
+-- unpartitioned table becomes live. The pre-partition backup from
+-- forward.sql is left alone.
+ALTER TABLE "{{schema}}"."{{table}}" RENAME TO "{{table}}_post_partition_backup";
+ALTER TABLE "{{schema}}"."{{table}}_unpartitioned" RENAME TO "{{table}}";
+
+COMMIT;
+
+-- Rollback complete. Two backups now exist on disk:
+--   {{table}}_pre_partition_backup   (from forward.sql)
+--   {{table}}_post_partition_backup  (from this script)
+-- Keep both until you're certain the rollback is stable. Disk is cheaper
+-- than re-running the migration.

--- a/recipes/scaling/partitioning/hash-on-stream/run.sh
+++ b/recipes/scaling/partitioning/hash-on-stream/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HASH-on-stream partitioning: forward runner
+# =============================================================================
+# This is a sample. Adapt to your environment. Always run during a
+# maintenance window. Always have a backup.
+#
+# Required env vars:
+#   SCHEMA       PG schema name (matches PostgresConfig.schema)
+#   TABLE        events table name (matches PostgresConfig.table)
+# Optional env vars:
+#   PARTITIONS   partition count (default 16, valid range [2, 64])
+#   DATABASE_URL libpq connection URL (preferred)
+#                or PGHOST / PGPORT / PGUSER / PGPASSWORD / PGDATABASE
+#
+# On any psql error the script aborts via ON_ERROR_STOP=1. Inspect the DB
+# state manually and decide whether to roll back (rollback.sql) or fix
+# forward.
+# =============================================================================
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+forward_sql="${script_dir}/forward.sql"
+
+: "${SCHEMA:?SCHEMA env var is required (PG schema name)}"
+: "${TABLE:?TABLE env var is required (events table name)}"
+
+partitions="${PARTITIONS:-16}"
+
+if ! [[ "${partitions}" =~ ^[0-9]+$ ]]; then
+    echo "PARTITIONS must be an integer, got: ${partitions}" >&2
+    exit 1
+fi
+if (( partitions < 2 || partitions > 64 )); then
+    echo "PARTITIONS must be in [2, 64], got: ${partitions}" >&2
+    echo "Outside that range you should reconsider whether HASH partitioning fits your workload." >&2
+    exit 1
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    : "${PGHOST:?DATABASE_URL or PG* env vars are required}"
+    : "${PGUSER:?DATABASE_URL or PG* env vars are required}"
+    : "${PGDATABASE:?DATABASE_URL or PG* env vars are required}"
+fi
+
+if [[ ! -f "${forward_sql}" ]]; then
+    echo "forward.sql not found at: ${forward_sql}" >&2
+    exit 1
+fi
+
+echo "Running HASH-on-stream forward migration:"
+echo "  schema     = ${SCHEMA}"
+echo "  table      = ${TABLE}"
+echo "  partitions = ${partitions}"
+echo
+
+# Substitute placeholders. The default forward.sql uses MODULUS 16; rewrite
+# the literal to the requested PARTITIONS value before piping to psql.
+rendered="$(
+    sed \
+        -e "s|{{schema}}|${SCHEMA}|g" \
+        -e "s|{{table}}|${TABLE}|g" \
+        -e "s|MODULUS 16|MODULUS ${partitions}|g" \
+        "${forward_sql}"
+)"
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+    echo "${rendered}" | psql -v ON_ERROR_STOP=1 "${DATABASE_URL}"
+else
+    echo "${rendered}" | psql -v ON_ERROR_STOP=1
+fi
+
+echo
+echo "Forward migration committed."
+echo "Run Phase 3 verification queries from README.md before declaring success."
+echo "Do not drop ${SCHEMA}.${TABLE}_pre_partition_backup until the partitioned table has run cleanly for at least a week."

--- a/recipes/scaling/partitioning/range-on-created/README.md
+++ b/recipes/scaling/partitioning/range-on-created/README.md
@@ -8,6 +8,23 @@
 > first; it's a series of gates that exist precisely so this page is
 > reached on purpose, not by accident.
 
+> **CONSISTENCY WARNING — read this before you run anything.** `DROP
+> PARTITION` deletes events from the events table. Act's `app.load(stream)`
+> reconstructs state by replaying every event for that stream from
+> version 1 forward. If a partition you drop contains events for a
+> stream that's still alive (no tombstone seeded by `app.close()` or
+> `.autocloses({...})`), the next `load()` of that stream returns
+> **silently wrong state** — the reducer chain runs over an incomplete
+> event history and produces whatever happens to be derivable from the
+> surviving events. There is no error, no warning, no integrity check.
+> The state is just wrong.
+>
+> This recipe is only safe when every stream with events in the dropped
+> partition has *already been retired or snapshotted* before the drop.
+> The [Consistency: retire or snapshot before drop](#consistency-retire-or-snapshot-before-drop)
+> section below is mandatory reading. Skip it and you'll corrupt
+> aggregate state in production.
+
 ## What this recipe does
 
 It rewrites the `events` table as a `PARTITION BY RANGE (created)` table
@@ -222,6 +239,54 @@ you don't need a long-term cold-storage copy, you can skip step 2
 and go straight from `DETACH` to `DROP`. Document that decision —
 the next operator (or auditor) will want to know why step 2 is
 missing.
+
+## Consistency: retire or snapshot before drop
+
+`DROP PARTITION` deletes events. Act doesn't have a way to know events used to exist — it reconstructs aggregate state by replaying every event for a stream from version 1. When that replay starts at version 50 because the lower versions vanished, the state the reducer returns is whatever happens to be derivable from the surviving events. Silently wrong, no error.
+
+The framework gives you exactly two ways to keep state consistent in the presence of partition drops:
+
+1. **Retire the stream before the partition drops.** Run `app.close({ stream })` (or let `.autocloses({...})` retire it on its own cycle) before the events fall into a partition you'll later drop. A closed stream seeds a `__tombstone__` event as the sole surviving event — future `load()` of that stream returns the default state plus the tombstone, which is the correct "this is gone" semantic. The historical events can vanish without breaking anything, because nothing is supposed to load them anymore.
+
+2. **Snapshot the stream before the partition drops.** Run `app.snap(stream)` (or rely on the state's `.snap` predicate to insert one) before the cutoff. A snapshot writes a `__snapshot__` event with the current reduced state baked in; subsequent `load()` calls start from the snapshot and reduce forward, never reaching the dropped events. The snapshot itself lives in a recent partition that won't be dropped.
+
+In practice, this means the partition-drop archival pipeline has a prerequisite check it must run **before** the `DROP`:
+
+```sql
+-- For every stream with events in the partition you're about to drop,
+-- confirm there is either a tombstone or a snapshot at or after the
+-- partition's upper bound. This SELECT returns ZERO rows when the
+-- archive is safe. Any rows mean you'd corrupt those streams.
+SELECT DISTINCT e.stream
+FROM {{schema}}.{{table}} e
+WHERE e.created < '{{cutoff}}'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM {{schema}}.{{table}} guard
+    WHERE guard.stream = e.stream
+      AND guard.created >= '{{cutoff}}'
+      AND guard.name IN ('__tombstone__', '__snapshot__')
+  );
+```
+
+The recipe's `drop-partition.sql` runs this check as its first step. If it returns any rows, the script aborts with a clear message: "These streams have events in the partition you're about to drop and no retire/snapshot marker on or after the cutoff. Retire them via `app.close()` or snapshot them via `app.snap()` first, then re-run."
+
+### The two-tool composition that actually scales
+
+Real systems running range-on-created compose two policies:
+
+- **Per-stream retirement** — `.autocloses({...})` declares the policy by which streams become semantically dead and earn their tombstone. The autoclose cycle runs continuously and retires streams as they go terminal. By the time a partition ages out of the retention window, the streams that ended in that partition are already retired; their tombstones live in the partition for the month they retired.
+- **Table-wide retention floor** — `drop-partition.sql` runs on a cron and drops partitions older than the cutoff. Because retirement happens per-stream over time, by the time a partition is up for drop, every stream with events in it is either retired (tombstone in a future partition, OK to drop) or still alive (snapshot in a future partition, OK to drop).
+
+States that lack a natural terminal event — long-running ledgers, append-only audit trails on entities that never end — need explicit snapshots before drops, scheduled in lock-step with the partition rotation cadence. A cron that runs `app.snap()` on every alive state before each archival run is the typical shape.
+
+States whose streams cross the retention boundary without retirement *or* snapshotting are the failure case. The pre-drop guard catches them; the operator's options are (a) retire them, (b) snapshot them, (c) extend the retention window. There is no fourth option that preserves correctness.
+
+### Why the framework doesn't enforce this automatically
+
+The framework knows about `Store.truncate()` (the close cycle's tool) but doesn't own the partition lifecycle. `DROP PARTITION` is a DDL statement issued by an operator script running outside the framework's process. The framework can't intercept it, can't run the pre-flight check inside it, and can't roll it back if the check fails. The check has to live in the recipe — and the recipe makes it the first SQL statement in `drop-partition.sql` so it can't be skipped accidentally.
+
+If you're tempted to drop the check ("my retention window is 7 years, nothing alive runs that long") — write it down as a comment in your scheduled-job runbook, get a second pair of eyes, and put the guard back. A 7-year-old assumption is exactly the assumption that gets violated by next quarter's product feature.
 
 ## What this recipe is NOT
 

--- a/recipes/scaling/partitioning/range-on-created/README.md
+++ b/recipes/scaling/partitioning/range-on-created/README.md
@@ -1,0 +1,266 @@
+# RANGE partitioning on `created` — retention-window archival
+
+> **Default Act is fine for most apps.** If your events table isn't measured
+> in hundreds of millions of rows, if your retention window is governed by
+> business policy rather than a regulator, or if you haven't already wired
+> `.autocloses({...})` and watched it fail to keep up — this recipe isn't
+> for you. Read [recipes/scaling/partitioning/README.md](../README.md)
+> first; it's a series of gates that exist precisely so this page is
+> reached on purpose, not by accident.
+
+## What this recipe does
+
+It rewrites the `events` table as a `PARTITION BY RANGE (created)` table
+with one child partition per month (or year — your call). Every event
+lands in the partition for the month it was committed. Once a partition
+falls fully behind your retention window, you `DETACH` it, copy the
+detached child to cold storage, and `DROP` it. The DDL is constant-time
+regardless of partition size, so dropping 50 million rows costs the same
+as dropping 50 thousand. A periodic cron — driven by `drop-partition.sql`
+in this folder — turns the events table into a sliding window that never
+grows past the retention boundary.
+
+It also ships:
+
+- `forward.sql` — the one-shot migration from unpartitioned to
+  partitioned, structured in the same Phase 1 (build + copy) / Phase 2
+  (atomic swap) shape as the HASH recipe.
+- `run.sh` — a thin wrapper that substitutes `{{schema}}` / `{{table}}`
+  placeholders and pipes the forward migration to `psql` with
+  `ON_ERROR_STOP=1`. Does **not** wrap `drop-partition.sql` — that's
+  cron-driven, has different failure modes, and shouldn't share a
+  blast radius with the migration.
+- `drop-partition.sql` — the archival half. Detach + (operator-wired)
+  cold-storage dump + drop, scoped to partitions older than a
+  `{{cutoff}}` date.
+
+## When to reach for it
+
+The narrow set of workloads where RANGE-on-`created` earns its keep:
+
+1. **Hard regulatory retention windows.** HIPAA requires six years
+   minimum; FINRA/SEC 17a-4 wants three to seven; GDPR Article 5(1)(e)
+   demands "no longer than necessary." When the regulator hands you a
+   number, the events table doesn't get to grow past it. `Act.close()`
+   per-row delete is too slow on the volumes that drive a regulator's
+   attention in the first place.
+2. **Audit-trail semantics that block `.autocloses({...})`.** An
+   audit log keeps every event up to the retention boundary, then
+   drops everything at once. The whole point is "no tombstones, no
+   per-row decisions, just a clean cutover at the boundary." That's
+   what partition-drop gives you.
+3. **Bulk archival where the disk story matters.** Per-row DELETE
+   leaves dead tuples that VACUUM has to chase; on a hundred-million-row
+   archive run, that's hours of background I/O. `DROP TABLE` on a
+   detached partition returns the disk in seconds.
+
+If you don't fit one of those, the steady-state answer is still
+`.autocloses({...})` — see
+[../../close-the-books/README.md](../../close-the-books/README.md) and
+the framework guide at
+[docs/docs/guides/close-policies.md](../../../../docs/docs/guides/close-policies.md).
+
+## Why `.autocloses({...})` doesn't fit here
+
+`.autocloses({ after: { days: 365 * 6 } })` would, in principle,
+truncate every stream older than six years. In practice three things
+fight you:
+
+- **Per-row work.** The autoclose cycle paginates streams, calls
+  `query_stats`, builds a candidate set, runs `run_close_cycle` per
+  batch. Each truncate is a per-stream `DELETE FROM events WHERE
+  stream = $1`, which on a multi-hundred-million-row table touches
+  index pages for every row it removes. The throughput ceiling is
+  the index update rate, not the row count.
+- **Tombstones stay behind.** `.autocloses({...})` leaves a
+  `__tombstone__` per closed stream so subsequent commits raise
+  `StreamClosedError`. For audit-trail use cases that's a feature.
+  For "the regulator says this data must be physically gone," it's
+  a problem: the tombstone is still a row in `events`, and some
+  regulators read "I kept a marker pointing at what used to be
+  there" as incomplete disposal.
+- **VACUUM tail.** Even after the truncate commits, autovacuum has
+  to reclaim the dead tuples. On a saturated archive run that VACUUM
+  itself becomes the bottleneck.
+
+`DETACH PARTITION` + `DROP TABLE` sidesteps all three. The DDL is
+metadata-only; the dropped partition's disk pages return to the
+filesystem in one extent free, no per-row touch, no VACUUM follow-up,
+no tombstones in the live table. Some regulators explicitly accept
+partition-drop as "physical disposal" — easier to defend in an audit
+than "we ran DELETE and trust VACUUM to finish eventually."
+
+## Trade-offs you sign up for
+
+- **Boundary granularity is your partition size.** Monthly partitions
+  mean you can dispose of data with month resolution; if the regulator
+  says "six years," the cleanest cutover is six years and one month
+  (drop the partition once it's fully behind the window — never drop a
+  partition that still has events inside the retention boundary).
+  Yearly partitions give whole-year accuracy at one-twelfth the
+  partition count. Pick based on how tight the retention boundary is
+  and how often you want to run the dropper.
+- **Cross-stream queries pay MergeAppend.** Every drain, every
+  projection advance, every `app.reset()` opens every partition,
+  sorts each by `id`, and merges. PG ≥ 14 with
+  `enable_partition_pruning = on` (default) handles this competently
+  for prepared statements; the overhead is per-partition planner work,
+  linear in partition count. With a 6-year monthly partition layout
+  you're paying 72-way MergeAppend on every cross-stream read. This is
+  the same trade described in
+  [../README.md](../README.md) — read it once, then accept it as the
+  price of partition-drop archival.
+- **Ongoing partition provisioning.** The migration creates a window
+  of child partitions (the template ships 24 months back + 12 months
+  forward). After that, you need either
+  [`pg_partman`](https://github.com/pgpartman/pg_partman) on a cron
+  or a hand-rolled "create next month's partition" job. If a commit
+  arrives for a month that doesn't have a partition, the insert fails
+  with `no partition of relation "{{table}}" found for row`. Wire
+  monitoring on that error early.
+- **PK becomes composite.** Postgres requires the partition key to
+  appear in every unique constraint, so the events PK becomes
+  `(id, created)` instead of `id`. Mechanically fine — Act only ever
+  reads `id` as a watermark, and the framework's `Store` contract
+  doesn't promise `id` is the sole PK — but any external tooling that
+  joined on `id` alone needs to be reviewed.
+- **Backups and replicas need rechecking.** Partitioned tables affect
+  `pg_basebackup` chunk boundaries, logical replication publication
+  semantics (each child is its own publishable relation), and any
+  point-in-time recovery target you computed against the old shape.
+
+## Workflow
+
+### Phase 0 — pre-flight
+
+The same gates as the HASH recipe apply, plus one:
+
+- **PG ≥ 14.** Partition pruning at execution time and
+  `DETACH PARTITION CONCURRENTLY` both need PG 14+.
+- **Disk headroom for 1.5× the events table.** Phase 1 copies the
+  whole table into a new partitioned shell before the swap. Peak
+  disk during the migration is "old table + new table + indexes" —
+  budget for at least 1.5× the current `pg_total_relation_size`,
+  measured during a representative workload.
+- **A maintenance window long enough for the copy.** Order-of-
+  magnitude: on a commodity NVMe + PG 17 instance the `INSERT INTO ...
+  SELECT FROM` rate is roughly 50–200k rows/sec, dominated by index
+  builds on the new partitions. Measure on a restored backup before
+  picking the window.
+- **No concurrent DDL or long-running transactions.** Phase 2 takes
+  `ACCESS EXCLUSIVE` on the old table briefly; an open transaction
+  holding even an `AccessShareLock` will block it indefinitely.
+- **A backup taken with restore tested.** The atomic swap renames
+  tables; a botched run is recoverable but only from a backup.
+- **A planned partition-provisioning solution.** Decide before the
+  migration whether you're using `pg_partman` or a custom cron job.
+  Don't leave it as a follow-up — the first month after the migration
+  ends is the deadline.
+
+### Phase 1 — migrate
+
+`forward.sql` handles the migration. Drive it via `run.sh`:
+
+```sh
+SCHEMA=public TABLE=events ./run.sh
+```
+
+Phase 1 of the script builds the new partitioned table
+(`{{table}}_new`), creates 36 child partitions (24 back + 12 forward
+— adjust the boundaries to your retention shape), creates the
+indexes on the parent, and copies the events table contents with a
+single bulk `INSERT INTO ... SELECT FROM`.
+
+Phase 2 takes `ACCESS EXCLUSIVE` on the source table, replays any
+late rows committed during Phase 1, advances `events_id_seq` past
+the watermark, and renames the tables in one transaction. The
+`streams` table is untouched (partitioning is on `events` only).
+
+### Phase 2 — recurring archival
+
+Once partitioning is live, set up a cron job — daily is the usual
+cadence — that runs `drop-partition.sql` with a cutoff based on the
+retention boundary:
+
+```sh
+# Daily at 03:00, drop partitions whose upper bound is older than 6 years.
+0 3 * * * SCHEMA=public TABLE=events CUTOFF=$(date -d "6 years ago" +%Y-%m-01) psql ...
+```
+
+The script is destructive — see the archival pattern below before
+wiring it.
+
+## The archival pattern
+
+`drop-partition.sql` documents the safe sequence; the operator wires
+the cold-storage step. The pattern is three phases, in order, per
+partition:
+
+1. **`ALTER TABLE ... DETACH PARTITION`** — removes the child from
+   the partitioned table. The partition is still a regular table on
+   disk; it just doesn't participate in queries against the parent
+   anymore. Read access still works directly against the detached
+   table name.
+2. **Cold-storage dump.** `pg_dump` the detached child to S3 / GCS /
+   tape / whatever your retention policy actually requires. The
+   recipe leaves this as a commented-out hook because the destination
+   is operator-specific. Verify the dump completed and the bytes
+   landed in cold storage **before** moving to step 3 — once you've
+   dropped the partition there's no second chance.
+3. **`DROP TABLE`** — the detached partition is now a regular table;
+   dropping it frees the disk extents in one DDL operation.
+
+The three-step shape exists because each step has a different
+failure mode. `DETACH` is reversible (`ATTACH PARTITION` back, if
+the child is still on disk and untouched). The dump is retryable —
+re-run it if it failed, the partition is detached but intact. The
+drop is irreversible — once the table is gone, the only path back
+is the cold-storage copy you took in step 2.
+
+If your regulator accepts partition-drop as physical disposal and
+you don't need a long-term cold-storage copy, you can skip step 2
+and go straight from `DETACH` to `DROP`. Document that decision —
+the next operator (or auditor) will want to know why step 2 is
+missing.
+
+## What this recipe is NOT
+
+- **Not a backup strategy.** Backups need point-in-time recovery,
+  cross-region replication, restore-tested cadences. Partition-drop
+  archival is one-way: once the partition is gone, the data is gone
+  from the live database. Pair it with a real backup pipeline.
+- **Not real-time replication.** If a downstream system needs the
+  archived events queryable, archive them somewhere queryable
+  (Parquet on S3, Snowflake, BigQuery) before the drop. The
+  `recipes/scaling/archival/README.md` recipe covers the
+  "keep-it-queryable" path; this one is for the "regulatory
+  disposal" path.
+- **Not for streams that should stay queryable from the app.** Once
+  the partition is dropped, `app.load(stream)` for a stream whose
+  events lived only in that partition will return an empty array.
+  The framework has no way to know the events used to exist.
+  Streams that should stay queryable belong outside the retention
+  window or in the always-current partition.
+- **Not a substitute for `.autocloses({...})`.** Inside the
+  retention window, `.autocloses({...})` is still the right tool
+  for keeping individual stream sizes bounded. Range-on-created
+  governs the table-wide retention floor; autocloses governs the
+  per-stream rotation. They compose — close streams as they go
+  terminal, drop whole partitions when they age out.
+
+## Pointers
+
+- Decision tree that landed you here:
+  [../README.md](../README.md)
+- Default close-the-books path:
+  [../../close-the-books/README.md](../../close-the-books/README.md)
+- Cold-storage archival (keep-it-queryable):
+  [../../archival/README.md](../../archival/README.md)
+- Framework guide for `.autocloses({...})`:
+  [../../../../docs/docs/guides/close-policies.md](../../../../docs/docs/guides/close-policies.md)
+- Production checklist (where partition planning fits in the
+  larger operational picture):
+  [../../../../docs/docs/guides/production-checklist.md](../../../../docs/docs/guides/production-checklist.md)
+- `act-pg` benchmark history (so you know what "fast" looks like
+  on the unpartitioned baseline before you decide it's not enough):
+  [../../../../libs/act-pg/PERFORMANCE.md](../../../../libs/act-pg/PERFORMANCE.md)

--- a/recipes/scaling/partitioning/range-on-created/drop-partition.sql
+++ b/recipes/scaling/partitioning/range-on-created/drop-partition.sql
@@ -8,6 +8,18 @@
 -- There is no per-row recovery — the only path back is your real
 -- database backup, which is a long restore.
 --
+-- CONSISTENCY WARNING: `DROP PARTITION` deletes events. Act
+-- reconstructs aggregate state via `app.load(stream)` by replaying
+-- every event for the stream from version 1 forward. If you drop
+-- a partition containing events for a stream that's still alive
+-- (no tombstone or snapshot at or after the cutoff), the next
+-- `load()` returns silently wrong state. The first SQL block in
+-- this script is the pre-flight check that catches this case;
+-- if it raises, abort the run and retire / snapshot the named
+-- streams via `app.close()` or `app.snap()` first. Do not skip
+-- the check. See README.md → "Consistency: retire or snapshot
+-- before drop" for the full explanation.
+--
 -- Before wiring this into cron:
 --
 --   1. Verify the cold-storage dump step. The pg_dump call below
@@ -46,6 +58,55 @@
 \set ON_ERROR_STOP on
 
 BEGIN;
+
+-- =============================================================
+-- Step 0 — consistency guard (DO NOT REMOVE).
+-- =============================================================
+--
+-- For every stream that has events older than the cutoff, this
+-- check confirms there is ALSO a tombstone or snapshot marker
+-- on or after the cutoff. Streams that pass are either retired
+-- (tombstone) or snapshotted forward (their `load()` won't reach
+-- the dropped events). Streams that fail are the ones whose
+-- aggregate state would be silently corrupted by the drop.
+--
+-- The expected output of this query is ZERO rows. Any rows mean
+-- you must retire those streams via app.close() or snapshot them
+-- via app.snap() BEFORE re-running this script. The transaction
+-- is rolled back if the check fails — no partition is touched.
+DO $$
+DECLARE
+    unsafe_count int;
+BEGIN
+    SELECT count(DISTINCT e.stream)
+    INTO unsafe_count
+    FROM {{schema}}.{{table}} e
+    WHERE e.created < :'cutoff'::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM {{schema}}.{{table}} guard
+        WHERE guard.stream = e.stream
+          AND guard.created >= :'cutoff'::date
+          AND guard.name IN ('__tombstone__', '__snapshot__')
+      );
+
+    IF unsafe_count > 0 THEN
+        RAISE EXCEPTION
+            'partition-drop aborted: % stream(s) have events before % '
+            'with no tombstone or snapshot at or after that date. '
+            'Dropping now would silently corrupt aggregate state on '
+            'next load(). Run app.close() or app.snap() on those '
+            'streams first, then re-run this script.',
+            unsafe_count,
+            :'cutoff';
+    END IF;
+
+    RAISE NOTICE
+        'Consistency check passed: every stream with events before % '
+        'has a tombstone or snapshot marker on or after that date.',
+        :'cutoff';
+END
+$$;
 
 -- Build the list of partitions whose declared upper bound is
 -- already <= the cutoff. pg_inherits + relpartbound is the

--- a/recipes/scaling/partitioning/range-on-created/drop-partition.sql
+++ b/recipes/scaling/partitioning/range-on-created/drop-partition.sql
@@ -1,0 +1,196 @@
+-- =============================================================
+-- RANGE-on-created partitioning — partition-drop archival
+-- =============================================================
+--
+-- WARNING: this script is destructive. Running it without prior
+-- cold-storage archival (step 2 of the three-phase pattern in
+-- README.md) means the events in dropped partitions are GONE.
+-- There is no per-row recovery — the only path back is your real
+-- database backup, which is a long restore.
+--
+-- Before wiring this into cron:
+--
+--   1. Verify the cold-storage dump step. The pg_dump call below
+--      is commented out — operator wires their own destination
+--      (S3, GCS, tape, whatever the retention policy says).
+--   2. Run it once manually with a known-safe cutoff and inspect
+--      the output. The script logs every partition it would
+--      detach before it touches anything.
+--   3. Confirm the regulator accepts partition-drop as physical
+--      disposal in your jurisdiction. Some don't.
+--
+-- Placeholders this script expects:
+--
+--   {{schema}}   — schema name, e.g. "public"
+--   {{table}}    — events table name, e.g. "events"
+--   {{cutoff}}   — date in 'YYYY-MM-DD' form. Partitions whose
+--                  upper bound is <= this date are eligible for
+--                  drop. Computed by the caller, NOT this script,
+--                  so the retention policy lives next to the cron.
+--
+-- Example cutoff calc (six-year retention, drop partitions fully
+-- behind that boundary):
+--
+--   CUTOFF=$(date -u -d "6 years ago" +%Y-%m-01)
+--
+-- Run shape:
+--
+--   psql --set ON_ERROR_STOP=1 \
+--        --set schema=public \
+--        --set table=events \
+--        --set cutoff="$CUTOFF" \
+--        -f drop-partition.sql
+--
+-- =============================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Build the list of partitions whose declared upper bound is
+-- already <= the cutoff. pg_inherits + relpartbound is the
+-- supported way to enumerate range partitions and their bounds
+-- on PG 14+.
+CREATE TEMP TABLE _drop_candidates AS
+SELECT
+    inhrelid::regclass         AS partition_oid,
+    inhrelid                   AS partition_relid,
+    pg_get_expr(c.relpartbound, c.oid) AS bound_expr,
+    -- Range partitions store bounds as a parseable expression.
+    -- Extract the upper bound by regex; for ranges shaped
+    -- FOR VALUES FROM ('YYYY-MM-01') TO ('YYYY-MM-01') the
+    -- captured group is the "TO" boundary.
+    (regexp_match(
+        pg_get_expr(c.relpartbound, c.oid),
+        E'TO \\\(''([0-9]{4}-[0-9]{2}-[0-9]{2})''\\\)'
+    ))[1]::date AS upper_bound
+FROM pg_inherits i
+JOIN pg_class c ON c.oid = i.inhrelid
+WHERE i.inhparent = '{{schema}}.{{table}}'::regclass;
+
+-- Diagnostic: show the operator what's about to be touched.
+-- This is the safety check — if the count is wrong or the
+-- cutoff is wrong, ABORT now before the DETACH runs.
+SELECT
+    partition_oid::text AS partition,
+    bound_expr,
+    upper_bound,
+    upper_bound <= :'cutoff'::date AS will_drop
+FROM _drop_candidates
+ORDER BY upper_bound;
+
+-- Detach every partition that's fully behind the cutoff. DETACH
+-- is metadata-only; the data still lives on disk in the
+-- detached child table. CONCURRENTLY avoids blocking writers
+-- to the parent table, at the cost of a short transaction
+-- split. Use plain DETACH if your maintenance window allows it.
+DO $$
+DECLARE
+    p_oid regclass;
+BEGIN
+    FOR p_oid IN
+        SELECT partition_oid FROM _drop_candidates
+        WHERE upper_bound <= :'cutoff'::date
+        ORDER BY upper_bound
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE {{schema}}.{{table}} '
+            'DETACH PARTITION %s;',
+            p_oid
+        );
+        RAISE NOTICE 'Detached %', p_oid;
+    END LOOP;
+END
+$$;
+
+COMMIT;
+
+
+-- -------------------------------------------------------------
+-- Cold-storage hook — OPERATOR WIRES THIS.
+-- -------------------------------------------------------------
+--
+-- After DETACH, each former partition is a regular table whose
+-- name follows the {{table}}_pYYYY_MM pattern. The cold-storage
+-- copy must complete (and be verified) BEFORE the DROP TABLE
+-- step below.
+--
+-- The recipe leaves this commented out because the destination
+-- is operator-specific. A typical shape uses pg_dump from a
+-- shell wrapper (NOT inside this SQL file — pg_dump is a
+-- client-side tool):
+--
+--   for p in $(psql -At -c "SELECT relname FROM pg_class
+--                          WHERE relname LIKE '{{table}}_p%'
+--                            AND NOT EXISTS (
+--                              SELECT 1 FROM pg_inherits
+--                              WHERE inhrelid = pg_class.oid
+--                            )"); do
+--     pg_dump \
+--       --schema={{schema}} \
+--       --table={{schema}}.$p \
+--       --format=custom \
+--       --file=/tmp/$p.dump
+--     aws s3 cp /tmp/$p.dump s3://events-archive/{{table}}/$p.dump
+--   done
+--
+-- Verify the upload (checksum, bytes-on-destination) before
+-- running the DROP step. Once dropped there is no second chance.
+-- =============================================================
+
+
+-- -------------------------------------------------------------
+-- Drop step — only run AFTER cold-storage archival is verified.
+-- Split into its own transaction so an operator can pause
+-- between detach + archive and the irreversible drop.
+-- -------------------------------------------------------------
+
+BEGIN;
+
+DO $$
+DECLARE
+    rel record;
+BEGIN
+    -- Detached partitions are ordinary tables whose names still
+    -- match the partition naming convention. Identify them by
+    -- absence from pg_inherits (i.e. they no longer belong to
+    -- the parent).
+    FOR rel IN
+        SELECT n.nspname, c.relname
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = '{{schema}}'
+          AND c.relname LIKE '{{table}}_p%'
+          AND c.relkind = 'r'
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_inherits
+              WHERE inhrelid = c.oid
+          )
+    LOOP
+        EXECUTE format(
+            'DROP TABLE %I.%I;',
+            rel.nspname, rel.relname
+        );
+        RAISE NOTICE 'Dropped %.%', rel.nspname, rel.relname;
+    END LOOP;
+END
+$$;
+
+COMMIT;
+
+-- =============================================================
+-- After successful run:
+--
+--   - The events table no longer contains any rows from dropped
+--     partitions.
+--   - Disk space returns to the filesystem in one extent free.
+--   - No VACUUM follow-up is needed; nothing was DELETEd.
+--   - The cold-storage copy in S3 / GCS / tape is your only
+--     remaining trace of the dropped data.
+--
+-- If something went wrong mid-run, see the recovery section in
+-- README.md. The short version: detached-but-not-dropped
+-- partitions are still on disk and can be re-attached with
+-- ALTER TABLE ... ATTACH PARTITION as long as no concurrent
+-- commit landed a duplicate id in the now-empty range.
+-- =============================================================

--- a/recipes/scaling/partitioning/range-on-created/forward.sql
+++ b/recipes/scaling/partitioning/range-on-created/forward.sql
@@ -1,0 +1,239 @@
+-- =============================================================
+-- RANGE-on-created partitioning — forward migration
+-- =============================================================
+--
+-- Placeholders this script expects (substitute via run.sh or
+-- envsubst before piping to psql):
+--
+--   {{schema}}   — schema name, e.g. "public"
+--   {{table}}    — events table name, e.g. "events"
+--
+-- Partition boundaries shipped here cover 24 months back from the
+-- migration date + 12 months forward. Adjust the GENERATE_SERIES
+-- range in Phase 1 to match your retention shape:
+--
+--   - Yearly partitions: switch to date_trunc('year', …) and a
+--     coarser GENERATE_SERIES (interval '1 year').
+--   - Tighter back-window: shorten the back range — but never go
+--     past the regulatory retention floor, or the first dropper
+--     run after the migration will refuse to drop anything.
+--   - Longer forward-window: extend the forward range if you
+--     don't want to wire pg_partman or a cron until after the
+--     migration settles.
+--
+-- After the migration, you MUST have ongoing partition
+-- provisioning in place. The forward window expires; commits
+-- arriving for a month with no partition fail with
+-- `no partition of relation "{{table}}" found for row`. Wire
+-- pg_partman or a "create next month" job before the forward
+-- window's tail.
+--
+-- States this script depends on / produces:
+--
+--   Pre-state:
+--     - {{schema}}.{{table}}      — unpartitioned events table
+--     - {{schema}}.{{table}}_streams — streams table (untouched)
+--     - events_id_seq (or {{schema}}.{{table}}_id_seq) owned by
+--       the events table
+--
+--   Post-state:
+--     - {{schema}}.{{table}}      — partitioned by RANGE (created),
+--       PK is (id, created), child partitions cover the configured
+--       window
+--     - {{schema}}.{{table}}_pre_partition — backup of the original
+--       (unpartitioned) table; keep until the partitioned table is
+--       verified, then DROP TABLE … to reclaim disk
+--
+-- Estimated cost on commodity NVMe + PG 17:
+--
+--   - INSERT copy rate: ~50–200k rows/sec, dominated by index
+--     builds on the new partitions. A 100M-row table takes
+--     ~10–30 minutes for the copy alone. Measure on a restored
+--     backup before picking the window.
+--   - Peak disk: ~1.5–2.0× the current pg_total_relation_size of
+--     {{table}} (old table + new partitioned table + indexes
+--     coexist during Phase 1).
+--   - Phase 2 ACCESS EXCLUSIVE window: seconds to low minutes,
+--     determined by the late-rows replay. Stop user-facing writes
+--     before Phase 2 if you want a tighter bound.
+--
+-- This migration is NOT online. Schedule a maintenance window.
+-- =============================================================
+
+
+-- -------------------------------------------------------------
+-- Phase 1: build the new partitioned table + child partitions,
+-- copy events.
+-- -------------------------------------------------------------
+
+BEGIN;
+
+-- New partitioned shell. PK MUST include the partition key, hence
+-- (id, created). Column shape matches the live schema in
+-- libs/act-pg/src/postgres-store.ts.
+CREATE TABLE {{schema}}.{{table}}_new (
+    id      serial      NOT NULL,
+    name    varchar(100) COLLATE pg_catalog."default" NOT NULL,
+    data    jsonb,
+    stream  varchar(100) COLLATE pg_catalog."default" NOT NULL,
+    version int         NOT NULL,
+    created timestamptz NOT NULL DEFAULT now(),
+    meta    jsonb,
+    pii     jsonb,
+    PRIMARY KEY (id, created)
+) PARTITION BY RANGE (created);
+
+-- Reuse the existing id sequence so global monotonicity holds
+-- across the migration. The serial column on the new table
+-- created its own sequence; drop it and point at the live one.
+ALTER TABLE {{schema}}.{{table}}_new
+    ALTER COLUMN id DROP DEFAULT;
+DROP SEQUENCE IF EXISTS {{schema}}.{{table}}_new_id_seq;
+ALTER TABLE {{schema}}.{{table}}_new
+    ALTER COLUMN id
+    SET DEFAULT nextval(pg_get_serial_sequence(
+        '{{schema}}.{{table}}', 'id'));
+
+-- Indexes on the parent — Postgres propagates them to every
+-- child partition automatically.
+CREATE UNIQUE INDEX {{table}}_new_stream_ix
+    ON {{schema}}.{{table}}_new
+    (stream COLLATE pg_catalog."default", version);
+CREATE INDEX {{table}}_new_name_ix
+    ON {{schema}}.{{table}}_new
+    (name COLLATE pg_catalog."default");
+CREATE INDEX {{table}}_new_created_id_ix
+    ON {{schema}}.{{table}}_new
+    (created, id);
+CREATE INDEX {{table}}_new_correlation_ix
+    ON {{schema}}.{{table}}_new
+    ((meta ->> 'correlation') COLLATE pg_catalog."default");
+
+-- Child partitions: 24 months back + 12 months forward. Adjust
+-- the start/end of GENERATE_SERIES to match your retention shape.
+-- The DO block generates one CREATE TABLE per month.
+DO $$
+DECLARE
+    bucket_start date;
+    bucket_end   date;
+    part_name    text;
+    months_back  int := 24;
+    months_fwd   int := 12;
+BEGIN
+    FOR bucket_start IN
+        SELECT generate_series(
+            date_trunc('month', now()) - make_interval(months => months_back),
+            date_trunc('month', now()) + make_interval(months => months_fwd),
+            interval '1 month'
+        )::date
+    LOOP
+        bucket_end := (bucket_start + interval '1 month')::date;
+        part_name  := format('{{table}}_p%s',
+                             to_char(bucket_start, 'YYYY_MM'));
+
+        EXECUTE format(
+            'CREATE TABLE {{schema}}.%I '
+            'PARTITION OF {{schema}}.{{table}}_new '
+            'FOR VALUES FROM (%L) TO (%L);',
+            part_name, bucket_start, bucket_end
+        );
+    END LOOP;
+END
+$$;
+
+-- Bulk copy. Single statement so the planner picks the best plan;
+-- pg_repack or COPY pipeline would be faster on very large tables
+-- but loses the convenience of a transactional checkpoint.
+INSERT INTO {{schema}}.{{table}}_new
+    (id, name, data, stream, version, created, meta, pii)
+SELECT
+    id, name, data, stream, version, created, meta, pii
+FROM {{schema}}.{{table}};
+
+COMMIT;
+
+
+-- -------------------------------------------------------------
+-- Phase 2: atomic swap. Locks the source table briefly, replays
+-- any rows that landed during Phase 1, advances the sequence,
+-- renames the tables.
+-- -------------------------------------------------------------
+
+BEGIN;
+
+-- Block writes on the source table for the duration of the swap.
+-- This is the maintenance-window-cost line item. If a long
+-- transaction is open against {{schema}}.{{table}} the LOCK
+-- waits forever — abort and investigate before retrying.
+LOCK TABLE {{schema}}.{{table}} IN ACCESS EXCLUSIVE MODE;
+
+-- Catch up any rows committed to the source table after Phase 1's
+-- bulk INSERT. With writes blocked there can't be new rows during
+-- this statement; the watermark is whatever made it through
+-- before the LOCK.
+INSERT INTO {{schema}}.{{table}}_new
+    (id, name, data, stream, version, created, meta, pii)
+SELECT
+    s.id, s.name, s.data, s.stream, s.version, s.created, s.meta, s.pii
+FROM {{schema}}.{{table}} s
+LEFT JOIN {{schema}}.{{table}}_new n ON n.id = s.id
+WHERE n.id IS NULL;
+
+-- Advance the shared sequence past the highest copied id so the
+-- next commit picks up where the unpartitioned table left off.
+SELECT setval(
+    pg_get_serial_sequence('{{schema}}.{{table}}', 'id'),
+    (SELECT COALESCE(MAX(id), 1) FROM {{schema}}.{{table}}_new)
+);
+
+-- Atomic rename. The old table becomes the named backup; the new
+-- partitioned table takes the production name.
+ALTER TABLE {{schema}}.{{table}}
+    RENAME TO {{table}}_pre_partition;
+ALTER TABLE {{schema}}.{{table}}_new
+    RENAME TO {{table}};
+
+-- Indexes on the new table were created with `_new` in their
+-- names; rename them to match the production naming convention.
+ALTER INDEX {{schema}}.{{table}}_new_stream_ix
+    RENAME TO {{table}}_stream_ix;
+ALTER INDEX {{schema}}.{{table}}_new_name_ix
+    RENAME TO {{table}}_name_ix;
+ALTER INDEX {{schema}}.{{table}}_new_created_id_ix
+    RENAME TO {{table}}_created_id_ix;
+ALTER INDEX {{schema}}.{{table}}_new_correlation_ix
+    RENAME TO {{table}}_correlation_ix;
+
+COMMIT;
+
+
+-- -------------------------------------------------------------
+-- Post-migration verification (run interactively, not as part of
+-- the migration transaction):
+-- -------------------------------------------------------------
+--
+--   -- Row count parity:
+--   SELECT
+--     (SELECT count(*) FROM {{schema}}.{{table}}_pre_partition) AS pre,
+--     (SELECT count(*) FROM {{schema}}.{{table}}) AS post;
+--
+--   -- Partition layout:
+--   SELECT inhrelid::regclass AS partition,
+--          pg_get_expr(relpartbound, inhrelid) AS bounds
+--   FROM pg_inherits
+--   JOIN pg_class ON pg_class.oid = inhrelid
+--   WHERE inhparent = '{{schema}}.{{table}}'::regclass
+--   ORDER BY partition::text;
+--
+--   -- Sequence advanced past the watermark:
+--   SELECT last_value
+--   FROM {{schema}}.{{table}}_id_seq;
+--
+-- Once verified and after a representative workload has run
+-- against the partitioned table, reclaim the backup:
+--
+--   DROP TABLE {{schema}}.{{table}}_pre_partition;
+--
+-- Don't drop the backup before verification — once it's gone, the
+-- only path back is your real backup, which is a longer recovery.
+-- =============================================================

--- a/recipes/scaling/partitioning/range-on-created/run.sh
+++ b/recipes/scaling/partitioning/range-on-created/run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# =============================================================
+# RANGE-on-created partitioning — forward migration runner
+# =============================================================
+#
+# This wrapper substitutes {{schema}} / {{table}} placeholders in
+# forward.sql and pipes the result to psql with ON_ERROR_STOP=1.
+# It does NOT wrap drop-partition.sql — that script runs on a
+# different cadence (cron-driven, daily/weekly), has a different
+# blast radius (irreversible data loss), and should never share
+# an invocation surface with the migration. Wire drop-partition
+# into cron separately and gate it on its own confirmation step.
+#
+# Usage:
+#
+#   SCHEMA=public TABLE=events ./run.sh
+#
+# Required environment:
+#
+#   SCHEMA       — schema name (no quoting; passed to sed)
+#   TABLE        — events table name
+#
+# Database connection — either:
+#
+#   DATABASE_URL — postgres://user:pass@host:port/db
+#
+# Or the standard PG* envs (PGHOST, PGPORT, PGUSER, PGPASSWORD,
+# PGDATABASE) that psql reads natively.
+#
+# Pre-flight expectations (the script does NOT verify these for
+# you; they're operator responsibility):
+#
+#   - You're in a planned maintenance window.
+#   - A verified backup exists and the restore path is tested.
+#   - No long-running transactions are open against the events
+#     table. Phase 2 takes ACCESS EXCLUSIVE; an existing lock
+#     waits forever.
+#   - Disk headroom is ~1.5–2× the current events-table size.
+#   - Partition provisioning (pg_partman or custom cron) is
+#     planned for after the migration. The forward.sql ships
+#     12 months of forward partitions; that's the deadline.
+#
+# Failure mode:
+#
+#   psql is invoked with --single-transaction so any error
+#   inside forward.sql rolls back to the pre-migration state.
+#   You can safely re-run after fixing whatever broke.
+# =============================================================
+
+set -euo pipefail
+
+# Fail fast on missing required env.
+: "${SCHEMA:?SCHEMA env var is required (e.g. SCHEMA=public)}"
+: "${TABLE:?TABLE env var is required (e.g. TABLE=events)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORWARD_SQL="${SCRIPT_DIR}/forward.sql"
+
+if [[ ! -f "${FORWARD_SQL}" ]]; then
+    echo "ERROR: ${FORWARD_SQL} not found" >&2
+    exit 1
+fi
+
+# Build the psql connection args. Prefer DATABASE_URL if present;
+# otherwise let psql pick up PG* envs from the environment.
+PSQL_ARGS=(
+    --set ON_ERROR_STOP=1
+    --single-transaction
+    --no-psqlrc
+    --quiet
+)
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+    PSQL_ARGS+=(--dbname "${DATABASE_URL}")
+fi
+
+echo "==> Running forward partition migration"
+echo "    schema = ${SCHEMA}"
+echo "    table  = ${TABLE}"
+echo "    script = ${FORWARD_SQL}"
+echo
+
+# Substitute placeholders and pipe. We use sed here (not psql
+# variables) because the placeholders appear in identifiers
+# (table names, index names) where :'var' interpolation would
+# inject quoting that breaks the DDL.
+if sed \
+        -e "s/{{schema}}/${SCHEMA}/g" \
+        -e "s/{{table}}/${TABLE}/g" \
+        "${FORWARD_SQL}" \
+   | psql "${PSQL_ARGS[@]}"; then
+    echo
+    echo "==> Migration complete."
+    echo
+    echo "Next steps:"
+    echo "  1. Verify row-count parity between"
+    echo "     ${SCHEMA}.${TABLE}_pre_partition and ${SCHEMA}.${TABLE}."
+    echo "  2. Inspect partition layout (see forward.sql for the query)."
+    echo "  3. Run a representative workload against the partitioned"
+    echo "     table before dropping ${SCHEMA}.${TABLE}_pre_partition."
+    echo "  4. Wire pg_partman or a custom cron to provision new"
+    echo "     monthly partitions before the forward window expires."
+    echo "  5. Wire drop-partition.sql into cron with a cutoff date"
+    echo "     computed from your retention policy. Verify the cold-"
+    echo "     storage hook before its first scheduled run."
+else
+    echo
+    echo "==> Migration FAILED. Transaction rolled back; database is" >&2
+    echo "    in its pre-migration state. Investigate the psql error" >&2
+    echo "    above before retrying." >&2
+    exit 1
+fi

--- a/recipes/scaling/partitioning/range-on-id/README.md
+++ b/recipes/scaling/partitioning/range-on-id/README.md
@@ -1,0 +1,124 @@
+# RANGE partitioning on `id` — for single-aggregate giants
+
+This recipe is **notes-only**. No SQL file ships alongside it, no migration runner, no `--confirm` script. The strategy is documented; the schema is yours to design.
+
+If that feels like a cop-out, read the last section first. The short version: the boundaries that make this strategy work are operator-specific in a way the others aren't, and a templated migration would lie about its own applicability.
+
+Default Act is fine for the overwhelming majority of apps. This recipe exists for one specific shape of pain.
+
+## What this recipe addresses
+
+This is the answer to case #2 from [the gating page](../README.md):
+
+> **Single-aggregate giants.** One stream with millions of events on a single aggregate — a multi-year IoT device telemetry trail, a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might.
+
+Concrete shapes that fit:
+
+- A telemetry stream for a single industrial sensor that emits an event every few seconds for a decade. By year five you're at a hundred million events in one stream.
+- A regulated entity's master ledger that books transactions across the lifetime of the business. The stream is the entity; closing it means closing the entity.
+- A workflow audit trail for a single long-running process — a clinical trial, a multi-year procurement contract, a credit facility — where the workflow is one durable thing and the audit is its history.
+
+Notice what these have in common. The stream cardinality is **small** (often one). The per-stream event count is **enormous**. And closing the stream is not on the table: the business still treats the aggregate as alive.
+
+## Why HASH partitioning doesn't help
+
+The instinct is to reach for [HASH on `stream`](../hash-on-stream/README.md) because it's the workhorse. For the single-aggregate-giant case, it does nothing useful.
+
+HASH on `stream` partitions events by `hashtext(stream) mod N`. Every event for a given stream lands in the same partition, every time. That property is what makes HASH good for the regulated-audit case — `claim()` and `commit()` on a single stream prune to one partition cleanly, and operators with thousands of streams see the events distributed across N partitions evenly.
+
+The giant stream is the pathological input to that scheme. It hashes to **one** partition. That partition holds every event for the giant. The other N-1 partitions sit nearly empty, holding the residue of whatever other streams the system has. You paid the full partitioning operational tax — composite PK, MergeAppend on cross-stream reads, planner overhead — and got a single 100M-row partition for your trouble. Same problem, more moving parts.
+
+HASH partitions by stream identity. To help a single-stream giant you need to partition by something **inside** that stream.
+
+## Why RANGE on `id` works
+
+The events `id` is a global monotonic sequence. For one append-heavy stream, ids arrive in roughly time order — id 1M happens earlier than id 50M happens earlier than id 200M. So a range on `id` is implicitly a range on time, even though the partition key is the integer sequence.
+
+Splitting the giant stream's events across id-ranged partitions gives you three properties HASH can't:
+
+1. **A small hot partition.** The newest partition holds only the most recent slice of ids. For an append-heavy workload, that's the only partition that takes writes. Its index height stays low, its working set fits in `shared_buffers`, and per-event commit latency stays close to what it was on day one.
+2. **Cold partitions that can move.** Older partitions are read-mostly or read-never. You can `ALTER TABLE ... SET TABLESPACE` them onto cheaper storage (slow disk, network volume, archival tier) without affecting the hot path.
+3. **Single-partition pruning on recent reads.** A `load()` that wants "the latest version of this stream" reads the tail. The planner prunes to the newest partition. A targeted `query` with `after: someId` prunes to whatever partition `someId` lives in. The ratio of pruned-to-MergeAppend reads on this workload is unusually favorable because the workload is unusually skewed.
+
+You're still paying MergeAppend for any cross-stream read in `id` order. That cost is real. On the single-aggregate-giant shape it's tolerable because cross-stream reads are rare — the system has one stream that matters and a handful of bookkeeping streams that don't.
+
+## The trade-off — partition maintenance
+
+HASH is set-and-forget. You pick N, run the migration, and never think about partitions again.
+
+RANGE on `id` is **not** set-and-forget. The id sequence keeps growing. Every partition you create has an upper bound, and once the sequence reaches that bound, the next insert needs a new partition that doesn't exist yet. If it isn't provisioned, the insert fails.
+
+You have three honest options:
+
+- **`pg_partman`.** Postgres extension that owns partition lifecycle — premake N partitions ahead of the sequence, drop expired partitions on a schedule. It speaks RANGE-on-integer natively. This is what you almost always want.
+- **A cron job.** A nightly script that checks the current `events_id_seq` value and creates the next partition when the sequence is within X% of the top of the current partition. Operationally simpler than `pg_partman`, less robust under bursty ingest.
+- **Manual provisioning during a maintenance window.** Defensible if your event rate is predictable enough that you'll provision a year's worth of partitions in one go. Don't choose this without a calendar reminder.
+
+If none of those options feels acceptable, partitioning is probably not the answer for you. Go back to [the gating page](../README.md) and re-read the "when not to partition" section.
+
+## Sketch of the strategy
+
+What follows is a design pattern, not a migration script. The numbers are placeholders.
+
+**Decide a boundary size.** A typical choice is 10M ids per partition, but it depends entirely on your ingest rate and how long you want each partition to stay hot. If the giant stream emits an event per second, 10M ids is about four months of data. If it emits a hundred per second, 10M ids is about a day, and you'll want a much larger boundary or a faster provisioning cadence.
+
+A good rule of thumb: size the partition so the hot partition's working set (events + indexes) comfortably fits in `shared_buffers` for the duration it's the hot one. If `shared_buffers` is 8 GB and your events average 200 bytes on disk including indexes, that's about 40M rows of headroom. Pick a boundary smaller than that and you'll never see the hot path leave memory.
+
+**At migration time:**
+
+```sql
+CREATE TABLE {{schema}}.{{table}}_new (
+  id          serial NOT NULL,
+  name        varchar(100) NOT NULL,
+  data        jsonb,
+  stream      varchar(100) NOT NULL,
+  version     int NOT NULL,
+  created     timestamptz NOT NULL DEFAULT now(),
+  meta        jsonb,
+  pii         jsonb,
+  PRIMARY KEY (id)
+) PARTITION BY RANGE (id);
+```
+
+Note the PK stays `(id)` — RANGE on `id` is the only strategy where the partition key is the existing primary key, so no composite PK is forced on you. External tooling that joins on `events.id` keeps working as-is.
+
+Then create child partitions for the existing id ranges (`FROM (0) TO (10000000)`, `FROM (10000000) TO (20000000)`, ...) up through the current top of the sequence, plus one or two empty future partitions, then copy data, swap names, and recreate indexes per-partition. The full schema (columns, the `(stream, version)` unique constraint, the `(created, id)` index, the `(name)` index, the correlation index) needs to be reapplied on the partitioned table.
+
+**Going forward:** `pg_partman` (or a cron) provisions the next partition before the sequence reaches the top of the current one. You don't need a runtime hook in your app; this is a database-level concern.
+
+## Operational concerns
+
+**Cold-storage migration.** Older partitions can move to cheaper storage with `ALTER TABLE {{schema}}.{{table}}_p_000000000 SET TABLESPACE cold_tier`. Reads still work, they're just slower. For the giant-stream case, "slower reads on history nobody asks for" is exactly the trade you want.
+
+**Projection rebuild.** `app.reset(targets)` still works post-migration. It walks every partition in id order via MergeAppend, the same way an unpartitioned table would walk in id order. If the projection reads only the giant stream, the planner prunes the unrelated partitions (there aren't any — RANGE on `id` doesn't distinguish by stream). If the projection has a watermark, you can prune cold partitions out of the rebuild manually by capping the `id >= start_id` clause, which is cheap to do but requires changes outside the framework.
+
+**Cross-stream reads pay MergeAppend.** Same trade as HASH. If you have a healthy fraction of cross-stream reads — drain, reactions across many streams, dashboards — measure them on your shape before committing. The PG perf data at [`libs/act-pg/PERFORMANCE.md`](../../../../libs/act-pg/PERFORMANCE.md) was measured on unpartitioned tables; expect cross-stream queries to slow by some MergeAppend constant per partition crossed.
+
+**VACUUM behavior changes.** Per-partition autovacuum runs independently. The hot partition will autovacuum often; cold partitions rarely. This is usually an improvement over the unpartitioned shape, where one autovacuum had to consider the whole table — but it does mean your monitoring needs to know the partition layout to make sense of vacuum metrics.
+
+## When this strategy does NOT fit
+
+- **You have many active streams.** Use [HASH on `stream`](../hash-on-stream/README.md) instead — RANGE on `id` gives you nothing if the events are already distributed across thousands of streams.
+- **You have one giant + you want global id parallelism on rebuild.** RANGE on `id` doesn't parallelize rebuild — MergeAppend is sequential by id. The rebuild-bench territory belongs to HASH, and even there the speedup is conditional on the shape. See the partitioned-vs-unpartitioned numbers logged with #851 in [`libs/act-pg/PERFORMANCE.md`](../../../../libs/act-pg/PERFORMANCE.md).
+- **`close()` would have worked.** Re-read [`docs/docs/guides/close-policies.md`](../../../../docs/docs/guides/close-policies.md). Most "long-lived" aggregates have unused terminal events. Closing the stream — manually or via `.autocloses({ is: "DeviceRetired" })` — is dramatically cheaper than partitioning.
+- **Your hot path is cross-stream.** If drain and reactions read across many streams, partitioning costs you on the read path. Range-on-id only pays off when the workload is dominated by appends and tail-reads on the giant stream.
+- **You don't actually have a giant yet.** Provision-as-you-go works fine in an unpartitioned table up to ten million rows or so. Don't pre-partition for a problem you don't have.
+
+## Why no migration script
+
+The other recipes in this folder ship templated SQL — `{{schema}}`, `{{table}}`, a few parameters at the top, and a `sed`-friendly file an operator can adapt in an hour. For range-on-id, a template would lie.
+
+The numbers that make this strategy work — partition boundary size, current id watermark, ongoing-maintenance choice, cold-tier tablespace policy, whether `pg_partman` is allowed in your environment — are all operator-specific. A 10M-id-per-partition template would be wrong for a workload doing a hundred events per second and equally wrong for a workload doing one. The migration shape changes depending on how much downtime you can take, whether you have a replica to fail over to, and whether your audit trail has any cross-stream correlations you need to preserve order on.
+
+What we can ship honestly is the **strategy**: partition by RANGE on `id`, pick a boundary that fits your hot partition into `shared_buffers`, automate the provisioning, accept that cross-stream reads pay MergeAppend. From there, the schema is a one-off design that belongs in your repo, not the framework's.
+
+If you want a starting point for the SQL itself, the [HASH on `stream` recipe](../hash-on-stream/README.md) is the closest template — same partitioning mechanics, different key. Use it as a structural reference and adapt the partition definitions.
+
+## Pointers
+
+- [Postgres partitioning documentation](https://www.postgresql.org/docs/current/ddl-partitioning.html) — start here if you've never partitioned a Postgres table before. Section 5.11 is the canonical reference.
+- [`pg_partman`](https://github.com/pgpartman/pg_partman) — the extension that owns ongoing partition lifecycle for RANGE strategies.
+- [Partitioning gating page](../README.md) — re-read before committing. The "when not to partition" section catches most operators.
+- [Close-the-books guide](../../../../docs/docs/guides/close-policies.md) — the strategy you should rule out before reaching this page.
+- [Production checklist](../../../../docs/docs/guides/production-checklist.md) — §10 "Closing the books" and §11 "Lane sizing" cover the surface area you should have already exhausted.
+- [HASH on `stream` recipe](../hash-on-stream/README.md) — for many-active-streams workloads, or as a structural reference for the SQL.

--- a/recipes/scaling/partitioning/range-on-id/README.md
+++ b/recipes/scaling/partitioning/range-on-id/README.md
@@ -10,15 +10,15 @@ Default Act is fine for the overwhelming majority of apps. This recipe exists fo
 
 This is the answer to case #2 from [the gating page](../README.md):
 
-> **Single-aggregate giants.** One stream with millions of events on a single aggregate — a multi-year IoT device telemetry trail, a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might.
+> **Single-aggregate giants.** One stream with millions of events on a single aggregate — a long-running ledger for one regulated entity, an audit trail for a critical workflow that runs for a decade. The aggregate can't be closed because the business still treats it as alive. HASH partitioning by `stream` does not help here (all the events for one stream land in one partition); range partitioning by `id` might.
 
-Concrete shapes that fit:
+Act targets business applications, so the "giant" here is a business-domain aggregate that legitimately accumulates events over years, not high-frequency telemetry (which doesn't fit Act's model in the first place — see the top-level [`recipes/README.md`](../../../README.md) for why). Concrete shapes that fit:
 
-- A telemetry stream for a single industrial sensor that emits an event every few seconds for a decade. By year five you're at a hundred million events in one stream.
 - A regulated entity's master ledger that books transactions across the lifetime of the business. The stream is the entity; closing it means closing the entity.
 - A workflow audit trail for a single long-running process — a clinical trial, a multi-year procurement contract, a credit facility — where the workflow is one durable thing and the audit is its history.
+- A compliance event log for a single legal entity that must retain every regulated event for the lifetime of the relationship.
 
-Notice what these have in common. The stream cardinality is **small** (often one). The per-stream event count is **enormous**. And closing the stream is not on the table: the business still treats the aggregate as alive.
+Notice what these have in common. The stream cardinality is **small** (often one). The per-stream event count is **enormous over time** (years, not seconds). And closing the stream is not on the table: the business still treats the aggregate as alive.
 
 ## Why HASH partitioning doesn't help
 
@@ -89,6 +89,8 @@ Then create child partitions for the existing id ranges (`FROM (0) TO (10000000)
 ## Operational concerns
 
 **Cold-storage migration.** Older partitions can move to cheaper storage with `ALTER TABLE {{schema}}.{{table}}_p_000000000 SET TABLESPACE cold_tier`. Reads still work, they're just slower. For the giant-stream case, "slower reads on history nobody asks for" is exactly the trade you want.
+
+**If you ever DROP an old partition, the consistency rules from the gating page apply.** Range-on-id partitions are usually moved to cold storage rather than dropped — the strategy is built around "keep everything, just stratify it." But operators sometimes drop the oldest range when retention policy says so, or when cold storage itself reaches its budget. The moment you do, you're in the same territory as range-on-created's drop path: every alive stream with events in the dropped range needs a `__tombstone__` (`app.close()` / `.autocloses({...})`) or a `__snapshot__` (`app.snap()` / state-level `.snap` predicate) **outside** the dropped range, or `app.load()` for that stream silently returns wrong state. See [the gating page's consistency section](../README.md#consistency-cost-when-a-strategy-involves-drop-partition) for the full explanation and the pre-flight check pattern. The recipe doesn't ship a drop runner for range-on-id because the cut points are app-specific; if you write one, copy the consistency guard from `recipes/scaling/partitioning/range-on-created/drop-partition.sql` and adapt the cutoff column from `created` to `id`.
 
 **Projection rebuild.** `app.reset(targets)` still works post-migration. It walks every partition in id order via MergeAppend, the same way an unpartitioned table would walk in id order. If the projection reads only the giant stream, the planner prunes the unrelated partitions (there aren't any — RANGE on `id` doesn't distinguish by stream). If the projection has a watermark, you can prune cold partitions out of the rebuild manually by capping the `id >= start_id` clause, which is cheap to do but requires changes outside the framework.
 


### PR DESCRIPTION
## Summary

Closes #675 (epic), #850, #851, #852, #853, #854 — the entire `act-ops` partitioning milestone.

Stands up a new `recipes/` folder at the repo root for operator playbooks — separate from `libs/` (framework code), `docs/` (framework reference), and `book/` (design-history essays). When an Act deployment hits a wall the framework defaults don't cover, the operator looks here.

## What's in `recipes/`

```
recipes/
├── README.md                                      Landing + envelope of safe operation
└── scaling/
    ├── README.md                                  Symptom -> recipe decision tree
    ├── close-the-books/
    │   ├── README.md                              .autocloses({...}) primary tool
    │   └── examples/
    │       ├── ticket-cooldown.ts                 Cooldown-after-terminal pattern
    │       └── retention-floor.ts                 Terminal + retention floor OR-backstop
    ├── archival/
    │   ├── README.md                              Cold-tier dumps with .archives()
    │   └── examples/
    │       └── s3-jsonl-archiver.ts               S3 + JSONL idempotent archiver
    └── partitioning/
        ├── README.md                              Gating page (replaces PARTITIONING.md)
        ├── hash-on-stream/                        HASH recipe — closes #850
        │   ├── README.md
        │   ├── forward.sql
        │   ├── rollback.sql
        │   └── run.sh
        ├── range-on-id/                           docs-only — closes #852
        │   └── README.md
        └── range-on-created/                      RANGE recipe — closes #853
            ├── README.md
            ├── forward.sql
            ├── drop-partition.sql
            └── run.sh
```

The TS samples compile against the live `@rotorsoft/act` API as it exists today. The SQL files use `{{schema}}` and `{{table}}` placeholders the operator substitutes via `sed` / `envsubst`. The `run.sh` wrappers pipe through `psql` with `ON_ERROR_STOP=1`. The `s3-jsonl-archiver.ts` sample notes that `@aws-sdk/client-s3` is illustrative — operators add the dep to their own project.

## Notable scope changes from the original tickets

- **No Node CLI runner for the partitioning migrations.** The original #850 asked for a TS `partition --confirm` CLI. After scoping it turned out to be the wrong shape: partitioning is a one-shot DBA operation almost nobody runs, and the operators who do run it pipe SQL into psql during a maintenance window. A CLI would have added framework maintenance burden for near-zero real callers. Shipping pure SQL plus thin bash wrappers instead.

- **#851 (parallel rebuild benchmark) closed as not-planned.** The gating page already correctly hedges the claim ("the theoretical N× parallel speedup is rarely the observed speedup"); per-deployment generalization isn't realistic. If an operator brings numbers and a workload, we layer a targeted bench on their reproducer.

- **#854 (framework opt-in additions) closed as not-planned.** No operator evidence; the framework stays partitioning-unaware. `PostgresStore` source is unchanged. `CREATE TABLE / CREATE INDEX IF NOT EXISTS` no-op the same against partitioned and unpartitioned tables; query paths hit single-partition pruning for stream-scoped reads and MergeAppend for cross-stream reads.

## Wire-up changes

- `libs/act-pg/PARTITIONING.md` becomes a stub redirect pointing at `recipes/scaling/partitioning/`.
- `libs/act-pg/README.md` "Operational concerns" + "Documentation" sections point at `recipes/scaling/` instead of the moved page.
- `CLAUDE.md` gains an "Operator recipes" subsection under "Where to find what" so future contributors know recipes are operator-facing.
- `biome.json` overrides extend to `recipes/**` so the TS sample scripts can use `console` output — they're runnable demos, console output IS the point.

## How this was built

Used Claude Code's parallel-subagent workflow to consolidate the entire ops milestone in one PR: one survey pass over the existing source material (`libs/act-pg/PARTITIONING.md`, `libs/act/PERFORMANCE.md`, `libs/act-pg/PERFORMANCE.md`, `docs/docs/guides/close-policies.md`) followed by 8 `act-doc-writer` subagents writing the recipe pages in parallel, each pinned to a self-contained brief.

## Test plan

- [x] All 17 recipe files exist (8 markdown pages + 3 TS samples + 4 SQL templates + 2 bash wrappers).
- [x] TS samples compile against the live `@rotorsoft/act` API (only remaining errors are `zod`/`@aws-sdk/client-s3` resolution in the standalone harness; both resolve in operator projects).
- [x] SQL files use `{{schema}}` / `{{table}}` placeholders consistently.
- [x] `run.sh` wrappers have executable bits set.
- [x] `pnpm lint` clean (0 errors).
- [x] `pnpm test` — 100% statements / 100% branches / 100% functions / 100% lines (no framework code changed).
- [x] `libs/act-pg/PARTITIONING.md` stubbed to redirect (no orphan content).
- [x] All six `act-ops` issues closed with summary comments.
- [ ] CI green.
- [ ] Reviewer signs off.

## Stability charter impact

None. No `libs/` source touched. The recipes folder is documentation + sample scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)