### PR TITLE
test(inspector): isolate tilde-expansion test from $HOME

### DIFF
--- a/packages/inspector/src/server/discovery/sqlite-probe.ts
+++ b/packages/inspector/src/server/discovery/sqlite-probe.ts
@@ -35,7 +35,7 @@ const REQUIRED_EVENT_COLUMNS = ["stream", "version", "meta"] as const;
  * treats `~` as a literal directory name, so we have to expand it
  * here. Any path without a leading `~` passes through unchanged.
  */
-function expandTilde(p: string): string {
+export function expandTilde(p: string): string {
   if (p === "~") return homedir();
   if (p.startsWith("~/") || p.startsWith("~\\")) {
     return path.join(homedir(), p.slice(2));

--- a/packages/inspector/test/discovery/sqlite-probe.spec.ts
+++ b/packages/inspector/test/discovery/sqlite-probe.spec.ts
@@ -7,12 +7,13 @@
  * in `afterEach` so the tempdir doesn't linger between tests.
  */
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { SqliteStore } from "@rotorsoft/act-sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   discoverSqlite,
+  expandTilde,
   probeSqliteFile,
 } from "../../src/server/discovery/sqlite-probe.js";
 
@@ -138,29 +139,18 @@ describe("discoverSqlite", () => {
     expect(path.basename(result[0]!.file)).toBe("valid.db");
   });
 
-  it("expands a leading `~/` to the operator's home directory", async () => {
-    // Build an Act file in $HOME directly so a tilde-only path finds
-    // it. We pick a marker filename unlikely to collide with anything
-    // a developer keeps in their home dir, and clean up after.
-    const { homedir } = await import("node:os");
-    const marker = `act-inspector-tilde-test-${process.pid}-${Date.now()}.db`;
-    const file = path.join(homedir(), marker);
-    // Full regex-metachar escape — CodeQL's `js/incomplete-sanitization`
-    // flags partial escapes (e.g. dots only), even when the input shape
-    // makes other metacharacters impossible.
-    const escapeForRegex = (s: string) =>
-      s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    try {
-      await buildActSqlite(file);
-      const result = await discoverSqlite({
-        dir: "~",
-        glob: `^${escapeForRegex(marker)}$`,
-      });
-      expect(result).toHaveLength(1);
-      expect(result[0]!.file).toBe(file);
-    } finally {
-      await rm(file, { force: true });
-    }
+  it("expands a leading `~` / `~/` / `~\\` to the operator's home directory", () => {
+    // Pure expansion check — exercises the only branch that needs
+    // testing without touching the operator's real home dir. The
+    // `readdir(expandedDir)` integration in `discoverSqlite` is
+    // already covered by every other test in this describe block.
+    const home = homedir();
+    expect(expandTilde("~")).toBe(home);
+    expect(expandTilde("~/foo/bar")).toBe(path.join(home, "foo/bar"));
+    expect(expandTilde("~\\foo\\bar")).toBe(path.join(home, "foo\\bar"));
+    expect(expandTilde("/abs/path")).toBe("/abs/path");
+    expect(expandTilde("relative/path")).toBe("relative/path");
+    expect(expandTilde("")).toBe("");
   });
 
   it("returns [] when given an invalid regex glob", async () => {


### PR DESCRIPTION
## Summary

The SQLite discovery probe's tilde-expansion test wrote a real `.db` file into the operator's home directory to verify `~` resolves correctly, then cleaned up only the main file — SQLite's `-shm` / `-wal` sidecars stayed behind on every run. Over time this left **118 orphan files** in `$HOME` on my machine; CI runners would accumulate them too if `$HOME` persisted across runs. This PR converts the integration test into a pure unit test that exercises `expandTilde` directly with synthetic paths.

## What changed

- `packages/inspector/src/server/discovery/sqlite-probe.ts` — export `expandTilde` so it can be unit-tested directly.
- `packages/inspector/test/discovery/sqlite-probe.spec.ts` — replace the integration test with a pure expansion check (`~`, `~/foo/bar`, `~\foo\bar`, absolute, relative, empty). No filesystem touch, no `$HOME` override, no tempdir needed for this case. The `readdir(expandedDir)` integration path is already covered by every other test in the `discoverSqlite` describe block.

## Why a unit test instead of a HOME override

An earlier draft of this fix kept the integration shape and pointed `process.env.HOME` at the per-test tempdir so `homedir()` would resolve there. That works, but the only branch the test was actually exercising was `expandTilde`'s — the filesystem trip added nothing. Exporting the helper removed the need to touch the filesystem at all for tilde expansion.

## Test plan

- [x] `pnpm -F @rotorsoft/act-inspector exec vitest run test/discovery/sqlite-probe.spec.ts` — 11/11 passing
- [x] `pnpm test` — full suite passes; coverage stays at 100%
- [x] `pnpm build` — all packages built clean
- [x] Verified no files land in `$HOME` after running the spec
- [x] Deleted 118 pre-existing orphan `act-inspector-tilde-test-*.db-{shm,wal}` files from `~` (local cleanup, not in this diff)
- [ ] CI green

Coverage: 100% statements / 100% branches / 100% functions / 100% lines.

Note: `pnpm typecheck` and `pnpm lint` each report one pre-existing failure on master, unrelated to this diff — `recipes/scaling/**/*.ts` missing `zod` / `@aws-sdk/client-s3` peer deps, and an unused `biome-ignore` comment in `libs/act/test/restore.spec.ts`. Worth a follow-up but not blocking here.

## Stability charter impact

None — no charter-covered files (`libs/act/src/builders/`, `act.ts`, `types/ports.ts`, `types/index.ts`, `ports.ts`) touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)